### PR TITLE
CPAOT Method handle support

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -214,7 +214,7 @@ namespace ILCompiler
             return _devirtualizationManager.ResolveVirtualMethod(declMethod, implType);
         }
 
-        public bool NeedsRuntimeLookup(ReadyToRunHelperId lookupKind, object targetOfLookup)
+        public virtual bool NeedsRuntimeLookup(ReadyToRunHelperId lookupKind, object targetOfLookup)
         {
             switch (lookupKind)
             {

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/PrecodeHelperMethodImport.cs
@@ -3,7 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Internal.Text;
+
+using Internal.JitInterface;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
@@ -15,12 +16,16 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     /// </summary>
     public class PrecodeHelperMethodImport : PrecodeHelperImport, IMethodNode
     {
-        private readonly MethodDesc _methodDesc;
+        private readonly MethodWithToken _methodWithToken;
+        private readonly bool _useInstantiatingStub;
+        private readonly SignatureContext _signatureContext;
 
-        public PrecodeHelperMethodImport(ReadyToRunCodegenNodeFactory factory, MethodDesc methodDesc, Signature signature)
+        public PrecodeHelperMethodImport(ReadyToRunCodegenNodeFactory factory, MethodWithToken methodWithToken, Signature signature, SignatureContext signatureContext, bool useInstantiatingStub)
             : base(factory, signature)
         {
-            _methodDesc = methodDesc;
+            _methodWithToken = methodWithToken;
+            _useInstantiatingStub = useInstantiatingStub;
+            _signatureContext = signatureContext;
         }
 
         protected override string GetName(NodeFactory factory)
@@ -28,8 +33,29 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             return "PrecodeHelperMethodImport->" + ImportSignature.GetMangledName(factory.NameMangler);
         }
 
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            foreach (DependencyListEntry baseEntry in base.GetStaticDependencies(factory))
+            {
+                yield return baseEntry;
+            }
+            if (_useInstantiatingStub)
+            {
+                // Require compilation of the canonical version for instantiating stubs
+                MethodDesc canonMethod = _methodWithToken.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
+                ISymbolNode canonMethodNode = r2rFactory.MethodEntrypoint(
+                    canonMethod,
+                    constrainedType: null,
+                    originalMethod: canonMethod,
+                    methodToken: _methodWithToken.Token,
+                    signatureContext: _signatureContext);
+                yield return new DependencyListEntry(canonMethodNode, "Canonical method for instantiating stub");
+            }
+        }
+
         public override int ClassCode => 668765432;
 
-        public MethodDesc Method => _methodDesc;
+        public MethodDesc Method => _methodWithToken.Method;
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -94,6 +94,10 @@ namespace ILCompiler.DependencyAnalysis
                     helperNode = CreateFieldHandleHelper((FieldDesc)target, signatureContext);
                     break;
 
+                case ReadyToRunHelperId.MethodHandle:
+                    helperNode = CreateMethodHandleHelper((MethodWithToken)target, signatureContext);
+                    break;
+
                 case ReadyToRunHelperId.VirtualCall:
                     helperNode = CreateVirtualCallHelper((MethodWithToken)target, signatureContext);
                     break;
@@ -198,6 +202,23 @@ namespace ILCompiler.DependencyAnalysis
             return new PrecodeHelperImport(
                 _codegenNodeFactory,
                 new FieldFixupSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_FieldHandle, field, signatureContext));
+        }
+
+        private ISymbolNode CreateMethodHandleHelper(MethodWithToken methodWithToken, SignatureContext signatureContext)
+        {
+            return new PrecodeHelperMethodImport(
+                _codegenNodeFactory,
+                methodWithToken,
+                _codegenNodeFactory.MethodSignature(
+                        ReadyToRunFixupKind.READYTORUN_FIXUP_MethodHandle,
+                        methodWithToken.Method,
+                        constrainedType: null,
+                        methodWithToken.Token,
+                        signatureContext: signatureContext,
+                        isUnboxingStub: false,
+                        isInstantiatingStub: true),
+                signatureContext,
+                useInstantiatingStub: true);
         }
 
         private ISymbolNode CreateVirtualCallHelper(MethodWithToken methodWithToken, SignatureContext signatureContext)
@@ -618,7 +639,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 genericDictionary = new PrecodeHelperMethodImport(
                     _codegenNodeFactory,
-                    method,
+                    new MethodWithToken(method, methodToken),
                     _codegenNodeFactory.MethodSignature(
                         ReadyToRunFixupKind.READYTORUN_FIXUP_MethodDictionary,
                         method,
@@ -626,7 +647,9 @@ namespace ILCompiler.DependencyAnalysis
                         methodToken: methodToken,
                         signatureContext: signatureContext,
                         isUnboxingStub: false,
-                        isInstantiatingStub: true));
+                        isInstantiatingStub: true),
+                    signatureContext,
+                    useInstantiatingStub: true);
                 _genericDictionaryCache.Add(method, genericDictionary);
             }
             return genericDictionary;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -159,26 +159,12 @@ namespace ILCompiler
         {
             switch (lookupKind)
             {
-                case ReadyToRunHelperId.TypeHandle:
-                case ReadyToRunHelperId.NecessaryTypeHandle:
-                case ReadyToRunHelperId.DefaultConstructor:
-                case ReadyToRunHelperId.TypeHandleForCasting:
-                    return ((TypeDesc)targetOfLookup).IsRuntimeDeterminedSubtype;
-
                 case ReadyToRunHelperId.MethodDictionary:
                 case ReadyToRunHelperId.MethodHandle:
                     return ((MethodWithToken)targetOfLookup).Method.IsRuntimeDeterminedExactMethod;
-
-                case ReadyToRunHelperId.MethodEntry:
-                case ReadyToRunHelperId.VirtualDispatchCell:
-                    return ((MethodDesc)targetOfLookup).IsRuntimeDeterminedExactMethod;
-
-                case ReadyToRunHelperId.FieldHandle:
-                    return ((FieldDesc)targetOfLookup).OwningType.IsRuntimeDeterminedSubtype;
-
-                default:
-                    throw new NotImplementedException();
             }
+
+            return base.NeedsRuntimeLookup(lookupKind, targetOfLookup);
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection.PortableExecutable;
@@ -153,5 +154,31 @@ namespace ILCompiler
         }
 
         public override ObjectNode GetFieldRvaData(FieldDesc field) => SymbolNodeFactory.GetRvaFieldNode(field);
+
+        public override bool NeedsRuntimeLookup(ReadyToRunHelperId lookupKind, object targetOfLookup)
+        {
+            switch (lookupKind)
+            {
+                case ReadyToRunHelperId.TypeHandle:
+                case ReadyToRunHelperId.NecessaryTypeHandle:
+                case ReadyToRunHelperId.DefaultConstructor:
+                case ReadyToRunHelperId.TypeHandleForCasting:
+                    return ((TypeDesc)targetOfLookup).IsRuntimeDeterminedSubtype;
+
+                case ReadyToRunHelperId.MethodDictionary:
+                case ReadyToRunHelperId.MethodHandle:
+                    return ((MethodWithToken)targetOfLookup).Method.IsRuntimeDeterminedExactMethod;
+
+                case ReadyToRunHelperId.MethodEntry:
+                case ReadyToRunHelperId.VirtualDispatchCell:
+                    return ((MethodDesc)targetOfLookup).IsRuntimeDeterminedExactMethod;
+
+                case ReadyToRunHelperId.FieldHandle:
+                    return ((FieldDesc)targetOfLookup).OwningType.IsRuntimeDeterminedSubtype;
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2543,8 +2543,14 @@ namespace Internal.JitInterface
                     Debug.Assert(pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Method);
                     helperId = ReadyToRunHelperId.MethodDictionary;
                 }
-                
+
+#if READYTORUN
+                MethodDesc exactMethod = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
+                target = new MethodWithToken(exactMethod, new ModuleToken(_tokenContext, pResolvedToken.token));
+#else
                 target = GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
+#endif
+
             }
             else if (!fEmbedParent && pResolvedToken.hField != null)
             {


### PR DESCRIPTION
Add support for loading method handles. Modify the `PreCodeHelperMethodImport` to support loading method handles eagerly. As with Tomas' GVM support change, root the canonical instantiation when a method handle is loaded to ensure the method body is generated by the JIT.

This change fixes compilation for several ASP.NET Core assemblies:
- Microsoft.AspNetCore.Connections.Abstractions
- Microsoft.AspNetCore.Http.Abstractions
- Microsoft.Extensions.DependencyInjection
- Microsoft.Extensions.DependencyInjection.Abstractions
