### PR TITLE
Pin CoreRT OS modules in memory

### DIFF
--- a/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
@@ -430,9 +430,12 @@ REDHAWK_PALEXPORT HANDLE REDHAWK_PALAPI PalCreateLowMemoryNotification()
 
 REDHAWK_PALEXPORT HANDLE REDHAWK_PALAPI PalGetModuleHandleFromPointer(_In_ void* pointer)
 {
+    // CoreRT is not designed to be unloadable today. Use GET_MODULE_HANDLE_EX_FLAG_PIN to prevent
+    // the module from ever unloading.
+
     HMODULE module;
     if (!GetModuleHandleExW(
-        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
         (LPCWSTR)pointer,
         &module))
     {

--- a/tests/src/Simple/SharedLibrary/SharedLibrary.cpp
+++ b/tests/src/Simple/SharedLibrary/SharedLibrary.cpp
@@ -62,5 +62,14 @@ int main(int argc, char* argv[])
     // managed class loaders were initialized successfully
     ensureManagedClassLoaders();
 
+    // CoreRT is not designed to be unloadable, so this won't actually unload the library properly. Verify that attempt
+    // to unload the library does not to crash at least.
+#ifdef _WIN32
+    FreeLibrary(handle);
+#else
+    // TODO: How to pin the library in memory on Unix?
+    // dlclose(handle);
+#endif
+
     return 100;
 }


### PR DESCRIPTION
CoreRT is not designed to be unloadable. Unloading modules before process shutdown leads to crashes and memory leaks.

Fixes #6993