### PR TITLE
Basic Runner for CPAOT / Crossgen

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,6 +6,7 @@
     <add key="myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget.org dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="myget.org system-commandline" value="https://dotnet.myget.org/F/system-commandline/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <config>

--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.IO;
+
+namespace ReadyToRun.SuperIlc
+{
+    internal enum ReadyToRunTool
+    {
+        Crossgen,
+        Cpaot
+    }
+
+    internal class CommandLineOptions
+    {
+        private string _inputPath;
+        private string _outputPath;
+        private bool _crossgen;
+        private bool _cpaot;
+        private string _toolPath;
+        private IReadOnlyList<string> _references = Array.Empty<string>();
+        private bool _helpRequested;
+        public ReadyToRunTool OptimizingTool => _crossgen ? ReadyToRunTool.Crossgen : ReadyToRunTool.Cpaot;
+        public string InputPath => _inputPath;
+        public string OutputPath => _outputPath;
+        public string ToolPath => _toolPath;
+        public IReadOnlyList<string> ReferenceFolders => _references;
+        public bool Help => _helpRequested;
+
+        public ArgumentSyntax ParseCommandLine(string[] args)
+        {
+            ArgumentSyntax argSyntax = ArgumentSyntax.Parse(args, syntax =>
+            {
+                syntax.ApplicationName = "ReadyToRun.SuperIlc";
+                syntax.HandleHelp = false;
+                syntax.HandleErrors = false;
+                syntax.HandleResponseFiles = true;
+                
+                syntax.DefineOption("h|help", ref _helpRequested, "");
+                syntax.DefineOption("crossgen", ref _crossgen, "Compile with Crossgen");
+                syntax.DefineOption("cpaot", ref _cpaot, "Compile with CPAOT");
+                syntax.DefineOptionList("r|ref", ref _references, "Folder containing assemblies to reference");
+                syntax.DefineOption("in", ref _inputPath, "Input folder of assemblies to optimize");
+                syntax.DefineOption("out", ref _outputPath, "Output folder for optimized assemblies");
+                syntax.DefineOption("toolpath", ref _toolPath, "Path to optimizing tool");
+            });
+
+            return argSyntax;
+        }
+
+        public bool Validate()
+        {
+            if (_crossgen && _cpaot)
+            {
+                Console.WriteLine($"Error: --crossgen and --cpaot both specified");
+            }
+
+            if (!Directory.Exists(InputPath))
+            {
+                Console.WriteLine($"Error: Input folder {InputPath} does not exist");
+                return false;
+            }
+
+            if (!Directory.Exists(ToolPath))
+            {
+                Console.WriteLine($"Error: Tool folder {ToolPath} does not exist");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+
+namespace ReadyToRun.SuperIlc
+{
+    class CompileDirectoryCommand
+    {
+        public static int CompileDirectory(DirectoryInfo toolDirectory, DirectoryInfo inputDirectory, DirectoryInfo outputDirectory, bool crossgen, bool cpaot, DirectoryInfo[] referencePath)
+        {
+            if (toolDirectory == null)
+            {
+                Console.WriteLine("--tool-directory is a required argument.");
+                return 1;
+            }
+
+            if (inputDirectory == null)
+            {
+                Console.WriteLine("--input-directory is a required argument.");
+                return 1;
+            }
+
+            if (outputDirectory == null)
+            {
+                Console.WriteLine("--output-directory is a required argument.");
+                return 1;
+            }
+
+            CompilerRunner runner;
+            if (cpaot)
+            {
+                runner = new CpaotRunner(toolDirectory.ToString(), inputDirectory.ToString(), outputDirectory.ToString(), referencePath?.Select(x => x.ToString())?.ToList());
+            }
+            else
+            {
+                runner = new CrossgenRunner(toolDirectory.ToString(), inputDirectory.ToString(), outputDirectory.ToString(), referencePath?.Select(x => x.ToString())?.ToList());
+            }
+
+            bool success = true;
+            foreach (var assemblyToOptimize in ComputeManagedAssemblies.GetManagedAssembliesInFolder(inputDirectory.ToString()))
+            {
+                // Compile all assemblies in the input folder
+                if (!runner.CompileAssembly(assemblyToOptimize))
+                    success = false;
+            }
+
+            return success ? 0 : 1;
+        }
+    }    
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -19,7 +19,7 @@ public abstract class CompilerRunner
         _compilerPath = compilerFolder;
         _inputPath = inputFolder;
         _outputPath = outputFolder;
-        _referenceFolders = referenceFolders;
+        _referenceFolders = referenceFolders ?? new List<string>();
     }
 
     protected abstract string CompilerFileName {get;}

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+public abstract class CompilerRunner
+{
+    protected string _compilerPath;
+    protected string _inputPath;
+    protected string _outputPath;
+    protected IReadOnlyList<string> _referenceFolders;
+
+    public CompilerRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders)
+    {
+        _compilerPath = compilerFolder;
+        _inputPath = inputFolder;
+        _outputPath = outputFolder;
+        _referenceFolders = referenceFolders;
+    }
+
+    protected abstract string CompilerFileName {get;}
+    protected abstract IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName);
+
+    public bool CompileAssembly(string assemblyFileName)
+    {
+        CreateOutputFolder();
+        string outputFileName = GetOutputFileName(assemblyFileName);
+        string responseFile = GetResponseFileName(assemblyFileName);
+        var commandLineArgs = BuildCommandLineArguments(assemblyFileName, outputFileName);
+        CreateResponseFile(responseFile, commandLineArgs);
+
+        using (var process = new Process())
+        {
+            process.StartInfo.FileName = Path.Combine(_compilerPath, CompilerFileName);
+            process.StartInfo.Arguments = $"@{responseFile}";
+            process.StartInfo.UseShellExecute = false;
+
+            process.Start();
+
+            process.OutputDataReceived += delegate (object sender, DataReceivedEventArgs args)
+            {
+                Console.WriteLine(args.Data);
+            };
+
+            process.ErrorDataReceived += delegate (object sender, DataReceivedEventArgs args)
+            {
+                Console.WriteLine(args.Data);
+            };
+
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                Console.WriteLine($"Compilation of {Path.GetFileName(assemblyFileName)} failed with exit code {process.ExitCode}");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected void CreateOutputFolder()
+    {
+        if (!Directory.Exists(_outputPath))
+        {
+            Directory.CreateDirectory(_outputPath);
+        }
+    }
+
+    protected void CreateResponseFile(string responseFile, IEnumerable<string> commandLineArguments)
+    {
+        using (TextWriter tw = File.CreateText(responseFile))
+        {
+            foreach (var arg in commandLineArguments)
+            {
+                tw.WriteLine(arg);
+            }
+        }
+    }
+
+    // <input>\a.dll -> <output>\a.ni.dll
+    protected string GetOutputFileName(string assemblyFileName) =>
+        Path.Combine(_outputPath, $"{Path.GetFileNameWithoutExtension(assemblyFileName)}.ni{Path.GetExtension(assemblyFileName)}"); 
+    protected string GetResponseFileName(string assemblyFileName) =>
+        Path.Combine(_outputPath, $"{Path.GetFileNameWithoutExtension(assemblyFileName)}.{Path.GetFileNameWithoutExtension(CompilerFileName)}.rsp");
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/ComputeManagedAssemblies.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ComputeManagedAssemblies.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+class ComputeManagedAssemblies
+{
+    public static IEnumerable<string> GetManagedAssembliesInFolder(string folder)
+    {
+        foreach (string file in Directory.EnumerateFiles(folder))
+        {
+            if (IsManaged(file))
+            {
+                yield return file;
+            }
+        }
+    }
+
+    public static bool IsManaged(string file)
+    {
+        // Only files named *.dll and *.exe are considered as possible assemblies
+        if (!Path.HasExtension(file) || (Path.GetExtension(file) != ".dll" && Path.GetExtension(file) != ".exe"))
+            return false;
+
+        try
+        {
+            using (FileStream moduleStream = File.OpenRead(file))
+            using (var module = new PEReader(moduleStream))
+            {
+                if (module.HasMetadata)
+                {
+                    MetadataReader moduleMetadataReader = module.GetMetadataReader();
+                    if (moduleMetadataReader.IsAssembly)
+                    {
+                        string culture = moduleMetadataReader.GetString(moduleMetadataReader.GetAssemblyDefinition().Culture);
+
+                        if (culture == "" || culture.Equals("neutral", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        catch (BadImageFormatException)
+        {
+        }
+
+        return false;
+    }
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Compiles assemblies using the Cross-Platform AOT compiler
+/// </summary>
+class CpaotRunner : CompilerRunner
+{
+    protected override string CompilerFileName => "ilc.exe";
+
+    public CpaotRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders) : base(compilerFolder, inputFolder, outputFolder, referenceFolders) {}
+
+    protected override IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName)
+    {
+        // The file to compile
+        yield return assemblyFileName;
+
+        // Output
+        yield return $"-o:{outputFileName}";
+
+        // Don't forget this one.
+        yield return "--readytorun";
+
+        // Todo: Allow control of some of these
+        yield return "-g";
+        yield return "--runtimeopt:RH_UseServerGC=1";
+        yield return "--targetarch=x64";
+        yield return "--stacktracedata";
+
+        foreach (var reference in ComputeManagedAssemblies.GetManagedAssembliesInFolder(_inputPath))
+        {
+            yield return $"-r:{reference}";
+        }
+
+        foreach (var referenceFolder in _referenceFolders)
+        {
+            foreach (var reference in ComputeManagedAssemblies.GetManagedAssembliesInFolder(referenceFolder))
+            {
+                yield return $"-r:{reference}";
+            }
+        }
+    }
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+/// <summary>
+/// Compiles assemblies using the Cross-Platform AOT compiler
+/// </summary>
+class CrossgenRunner : CompilerRunner
+{
+    protected override string CompilerFileName => "crossgen.exe";
+
+    public CrossgenRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders) : base(compilerFolder, inputFolder, outputFolder, referenceFolders) {}
+
+    protected override IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName)
+    {
+        // The file to compile
+        yield return "/in";
+        yield return assemblyFileName;
+
+        // Output
+        yield return "/out";
+        yield return outputFileName;
+
+        yield return "/platform_assemblies_paths";
+        
+        StringBuilder sb = new StringBuilder();
+        sb.Append(_outputPath + (_referenceFolders.Count > 0 ? ";" : ""));
+        sb.AppendJoin(';', _referenceFolders);
+        yield return sb.ToString();
+    }
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/Program.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/Program.cs
@@ -3,46 +3,30 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO;
+using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
 
 namespace ReadyToRun.SuperIlc
 {
     class Program
     {
-        static void ShowUsage()
+        static int Main(string[] args)
         {
-            Console.WriteLine("dotnet SuperIlc --in <FolderToCompile> --out <OutputFolder> --ref <Referenced assembly folder> [--cpaot] [--crossgen]");
-        }
+            var parser = CommandLineOptions.Build()
+                
+                .UseHelp()
+                .UseParseDirective()
+                .UseDebugDirective()
+                .UseSuggestDirective()
+                .RegisterWithDotnetSuggest()
+                .UseParseErrorReporting()
+                .UseExceptionHandler()
+                .UseTypoCorrections()
 
-        static void Main(string[] args)
-        {
-            var commandLine = new CommandLineOptions();
-            var helpSyntax = commandLine.ParseCommandLine(args);
+                .Build();
 
-            if (commandLine.Help || args.Length == 0)
-            {
-                Console.WriteLine(helpSyntax.GetHelpText());
-                return;
-            }
-
-            if (!commandLine.Validate())
-                return;
-
-            CompilerRunner runner;
-            if (commandLine.OptimizingTool == ReadyToRunTool.Cpaot)
-            {
-                runner = new CpaotRunner(commandLine.ToolPath, commandLine.InputPath, commandLine.OutputPath, commandLine.ReferenceFolders);
-            }
-            else
-            {
-                runner = new CrossgenRunner(commandLine.ToolPath, commandLine.InputPath, commandLine.OutputPath, commandLine.ReferenceFolders);
-            }
-
-            foreach (var assemblyToOptimize in ComputeManagedAssemblies.GetManagedAssembliesInFolder(commandLine.InputPath))
-            {
-                // Compile all assemblies in the input folder
-                runner.CompileAssembly(assemblyToOptimize);
-            }
+            return parser.InvokeAsync(args).Result;
         }
     }
 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/Program.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/Program.cs
@@ -11,7 +11,7 @@ namespace ReadyToRun.SuperIlc
 {
     class Program
     {
-        static int Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
             var parser = CommandLineOptions.Build()
                 
@@ -26,7 +26,7 @@ namespace ReadyToRun.SuperIlc
 
                 .Build();
 
-            return parser.InvokeAsync(args).Result;
+            return await parser.InvokeAsync(args);
         }
     }
 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/Program.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/Program.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+namespace ReadyToRun.SuperIlc
+{
+    class Program
+    {
+        static void ShowUsage()
+        {
+            Console.WriteLine("dotnet SuperIlc --in <FolderToCompile> --out <OutputFolder> --ref <Referenced assembly folder> [--cpaot] [--crossgen]");
+        }
+
+        static void Main(string[] args)
+        {
+            var commandLine = new CommandLineOptions();
+            var helpSyntax = commandLine.ParseCommandLine(args);
+
+            if (commandLine.Help || args.Length == 0)
+            {
+                Console.WriteLine(helpSyntax.GetHelpText());
+                return;
+            }
+
+            if (!commandLine.Validate())
+                return;
+
+            CompilerRunner runner;
+            if (commandLine.OptimizingTool == ReadyToRunTool.Cpaot)
+            {
+                runner = new CpaotRunner(commandLine.ToolPath, commandLine.InputPath, commandLine.OutputPath, commandLine.ReferenceFolders);
+            }
+            else
+            {
+                runner = new CrossgenRunner(commandLine.ToolPath, commandLine.InputPath, commandLine.OutputPath, commandLine.ReferenceFolders);
+            }
+
+            foreach (var assemblyToOptimize in ComputeManagedAssemblies.GetManagedAssembliesInFolder(commandLine.InputPath))
+            {
+                // Compile all assemblies in the input folder
+                runner.CompileAssembly(assemblyToOptimize);
+            }
+        }
+    }
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/Program.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/Program.cs
@@ -14,16 +14,12 @@ namespace ReadyToRun.SuperIlc
         static async Task<int> Main(string[] args)
         {
             var parser = CommandLineOptions.Build()
-                
                 .UseHelp()
                 .UseParseDirective()
-                .UseDebugDirective()
                 .UseSuggestDirective()
-                .RegisterWithDotnetSuggest()
                 .UseParseErrorReporting()
                 .UseExceptionHandler()
                 .UseTypoCorrections()
-
                 .Build();
 
             return await parser.InvokeAsync(args);

--- a/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetName>SuperIlc</TargetName> -->
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
+    <!-- Force C# 7.1 so we can use async Main -->
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="0.1.0-e160119-1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.1.0-alpha-63724-02" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
   </ItemGroup>
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- <TargetName>SuperIlc</TargetName> -->
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="0.1.0-e160119-1" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/src/tools/ReadyToRun.TestHarness/Program.cs
+++ b/tests/src/tools/ReadyToRun.TestHarness/Program.cs
@@ -60,7 +60,7 @@ namespace ReadyToRun.TestHarness
                 syntax.HandleErrors = true;
                 syntax.HandleResponseFiles = true;
 
-                syntax.DefineOption("h|help", ref _help, "Help message for R2RDump");
+                syntax.DefineOption("h|help", ref _help, "Help message for TestHarness");
                 syntax.DefineOption("c|corerun", ref _coreRunExePath, "Path to CoreRun");
                 syntax.DefineOption("i|in", ref _testExe, "Path to test exe");
                 syntax.DefineOptionList("r|ref", ref _referenceFilenames, "Paths to referenced assemblies");


### PR DESCRIPTION
This is a small test harness whose aim is to abstract away running compilation scenarios on either CPAOT or Crossgen. The goal is to produce an equivalent to UWP's TestIlc that lets us easily optimize a folder of assemblies without needing a project system.

A second goal is to allow for special case compilation scenarios. For example, setting up SuperPMI before compilation so we can diff the answers provided by the front-end to the JIT.

The command line isn't fully baked yet but the goal is to specify an
input and output folder, plus reference folders. Then specify either
--crossgen or --cpaot and the tool will pass the correct parameters
to the selected compiler.

Example command:
dotnet run -- --cpaot --in c:\git\corert\samples\WebAPI\bin\Debug\netcoreapp2.1\win-x64\publish --out c:\repro\r2r\WebAPI\cpaot --toolpath C:\git\corert\bin\Windows_NT.x64.Debug\tools