### PR TITLE
wasm: Refactor simple tests and exit with error code on failure

### DIFF
--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -295,8 +295,8 @@ internal static class Program
     internal static void FailTest(string failMessage = null)
     {
         Success = false;
-        if(failMessage != null) PrintString(failMessage + "-");
-        FailTest();
+        PrintLine("Failed.");
+        if (failMessage != null) PrintLine(failMessage + "-");
     }
 
     private static int StaticDelegateTarget()
@@ -388,7 +388,7 @@ internal static class Program
 
     private static void IntToStringTest()
     {
-        StartTest("Int to String Test: Ok if says 42:");
+        StartTest("Int to String Test: Ok if says 42");
         string intString = 42.ToString();
         PrintLine(intString);
         EndTest(intString == "42");
@@ -431,7 +431,7 @@ internal static class Program
         EndTest(ItfCaller(itfStruct) == 4);
 
         ClassWithSealedVTable classWithSealedVTable = new ClassWithSealedVTable();
-        StartTest("Interface dispatch with sealed vtable test: ");
+        StartTest("Interface dispatch with sealed vtable test");
         EndTest(CallItf(classWithSealedVTable) == 37);
     }
 
@@ -630,7 +630,7 @@ internal static class Program
 
         var gentT = new Gen<int>();
         var genParamType = gentT.TestTypeOf();
-        StartTest("type of generic parameter: ");
+        StartTest("type of generic parameter");
         if (genParamType.FullName != "System.Int32")
         {
             FailTest("expected System.Int32 but was " + genParamType.FullName);
@@ -652,7 +652,7 @@ internal static class Program
         }
 
         var genericType = typeof(List<object>);
-        StartTest("type of generic : ");
+        StartTest("type of generic");
         if (genericType.FullName != "System.Collections.Generic.List`1[[System.Object, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]")
         {
             FailTest("expected System.Collections.Generic.List`1[[System.Object, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]] but was " + genericType.FullName);

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -16,45 +16,33 @@ internal static class Program
     private static int staticInt;
     [ThreadStatic]
     private static int threadStaticInt;
+
+    internal static bool Success;
     private static unsafe int Main(string[] args)
     {
+        Success = true;
         PrintLine("Starting");
 
         Add(1, 2);
+        PrintLine("Hello from C#!");
         int tempInt = 0;
         int tempInt2 = 0;
+        StartTest("Address/derefernce test");
         (*(&tempInt)) = 9;
-        if(tempInt == 9)
-        {
-            PrintLine("Hello from C#!");
-        }
+        EndTest(tempInt == 9);
 
         int* targetAddr = (tempInt > 0) ? (&tempInt2) : (&tempInt);
 
+        StartTest("basic block stack entry Test");
         (*targetAddr) = 1;
-        if(tempInt2 == 1 && tempInt == 9)
-        {
-            PrintLine("basic block stack entry Test: Ok.");
-        }
+        EndTest(tempInt2 == 1 && tempInt == 9);
 
-        if(ILHelpers.ILHelpersTest.InlineAssignByte() == 100)
-        {
-            PrintLine("Inline assign byte Test: Ok.");
-        }
-        else
-        {
-            PrintLine("Inline assign byte Test: Failed.");
-        }
+        StartTest("Inline assign byte Test");
+        EndTest(ILHelpers.ILHelpersTest.InlineAssignByte() == 100);
 
+        StartTest("dup test");
         int dupTestInt = 9;
-        if(ILHelpers.ILHelpersTest.DupTest(ref dupTestInt) == 209 && dupTestInt == 209)
-        {
-            PrintLine("dup test: Ok.");
-        }
-        else
-        {
-            PrintLine("dup test: Failed.");
-        }
+        EndTest(ILHelpers.ILHelpersTest.DupTest(ref dupTestInt) == 209 && dupTestInt == 209);
 
         TestClass tempObj = new TestDerivedClass(1337);
         tempObj.TestMethod("Hello");
@@ -66,132 +54,101 @@ internal static class Program
         *(&str) = str2;
         str2 = *(&str);
 
-        if (str2.second == 4)
-        {
-            PrintLine("value type int field test: Ok.");
-        }
-        
+        StartTest("value type int field test");
+        EndTest(str2.second == 4);
+
+        StartTest("static int field test");
         staticInt = 5;
-        if (staticInt == 5)
-        {
-            PrintLine("static int field test: Ok.");
-        }
+        EndTest(staticInt == 5);
 
-        if(threadStaticInt == 0)
-        {
-            PrintLine("thread static int initial value field test: Ok.");
-        }
+        StartTest("thread static int initial value field test");
+        EndTest(threadStaticInt == 0);
 
+        StartTest("thread static int field test");
         threadStaticInt = 9;
-        if(threadStaticInt == 9)
-        {
-            PrintLine("thread static int field test: Ok.");
-        }
+        EndTest(threadStaticInt == 9);
 
         StaticCtorTest();
 
+        StartTest("box test");
         var boxedInt = (object)tempInt;
-        if(((int)boxedInt) == 9)
+        if (((int)boxedInt) == 9)
         {
-            PrintLine("box test: Ok.");
+            PassTest();
         }
         else
         {
-            PrintLine("box test: Failed. Value:");
+            FailTest();
+            PrintLine("Value:");
             PrintLine(boxedInt.ToString());
         }
-        
+
         var boxedStruct = (object)new BoxStubTest { Value = "Boxed Stub Test: Ok." };
         PrintLine(boxedStruct.ToString());
 
+        StartTest("Subtraction Test");
         int subResult = tempInt - 1;
-        if (subResult == 8)
-        {
-            PrintLine("Subtraction Test: Ok.");
-        }
+        EndTest(subResult == 8);
 
+        StartTest("Division Test");
         int divResult = tempInt / 3;
-        if (divResult == 3)
-        {
-            PrintLine("Division Test: Ok.");
-        }
+        EndTest(divResult == 3);
 
+        StartTest("not test");
         var not = Not(0xFFFFFFFF) == 0x00000000;
-        if (not)
-        {
-            PrintLine("not test: Ok.");
-        }
+        EndTest(not);
 
+        StartTest("negInt test");
         var negInt = Neg(42) == -42;
-        if (negInt)
-        {
-            PrintLine("negInt test: Ok.");
-        }
+        EndTest(negInt);
 
+        StartTest("shiftLeft test");
         var shiftLeft = ShiftLeft(1, 2) == 4;
-        if (shiftLeft)
-        {
-            PrintLine("shiftLeft test: Ok.");
-        }
+        EndTest(shiftLeft);
 
+        StartTest("shiftRight test");
         var shiftRight = ShiftRight(4, 2) == 1;
-        if (shiftRight)
-        {
-            PrintLine("shiftRight test: Ok.");
-        }
+        EndTest(shiftRight);
 
+        StartTest("unsignedShift test");
         var unsignedShift = UnsignedShift(0xFFFFFFFFu, 4) == 0x0FFFFFFFu;
-        if (unsignedShift)
-        {
-            PrintLine("unsignedShift test: Ok.");
-        }
-        
+        EndTest(unsignedShift);
+
+        StartTest("SwitchOp0 test");
         var switchTest0 = SwitchOp(5, 5, 0);
-        if (switchTest0 == 10)
-        {
-            PrintLine("SwitchOp0 test: Ok.");
-        }
+        EndTest(switchTest0 == 10);
 
+        StartTest("SwitchOp1 test");
         var switchTest1 = SwitchOp(5, 5, 1);
-        if (switchTest1 == 25)
-        {
-            PrintLine("SwitchOp1 test: Ok.");
-        }
+        EndTest(switchTest1 == 25);
 
+        StartTest("SwitchOpDefault test");
         var switchTestDefault = SwitchOp(5, 5, 20);
-        if (switchTestDefault == 0)
-        {
-            PrintLine("SwitchOpDefault test: Ok.");
-        }
+        EndTest(switchTestDefault == 0);
 
 #if PLATFORM_WINDOWS
+        StartTest("CpObj test");
         var cpObjTestA = new TestValue { Field = 1234 };
         var cpObjTestB = new TestValue { Field = 5678 };
         CpObjTest.CpObj(ref cpObjTestB, ref cpObjTestA);
-        if (cpObjTestB.Field == 1234)
-        {
-            PrintLine("CpObj test: Ok.");
-        }
+        EndTest (cpObjTestB.Field == 1234);
 #endif
 
+        StartTest("Static delegate test");
         Func<int> staticDelegate = StaticDelegateTarget;
-        if(staticDelegate() == 7)
-        {
-            PrintLine("Static delegate test: Ok.");
-        }
+        EndTest(staticDelegate() == 7);
 
+        StartTest("Instance delegate test");
         tempObj.TestInt = 8;
         Func<int> instanceDelegate = tempObj.InstanceDelegateTarget;
-        if(instanceDelegate() == 8)
-        {
-            PrintLine("Instance delegate test: Ok.");
-        }
+        EndTest(instanceDelegate() == 8);
 
+        StartTest("Virtual Delegate Test");
         Action virtualDelegate = tempObj.VirtualDelegateTarget;
         virtualDelegate();
 
         var arrayTest = new BoxStubTest[] { new BoxStubTest { Value = "Hello" }, new BoxStubTest { Value = "Array" }, new BoxStubTest { Value = "Test" } };
-        foreach(var element in arrayTest)
+        foreach (var element in arrayTest)
             PrintLine(element.Value);
 
         arrayTest[1].Value = "Array load/store test: Ok.";
@@ -200,30 +157,24 @@ internal static class Program
         int ii = 0;
         arrayTest[ii++].Value = "dup ref test: Ok.";
         PrintLine(arrayTest[0].Value);
-        
+
+        StartTest("Large array load/store test");
         var largeArrayTest = new long[] { Int64.MaxValue, 0, Int64.MinValue, 0 };
-        if(largeArrayTest[0] == Int64.MaxValue &&
-            largeArrayTest[1] == 0 &&
-            largeArrayTest[2] == Int64.MinValue &&
-            largeArrayTest[3] == 0)
-        {
-            PrintLine("Large array load/store test: Ok.");
-        }
+        EndTest(largeArrayTest[0] == Int64.MaxValue &&
+                largeArrayTest[1] == 0 &&
+                largeArrayTest[2] == Int64.MinValue &&
+                largeArrayTest[3] == 0);
 
+        StartTest("Small array load/store test");
         var smallArrayTest = new long[] { Int16.MaxValue, 0, Int16.MinValue, 0 };
-        if(smallArrayTest[0] == Int16.MaxValue &&
-            smallArrayTest[1] == 0 &&
-            smallArrayTest[2] == Int16.MinValue &&
-            smallArrayTest[3] == 0)
-        {
-            PrintLine("Small array load/store test: Ok.");
-        }
+        EndTest(smallArrayTest[0] == Int16.MaxValue &&
+                smallArrayTest[1] == 0 &&
+                smallArrayTest[2] == Int16.MinValue &&
+                smallArrayTest[3] == 0);
 
+        StartTest("Newobj value type test");
         IntPtr returnedIntPtr = NewobjValueType();
-        if (returnedIntPtr.ToInt32() == 3)
-        {
-            PrintLine("Newobj value type test: Ok.");
-        }
+        EndTest(returnedIntPtr.ToInt32() == 3);
 
         StackallocTest();
 
@@ -233,89 +184,76 @@ internal static class Program
 
         PrintLine("interface call test: Ok " + (castingTest as ICastingTest1).GetValue().ToString());
 
-        if (((DerivedCastingTestClass1)castingTest).GetValue() == 1 && !(castingTest is DerivedCastingTestClass2))
-        {
-            PrintLine("Type casting with isinst & castclass to class test: Ok.");
-        }
+        StartTest("Type casting with isinst & castclass to class test");
+        EndTest(((DerivedCastingTestClass1)castingTest).GetValue() == 1 && !(castingTest is DerivedCastingTestClass2));
 
+        StartTest("Type casting with isinst & castclass to interface test");
         // Instead of checking the result of `GetValue`, we use null check by now until interface dispatch is implemented.
-        if ((ICastingTest1)castingTest != null && !(castingTest is ICastingTest2))
-        {
-            PrintLine("Type casting with isinst & castclass to interface test: Ok.");
-        }
+        EndTest((ICastingTest1)castingTest != null && !(castingTest is ICastingTest2));
 
+        StartTest("Type casting with isinst & castclass to array test");
         object arrayCastingTest = new BoxStubTest[] { new BoxStubTest { Value = "Array" }, new BoxStubTest { Value = "Cast" }, new BoxStubTest { Value = "Test" } };
         PrintLine(((BoxStubTest[])arrayCastingTest)[0].Value);
         PrintLine(((BoxStubTest[])arrayCastingTest)[1].Value);
         PrintLine(((BoxStubTest[])arrayCastingTest)[2].Value);
-        if (!(arrayCastingTest is CastingTestClass[]))
-        {   
-            PrintLine("Type casting with isinst & castclass to array test: Ok.");
-        }
+        EndTest(!(arrayCastingTest is CastingTestClass[]));
 
         ldindTest();
 
         InterfaceDispatchTest();
 
+        StartTest("Runtime.Helpers array initialization test");
         var testRuntimeHelpersInitArray = new long[] { 1, 2, 3 };
-        if (testRuntimeHelpersInitArray[0] == 1 &&
-            testRuntimeHelpersInitArray[1] == 2 &&
-            testRuntimeHelpersInitArray[2] == 3)
-        {
-            PrintLine("Runtime.Helpers array initialization test: Ok.");
-        }
+        EndTest(testRuntimeHelpersInitArray[0] == 1 &&
+                testRuntimeHelpersInitArray[1] == 2 &&
+                testRuntimeHelpersInitArray[2] == 3);
 
+        StartTest("Multi-dimension array instantiation test");
         var testMdArrayInstantiation = new int[2, 2];
-        if (testMdArrayInstantiation != null && testMdArrayInstantiation.GetLength(0) == 2 && testMdArrayInstantiation.GetLength(1) == 2)
-            PrintLine("Multi-dimension array instantiation test: Ok.");
+        EndTest(testMdArrayInstantiation != null && testMdArrayInstantiation.GetLength(0) == 2 && testMdArrayInstantiation.GetLength(1) == 2);
 
         FloatDoubleTest();
 
+        StartTest("long comparison");
         long l = 0x1;
-        if (l > 0x7FF0000000000000)
-        {
-            PrintLine("long comparison: Failed");
-        }
-        else
-        {
-            PrintLine("long comparison: Ok");
-        }
+        EndTest(l < 0x7FF0000000000000);
 
         // Create a ByReference<char> through the ReadOnlySpan ctor and call the ByReference.Value via the indexer.
+        StartTest("ByReference intrinsics exercise via ReadOnlySpan");
         var span = "123".AsSpan();
         if (span[0] != '1'
             || span[1] != '2'
             || span[2] != '3')
         {
-            PrintLine("ByReference intrinsics exercise via ReadOnlySpan failed");
+            FailTest();
             PrintLine(span[0].ToString());
             PrintLine(span[1].ToString());
             PrintLine(span[2].ToString());
         }
         else
         {
-            PrintLine("ByReference intrinsics exercise via ReadOnlySpan OK.");
+            PassTest();
         }
 
         TestConstrainedClassCalls();
 
         TestValueTypeElementIndexing();
-        
+
         TestArrayItfDispatch();
 
         TestMetaData();
-        
+
         TestTryFinally();
 
+        StartTest("RVA static field test");
         int rvaFieldValue = ILHelpers.ILHelpersTest.StaticInitedInt;
         if (rvaFieldValue == 0x78563412)
         {
-            PrintLine("RVA static field test: Ok.");
+            PassTest();
         }
         else
         {
-            PrintLine("RVA static field test: Failed.");
-            PrintLine(rvaFieldValue.ToString());
+            FailTest(rvaFieldValue.ToString());
         }
 
         TestNativeCallback();
@@ -329,7 +267,36 @@ internal static class Program
         System.Diagnostics.Debugger.Break();
 
         PrintLine("Done");
-        return 100;
+        return Success ? 100 : -1;
+    }
+
+    private static void StartTest(string testDescription)
+    {
+        PrintString(testDescription + ": ");
+    }
+
+    private static void EndTest(bool result, string failMessage = null)
+    {
+        if (result)
+        {
+            PassTest();
+        }
+        else
+        {
+            FailTest(failMessage);
+        }
+    }
+
+    internal static void PassTest()
+    {
+        PrintLine("Ok.");
+    }
+
+    internal static void FailTest(string failMessage = null)
+    {
+        Success = false;
+        if(failMessage != null) PrintString(failMessage + "-");
+        FailTest();
     }
 
     private static int StaticDelegateTarget()
@@ -411,25 +378,25 @@ internal static class Program
 
     private unsafe static void StackallocTest()
     {
+        StartTest("Stackalloc test");
         int* intSpan = stackalloc int[2];
         intSpan[0] = 3;
         intSpan[1] = 7;
 
-        if (intSpan[0] == 3 && intSpan[1] == 7)
-        {
-            PrintLine("Stackalloc test: Ok.");
-        }
+        EndTest(intSpan[0] == 3 && intSpan[1] == 7);
     }
 
     private static void IntToStringTest()
     {
-        PrintLine("Int to String Test: Ok if next line says 42.");
+        StartTest("Int to String Test: Ok if says 42:");
         string intString = 42.ToString();
         PrintLine(intString);
+        EndTest(intString == "42");
     }
 
     private unsafe static void ldindTest()
     {
+        StartTest("ldind test");
         var ldindTarget = new TwoByteStr { first = byte.MaxValue, second = byte.MinValue };
         var ldindField = &ldindTarget.first;
         if((*ldindField) == byte.MaxValue)
@@ -439,42 +406,33 @@ internal static class Program
             //ensure there isnt any overwrite of nearby fields
             if(ldindTarget.first == byte.MinValue && ldindTarget.second == byte.MaxValue)
             {
-                PrintLine("ldind test: Ok.");
+                PassTest();
             }
             else if(ldindTarget.first != byte.MinValue)
             {
-                PrintLine("ldind test: Failed didnt update target.");
+                FailTest("didnt update target.");
             }
             else
             {
-                PrintLine("ldind test: Failed overwrote data");
+                FailTest("overwrote data");
             }
         }
         else
         {
             uint ldindFieldValue = *ldindField;
-            PrintLine("ldind test: Failed." + ldindFieldValue.ToString());
+            FailTest(ldindFieldValue.ToString());
         }
     }
 
     private static void InterfaceDispatchTest()
     {
+        StartTest("Struct interface test");
         ItfStruct itfStruct = new ItfStruct();
-        if (ItfCaller(itfStruct) == 4)
-        {
-            PrintLine("Struct interface test: Ok.");
-        }
+        EndTest(ItfCaller(itfStruct) == 4);
 
         ClassWithSealedVTable classWithSealedVTable = new ClassWithSealedVTable();
-        PrintString("Interface dispatch with sealed vtable test: ");
-        if (CallItf(classWithSealedVTable) == 37)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        StartTest("Interface dispatch with sealed vtable test: ");
+        EndTest(CallItf(classWithSealedVTable) == 37);
     }
 
     // Calls the ITestItf interface via a generic to ensure the concrete type is known and
@@ -498,123 +456,63 @@ internal static class Program
         }
         else
         {
+            StartTest("BeforeFieldInit test");
             int x = BeforeFieldInitTest.TestField;
-            if (StaticsInited.BeforeFieldInitInited)
-            {
-                PrintLine("BeforeFieldInit test: Ok.");
-            }
-            else
-            {
-                PrintLine("BeforeFieldInit cctor not run");
-            }
+            EndTest(StaticsInited.BeforeFieldInitInited, "cctor not run");
         }
 
+        StartTest("NonBeforeFieldInit test");
         NonBeforeFieldInitTest.Nop();
-        if (StaticsInited.NonBeforeFieldInitInited)
-        {
-            PrintLine("NonBeforeFieldInit test: Ok.");
-        }
-        else
-        { 
-            PrintLine("NonBeforeFieldInitType cctor not run");
-        }
+        EndTest(StaticsInited.NonBeforeFieldInitInited, "cctor not run");
     }
 
     private static void TestConstrainedClassCalls()
     {
         string s = "utf-8";
 
-        PrintString("Direct ToString test: ");
+        StartTest("Direct ToString test");
         string stringDirectToString = s.ToString();
         if (s.Equals(stringDirectToString))
         {
-            PrintLine("Ok.");
+            PassTest();
         }
         else
         {
-            PrintString("Failed. Returned string:\"");
+            FailTest();
+            PrintString("Returned string:\"");
             PrintString(stringDirectToString);
             PrintLine("\"");
         }
        
         // Generic calls on methods not defined on object
         uint dataFromBase = GenericGetData<MyBase>(new MyBase(11));
-        PrintString("Generic call to base class test: ");
-        if (dataFromBase == 11)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        StartTest("Generic call to base class test");
+        EndTest(dataFromBase == 11);
 
         uint dataFromUnsealed = GenericGetData<UnsealedDerived>(new UnsealedDerived(13));
-        PrintString("Generic call to unsealed derived class test: ");
-        if (dataFromUnsealed == 26)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        StartTest("Generic call to unsealed derived class test");
+        EndTest(dataFromUnsealed == 26);
 
         uint dataFromSealed = GenericGetData<SealedDerived>(new SealedDerived(15));
-        PrintString("Generic call to sealed derived class test: ");
-        if (dataFromSealed == 45)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        StartTest("Generic call to sealed derived class test");
+        EndTest(dataFromSealed == 45);
 
         uint dataFromUnsealedAsBase = GenericGetData<MyBase>(new UnsealedDerived(17));
-        PrintString("Generic call to unsealed derived class as base test: ");
-        if (dataFromUnsealedAsBase == 34)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        StartTest("Generic call to unsealed derived class as base test");
+        EndTest(dataFromUnsealedAsBase == 34);
 
         uint dataFromSealedAsBase = GenericGetData<MyBase>(new SealedDerived(19));
-        PrintString("Generic call to sealed derived class as base test: ");
-        if (dataFromSealedAsBase == 57)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        StartTest("Generic call to sealed derived class as base test");
+        EndTest(dataFromSealedAsBase == 57);
 
         // Generic calls to methods defined on object
         uint hashCodeOfSealedViaGeneric = (uint)GenericGetHashCode<MySealedClass>(new MySealedClass(37));
-        PrintString("Generic GetHashCode for sealed class test: ");
-        if (hashCodeOfSealedViaGeneric == 74)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        StartTest("Generic GetHashCode for sealed class test");
+        EndTest(hashCodeOfSealedViaGeneric == 74);
 
         uint hashCodeOfUnsealedViaGeneric = (uint)GenericGetHashCode<MyUnsealedClass>(new MyUnsealedClass(41));
-        PrintString("Generic GetHashCode for unsealed class test: ");
-        if (hashCodeOfUnsealedViaGeneric == 82)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        StartTest("Generic GetHashCode for unsealed class test");
+        EndTest(hashCodeOfUnsealedViaGeneric == 82);
     }
 
     static uint GenericGetData<T>(T obj) where T : MyBase
@@ -630,99 +528,60 @@ internal static class Program
     private static void TestArrayItfDispatch()
     {
         ICollection<int> arrayItfDispatchTest = new int[37];
-        PrintString("Array interface dispatch test: ");
-        if (arrayItfDispatchTest.Count == 37)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.  asm.js (WASM=1) known to fail due to alignment problem, although this problem sometimes means we don't even get this far and fails with an invalid function pointer.");
-        }
+        StartTest("Array interface dispatch test");
+        EndTest(arrayItfDispatchTest.Count == 37,
+            "Failed.  asm.js (WASM=1) known to fail due to alignment problem, although this problem sometimes means we don't even get this far and fails with an invalid function pointer.");
     }
 
     private static void TestValueTypeElementIndexing()
     {
         var chars = new[] { 'i', 'p', 's', 'u', 'm' };
-        PrintString("Value type element indexing: ");
-        if (chars[0] == 'i' && chars[1] == 'p' && chars[2] == 's' && chars[3] == 'u' && chars[4] == 'm')
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        StartTest("Value type element indexing: ");
+        EndTest(chars[0] == 'i' && chars[1] == 'p' && chars[2] == 's' && chars[3] == 'u' && chars[4] == 'm');
     }
 
     private static void FloatDoubleTest()
     {
+        StartTest("(double) cast test");
         int intToCast = 1;
         double castedDouble = (double)intToCast;
         if (castedDouble == 1d)
         {
-            PrintLine("(double) cast test: Ok.");
+            PassTest();
         }
         else
         {
             var toInt = (int)castedDouble;
             //            PrintLine("expected 1m, but was " + castedDouble.ToString());  // double.ToString is not compiling at the time of writing, but this would be better output
-            PrintLine($"(double) cast test : Failed. Back to int on next line");
+            FailTest("Back to int on next line");
             PrintLine(toInt.ToString());
         }
 
-        if (1f < 2d && 1d < 2f && 1f == 1d)
-        {
-            PrintLine("different width float comparisons: Ok.");
-        }
+        StartTest("different width float comparisons");
+        EndTest(1f < 2d && 1d < 2f && 1f == 1d);
 
+        StartTest("double precision comparison");
         // floats are 7 digits precision, so check some double more precise to make sure there is no loss occurring through some inadvertent cast to float
-        if (10.23456789d != 10.234567891d)
-        {
-            PrintLine("double precision comparison: Ok.");
-        }
+        EndTest(10.23456789d != 10.234567891d);
 
-        if (12.34567f == 12.34567f && 12.34567f != 12.34568f)
-        {
-            PrintLine("float comparison: Ok.");
-        }
+        StartTest("float comparison");
+        EndTest(12.34567f == 12.34567f && 12.34567f != 12.34568f);
 
-        PrintString("Test comparison of float constant: ");
+        StartTest("Test comparison of float constant");
         var maxFloat = Single.MaxValue;
-        if (maxFloat == Single.MaxValue)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest(maxFloat == Single.MaxValue);
 
-        PrintString("Test comparison of double constant: ");
+        StartTest("Test comparison of double constant");
         var maxDouble = Double.MaxValue;
-        if (maxDouble == Double.MaxValue)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest(maxDouble == Double.MaxValue);
     }
 
     private static bool callbackResult;
     private static unsafe void TestNativeCallback()
     {
+        StartTest("Native callback test");
         CallMe(123);
-        PrintString("Native callback test: ");
-        if (callbackResult)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest(callbackResult);
     }
 
     [System.Runtime.InteropServices.NativeCallable(EntryPoint = "CallMe")]
@@ -739,219 +598,134 @@ internal static class Program
 
     private static void TestMetaData()
     {
-
+        StartTest("type == null.  Simple class metadata test");
         var typeGetType = Type.GetType("System.Char, System.Private.CoreLib");
         if (typeGetType == null)
         {
-            PrintLine("type == null.  Simple class metadata test: Failed");
+            FailTest("type == null.  Simple class metadata test");
         }
         else
         {
             if (typeGetType.FullName != "System.Char")
             {
-                PrintLine("type != System.Char.  Simple class metadata test: Failed");
+                FailTest("type != System.Char.  Simple class metadata test");
             }
-            else PrintLine("Simple class metadata test: Ok.");
+            else PassTest();
         }
 
+        StartTest("Simple struct metadata test (typeof(Char))");
         var typeofChar = typeof(Char);
         if (typeofChar == null)
         {
-            PrintLine("type == null.  Simple struct metadata test: Failed");
+            FailTest("type == null.  Simple struct metadata test");
         }
         else
         {
             if (typeofChar.FullName != "System.Char")
             {
-                PrintLine("type != System.Char.  Simple struct metadata test: Failed");
+                FailTest("type != System.Char.  Simple struct metadata test");
             }
-            else PrintLine("Simple struct metadata test (typeof(Char)): Ok.");
+            else PassTest();
         }
 
         var gentT = new Gen<int>();
         var genParamType = gentT.TestTypeOf();
-        PrintString("type of generic parameter: ");
+        StartTest("type of generic parameter: ");
         if (genParamType.FullName != "System.Int32")
         {
-            PrintString("expected System.Int32 but was " + genParamType.FullName);
-            PrintLine(" Failed.");
+            FailTest("expected System.Int32 but was " + genParamType.FullName);
         }
         else
         {
-            PrintLine("Ok.");
+            PassTest();
         }
 
         var arrayType = typeof(object[]);
-        PrintString("type of array: ");
+        StartTest("type of array");
         if (arrayType.FullName != "System.Object[]")
         {
-            PrintString("expected System.Object[] but was " + arrayType.FullName);
-            PrintLine(" Failed.");
+            FailTest("expected System.Object[] but was " + arrayType.FullName);
         }
         else
         {
-            PrintLine("Ok.");
+            PassTest();
         }
 
         var genericType = typeof(List<object>);
-        PrintString("type of generic : ");
+        StartTest("type of generic : ");
         if (genericType.FullName != "System.Collections.Generic.List`1[[System.Object, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]")
         {
-            PrintString("expected System.Collections.Generic.List`1[[System.Object, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]] but was " + genericType.FullName);
-            PrintLine(" Failed.");
+            FailTest("expected System.Collections.Generic.List`1[[System.Object, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]] but was " + genericType.FullName);
         }
         else
         {
-            PrintLine("Ok.");
+            PassTest();
         }
 
-        PrintString("Type GetFields length: ");
+        StartTest("Type GetFields length");
         var x = new ClassForMetaTests();
         var s = x.StringField;  
         var i = x.IntField;
         var classForMetaTestsType = typeof(ClassForMetaTests);
         FieldInfo[] fields = classForMetaTestsType.GetFields();
-        if (fields.Length == 3)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine(" Failed.");
-        }
+        EndTest(fields.Length == 3);
 
-        PrintString("Type get string field via reflection: ");
+        StartTest("Type get string field via reflection");
         var stringFieldInfo = classForMetaTestsType.GetField("StringField");
-        if ((string)stringFieldInfo.GetValue(x) == s)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
-        PrintString("Type get int field via reflection: ");
+        EndTest((string)stringFieldInfo.GetValue(x) == s);
+
+        StartTest("Type get int field via reflection");
         var intFieldInfo = classForMetaTestsType.GetField("IntField");
-        if ((int)intFieldInfo.GetValue(x) == i)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest((int)intFieldInfo.GetValue(x) == i);
 
-        PrintString("Type get static int field via reflection: ");
+        StartTest("Type get static int field via reflection");
         var staticIntFieldInfo = classForMetaTestsType.GetField("StaticIntField");
-        if ((int)staticIntFieldInfo.GetValue(x) == 23)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest((int)staticIntFieldInfo.GetValue(x) == 23);
 
-        PrintString("Type set string field via reflection: ");
+        StartTest("Type set string field via reflection");
         stringFieldInfo.SetValue(x, "bcd");
-        if (x.StringField == "bcd")
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest(x.StringField == "bcd");
 
-        PrintString("Type set int field via reflection: ");
+        StartTest("Type set int field via reflection");
         intFieldInfo.SetValue(x, 456);
-        if (x.IntField == 456)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest(x.IntField == 456);
 
-        PrintString("Type set static int field via reflection: ");
+        StartTest("Type set static int field via reflection");
         staticIntFieldInfo.SetValue(x, 987);
-        if (ClassForMetaTests.StaticIntField == 987)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest(ClassForMetaTests.StaticIntField == 987);
+
         var st = new StructForMetaTests();
         st.StringField = "xyz";
         var fieldStructType = typeof(StructForMetaTests);
         var structStringFieldInfo = fieldStructType.GetField("StringField");
-        PrintString("Struct get string field via reflection: ");
-        if ((string)structStringFieldInfo.GetValue(st) == "xyz")
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        StartTest("Struct get string field via reflection");
+        EndTest((string)structStringFieldInfo.GetValue(st) == "xyz");
 
-        PrintString("Class get+invoke ctor via reflection: ");
+        StartTest("Class get+invoke ctor via reflection");
         var ctor = classForMetaTestsType.GetConstructor(new Type[0]);
         ClassForMetaTests instance = (ClassForMetaTests)ctor.Invoke(null);
-        if (instance.IntField == 12)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest(instance.IntField == 12);
 
         instance.ReturnTrueIf1(0); // force method output
         instance.ReturnTrueIf1AndThis(0, null); // force method output
         ClassForMetaTests.ReturnsParam(null); // force method output
 
-        PrintString("Class get+invoke simple method via reflection: ");
+        StartTest("Class get+invoke simple method via reflection");
         var mtd = classForMetaTestsType.GetMethod("ReturnTrueIf1");
         bool shouldBeTrue = (bool)mtd.Invoke(instance, new object[] {1});
         bool shouldBeFalse = (bool)mtd.Invoke(instance, new object[] {2});
-        if (shouldBeTrue && !shouldBeFalse)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest(shouldBeTrue && !shouldBeFalse);
 
-        PrintString("Class get+invoke method with ref param via reflection: ");
+        StartTest("Class get+invoke method with ref param via reflection");
         var mtdWith2Params = classForMetaTestsType.GetMethod("ReturnTrueIf1AndThis");
         shouldBeTrue = (bool)mtdWith2Params.Invoke(instance, new object[] { 1, instance });
         shouldBeFalse = (bool)mtdWith2Params.Invoke(instance, new object[] { 1, new ClassForMetaTests() });
-        if (shouldBeTrue && !shouldBeFalse)
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest(shouldBeTrue && !shouldBeFalse);
 
-
-        PrintString("Class get+invoke static method with ref param via reflection: ");
+        StartTest("Class get+invoke static method with ref param via reflection");
         var staticMtd = classForMetaTestsType.GetMethod("ReturnsParam");
         var retVal = (ClassForMetaTests)staticMtd.Invoke(null, new object[] { instance });
-        if (Object.ReferenceEquals(retVal, instance))
-        {
-            PrintLine("Ok.");
-        }
-        else
-        {
-            PrintLine("Failed.");
-        }
+        EndTest(Object.ReferenceEquals(retVal, instance));
     }
 
     public class ClassForMetaTests
@@ -997,15 +771,15 @@ internal static class Program
     /// </summary>
     private static void TestTryFinally()
     {
-        PrintString("Try/Finally test: ");
+        StartTest("Try/Finally test");
         uint result = TryFinallyInner();
         if (result == 1111)
         {
-            PrintLine("Ok.");
+            PassTest();
         }
         else
         {
-            PrintLine("Failed. Result: " + result.ToString());
+            FailTest("Result: " + result.ToString());
         }
     }
 
@@ -1034,13 +808,14 @@ internal static class Program
     {
         public void MixedArgFunc(int firstInt, object shadowStackArg, int secondInt, object secondShadowStackArg)
         {
-            PrintString("MixedParamFuncWithExceptionRegions does not overwrite args : ");
+            Program.StartTest("MixedParamFuncWithExceptionRegions does not overwrite args");
             bool ok = true;
             int p1 = firstInt;
             try // add a try/catch to get _exceptionRegions.Length > 0 and copy stack args to shadow stack
             {
                 if (shadowStackArg != null)
                 {
+                    FailTest("shadowStackArg != null");
                     ok = false;
                 }
             }
@@ -1050,29 +825,25 @@ internal static class Program
             }
             if (p1 != 1)
             {
-                PrintString("p1 not 1, was ");
+                FailTest("p1 not 1, was ");
                 PrintLine(p1.ToString());
                 ok = false;
             }
 
             if (secondInt != 2)
             {
-                PrintString("secondInt not 2, was ");
+                FailTest("secondInt not 2, was ");
                 PrintLine(secondInt.ToString());
                 ok = false;
             }
             if (secondShadowStackArg != null)
             {
-                PrintLine("secondShadowStackArg != null");
+                FailTest("secondShadowStackArg != null");
                 ok = false;
             }
             if (ok)
             {
-                PrintLine("Ok.");
-            }
-            else
-            {
-                PrintLine("Failed.");
+                PassTest();
             }
         }
     }
@@ -1081,62 +852,62 @@ internal static class Program
     {
         var firstClass = new ClassWithFourThreadStatics();
         int firstClassStatic = firstClass.GetStatic();
-        PrintString("Static should be initialised: ");
+        StartTest("Static should be initialised");
         if (firstClassStatic == 2)
         {
-            PrintLine("Ok.");
+            PassTest();
         }
         else
         {
-            PrintLine("Failed.");
+            FailTest();
             PrintLine("Was: " + firstClassStatic.ToString());
         }
-        PrintString("Second class with same statics should be initialised: ");
+        StartTest("Second class with same statics should be initialised");
         int secondClassStatic = new AnotherClassWithFourThreadStatics().GetStatic();
         if (secondClassStatic == 13)
         {
-            PrintLine("Ok.");
+            PassTest();
         }
         else
         {
-            PrintLine("Failed.");
+            FailTest();
             PrintLine("Was: " + secondClassStatic.ToString());
         }
 
-        PrintString("First class increment statics: ");
+        StartTest("First class increment statics");
         firstClass.IncrementStatics();
         firstClassStatic = firstClass.GetStatic();
         if (firstClassStatic == 3)
         {
-            PrintLine("Ok.");
+            PassTest();
         }
         else
         {
-            PrintLine("Failed.");
+            FailTest();
             PrintLine("Was: " + firstClassStatic.ToString());
         }
 
-        PrintString("Second class should not be overwritten: "); // catches a type of bug where beacuse the 2 types share the same number and types of ThreadStatics, the first class can end up overwriting the second
+        StartTest("Second class should not be overwritten"); // catches a type of bug where beacuse the 2 types share the same number and types of ThreadStatics, the first class can end up overwriting the second
         secondClassStatic = new AnotherClassWithFourThreadStatics().GetStatic();
         if (secondClassStatic == 13)
         {
-            PrintLine("Ok.");
+            PassTest();
         }
         else
         {
-            PrintLine("Failed.");
+            FailTest();
             PrintLine("Was: " + secondClassStatic.ToString());
         }
 
-        PrintString("First class 2nd instance should share static: ");
+        StartTest("First class 2nd instance should share static");
         int secondInstanceOfFirstClassStatic = new ClassWithFourThreadStatics().GetStatic();
         if (secondInstanceOfFirstClassStatic == 3)
         {
-            PrintLine("Ok.");
+            PassTest();
         }
         else
         {
-            PrintLine("Failed.");
+            FailTest();
             PrintLine("Was: " + secondInstanceOfFirstClassStatic.ToString());
         }
         Thread.Sleep(10);
@@ -1202,7 +973,7 @@ public class TestClass
 
     public virtual void VirtualDelegateTarget()
     {
-        Program.PrintLine("Virtual delegate incorrectly dispatched to base.");
+        Program.FailTest("Virtual delegate incorrectly dispatched to base.");
     }
 }
 
@@ -1225,6 +996,7 @@ public class TestDerivedClass : TestClass
 
     public override void VirtualDelegateTarget()
     {
+        Program.PassTest();
         Program.PrintLine("Virtual Delegate Test: Ok");
     }
 }


### PR DESCRIPTION
There was a lot of duplication in the test pattern used and when a non-fatal error occurred the test exited with a success error code making finding errors a question of scanning the output for "Failed" text.  This PR removes some of the boilerplate in the tests and exits with `-1` in the case of a test failure.