### PR TITLE
Wasm: fix operations on bytes that are stored in shorts

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2823,7 +2823,8 @@ namespace Internal.IL
             StackEntry numBitsToShift = _stack.Pop();
             StackEntry valueToShift = _stack.Pop();
 
-            LLVMValueRef valueToShiftValue = valueToShift.ValueForStackKind(valueToShift.Kind, _builder, false);
+            TypeDesc finalType = valueToShift.Kind == StackValueKind.Int64 ? GetWellKnownType(WellKnownType.Int64) : GetWellKnownType(WellKnownType.Int32);
+            LLVMValueRef valueToShiftValue = valueToShift.ValueAsType(finalType, _builder);
 
             // while it seems excessive that the bits to shift should need to be 64 bits, the LLVM docs say that both operands must be the same type and a compilation failure results if this is not the case.
             LLVMValueRef rhs;

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2820,15 +2820,16 @@ namespace Internal.IL
 
         private TypeDesc WidenBytesAndShorts(TypeDesc type)
         {
-            if (type == GetWellKnownType(WellKnownType.Byte)
-                || type == GetWellKnownType(WellKnownType.SByte)
-                || type == GetWellKnownType(WellKnownType.UInt16)
-                || type == GetWellKnownType(WellKnownType.Int16)
-            )
+            switch (type.Category)
             {
-                return GetWellKnownType(WellKnownType.Int32);
+                case TypeFlags.Byte:
+                case TypeFlags.SByte:
+                case TypeFlags.Int16:
+                case TypeFlags.UInt16:
+                    return GetWellKnownType(WellKnownType.Int32);
+                default:
+                    return type;
             }
-            return type;
         }
 
         private void ImportShiftOperation(ILOpcode opcode)

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using Internal.TypeSystem;
 using ILCompiler;
 using LLVMSharp;

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2756,6 +2756,15 @@ namespace Internal.IL
             }
             else
             {
+                // these ops return an int32 for these.
+                if (type == GetWellKnownType(WellKnownType.Byte)
+                    || type == GetWellKnownType(WellKnownType.SByte)
+                    || type == GetWellKnownType(WellKnownType.UInt16)
+                    || type == GetWellKnownType(WellKnownType.Int16)
+                )
+                {
+                    type = GetWellKnownType(WellKnownType.Int32);
+                }
                 switch (opcode)
                 {
                     case ILOpcode.add:
@@ -2823,8 +2832,7 @@ namespace Internal.IL
             StackEntry numBitsToShift = _stack.Pop();
             StackEntry valueToShift = _stack.Pop();
 
-            TypeDesc finalType = valueToShift.Kind == StackValueKind.Int64 ? GetWellKnownType(WellKnownType.Int64) : GetWellKnownType(WellKnownType.Int32);
-            LLVMValueRef valueToShiftValue = valueToShift.ValueAsType(finalType, _builder);
+            LLVMValueRef valueToShiftValue = valueToShift.ValueForStackKind(valueToShift.Kind, _builder, false);
 
             // while it seems excessive that the bits to shift should need to be 64 bits, the LLVM docs say that both operands must be the same type and a compilation failure results if this is not the case.
             LLVMValueRef rhs;

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -20,6 +20,10 @@ internal static class Program
     internal static bool Success;
     private static unsafe int Main(string[] args)
     {
+        byte byteConstant2 = (byte)0x80;
+        var shiftbyte2 = byteConstant2 << 1;
+        EndTest(shiftbyte2 == 0x0100);
+
         Success = true;
         PrintLine("Starting");
 
@@ -94,13 +98,11 @@ internal static class Program
         int divResult = tempInt / 3;
         EndTest(divResult == 3);
 
-        StartTest("Addition of short and int Test");
-        int shortAndIntResult = (short)1 + 0x10000f;
-        EndTest(shortAndIntResult == 0x10001f);
-
-        StartTest("Addition of int and short Test");
-        int intAndShortResult = 0x10000f + (short)1;
-        EndTest(intAndShortResult == 0x10001f);
+        StartTest("Addition of byte and short test");
+        byte aByte = 2;
+        short aShort = 0x100;
+        short byteAndShortResult = (short)(aByte + aShort);
+        EndTest(byteAndShortResult == 0x102);
 
         StartTest("not test");
         var not = Not(0xFFFFFFFF) == 0x00000000;

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -20,10 +20,6 @@ internal static class Program
     internal static bool Success;
     private static unsafe int Main(string[] args)
     {
-        byte byteConstant2 = (byte)0x80;
-        var shiftbyte2 = byteConstant2 << 1;
-        EndTest(shiftbyte2 == 0x0100);
-
         Success = true;
         PrintLine("Starting");
 
@@ -124,10 +120,10 @@ internal static class Program
         var unsignedShift = UnsignedShift(0xFFFFFFFFu, 4) == 0x0FFFFFFFu;
         EndTest(unsignedShift);
 
-        StartTest("shiftLeft byte test");
+        StartTest("shiftLeft byte to short test");
         byte byteConstant = (byte)0x80;
-        var shiftbyte = byteConstant << 1 == 0x0100;
-        EndTest(shiftbyte);
+        ushort shiftedToShort = (ushort)(byteConstant << 1);
+        EndTest((int)shiftedToShort == 0x0100);
 
         StartTest("SwitchOp0 test");
         var switchTest0 = SwitchOp(5, 5, 0);

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -94,6 +94,14 @@ internal static class Program
         int divResult = tempInt / 3;
         EndTest(divResult == 3);
 
+        StartTest("Addition of short and int Test");
+        int shortAndIntResult = (short)1 + 0x10000f;
+        EndTest(shortAndIntResult == 0x10001f);
+
+        StartTest("Addition of int and short Test");
+        int intAndShortResult = 0x10000f + (short)1;
+        EndTest(intAndShortResult == 0x10001f);
+
         StartTest("not test");
         var not = Not(0xFFFFFFFF) == 0x00000000;
         EndTest(not);
@@ -113,6 +121,11 @@ internal static class Program
         StartTest("unsignedShift test");
         var unsignedShift = UnsignedShift(0xFFFFFFFFu, 4) == 0x0FFFFFFFu;
         EndTest(unsignedShift);
+
+        StartTest("shiftLeft byte test");
+        byte byteConstant = (byte)0x80;
+        var shiftbyte = byteConstant << 1 == 0x0100;
+        EndTest(shiftbyte);
 
         StartTest("SwitchOp0 test");
         var switchTest0 = SwitchOp(5, 5, 0);


### PR DESCRIPTION
The final expression type for binary ops like `add` and shift ops `<<` was incorrectly set to `byte` when the operand was of type `byte`.  These operations act on ints (or int64 - which was ok), and they were incorrectly being truncated back to `byte`.  E.g.

```
        byte aByte = 2;
        short aShort = 0x100;
        short byteAndShortResult = (short)(aByte + aShort);
```
was resulting in `2`.