### PR TITLE
Include eetype.inl in gcwks.cpp

### DIFF
--- a/src/Native/Runtime/AsmOffsetsVerify.cpp
+++ b/src/Native/Runtime/AsmOffsetsVerify.cpp
@@ -6,7 +6,6 @@
 #include "gcheaputilities.h"
 #include "rhassert.h"
 #include "RedhawkWarnings.h"
-#include "slist.h"
 #include "gcrhinterface.h"
 #include "varint.h"
 #include "regdisplay.h"
@@ -14,11 +13,8 @@
 #include "thread.h"
 #include "TargetPtrs.h"
 #include "rhbinder.h"
-#include "RWLock.h"
-#include "RuntimeInstance.h"
 #include "CachedInterfaceDispatch.h"
 #include "shash.h"
-#include "module.h"
 #include "CallDescr.h"
 
 class AsmOffsets

--- a/src/Native/Runtime/FinalizerHelpers.cpp
+++ b/src/Native/Runtime/FinalizerHelpers.cpp
@@ -9,12 +9,8 @@
 #include "gcenv.h"
 #include "gcheaputilities.h"
 
-#include "slist.h"
 #include "gcrhinterface.h"
-#include "RWLock.h"
-#include "RuntimeInstance.h"
 #include "shash.h"
-#include "module.h"
 
 #include "regdisplay.h"
 #include "StackFrameIterator.h"

--- a/src/Native/Runtime/GCHelpers.cpp
+++ b/src/Native/Runtime/GCHelpers.cpp
@@ -14,13 +14,11 @@
 #include "gcrhinterface.h"
 
 #include "PalRedhawkCommon.h"
-#include "slist.h"
 #include "varint.h"
 #include "regdisplay.h"
 #include "StackFrameIterator.h"
 
 #include "thread.h"
-#include "RWLock.h"
 #include "threadstore.h"
 #include "threadstore.inl"
 #include "thread.inl"

--- a/src/Native/Runtime/gcenv.h
+++ b/src/Native/Runtime/gcenv.h
@@ -28,6 +28,12 @@
 #include "gcrhinterface.h"
 #include "gcenv.interlocked.inl"
 
+#include "slist.h"
+#include "RWLock.h"
+#include "module.h"
+#include "RuntimeInstance.h"
+#include "eetype.inl"
+
 #include "stressLog.h"
 #ifdef FEATURE_ETW
 

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -24,7 +24,6 @@
 
 #include "gcrhinterface.h"
 
-#include "slist.h"
 #include "varint.h"
 #include "regdisplay.h"
 #include "StackFrameIterator.h"
@@ -32,11 +31,7 @@
 #include "thread.h"
 
 #include "shash.h"
-#include "RWLock.h"
-#include "module.h"
-#include "RuntimeInstance.h"
 #include "objecthandle.h"
-#include "eetype.inl"
 #include "RhConfig.h"
 
 #include "threadstore.h"

--- a/src/Native/Runtime/gcrhscan.cpp
+++ b/src/Native/Runtime/gcrhscan.cpp
@@ -17,7 +17,6 @@
 
 #include "gcrhinterface.h"
 
-#include "slist.h"
 #include "varint.h"
 #include "regdisplay.h"
 #include "StackFrameIterator.h"
@@ -25,9 +24,6 @@
 #include "thread.h"
 
 #include "shash.h"
-#include "RWLock.h"
-#include "module.h"
-#include "RuntimeInstance.h"
 #include "threadstore.h"
 #include "threadstore.inl"
 #include "thread.inl"


### PR DESCRIPTION
Without it we have following error when link against release libRuntime.a:
```
libRuntime.a(gcwks.cpp.o): In function `EEType::RequiresAlign8()':
eetype.h:546: undefined reference to `EEType::get_RareFlags()'
...
```