### PR TITLE
Wasm: fix to enable multidimensional array get and set operations

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -338,8 +338,7 @@ namespace Internal.IL
                 }
             }
 
-            MetadataType metadataType = (MetadataType)_thisType;
-            if (!metadataType.IsBeforeFieldInit
+            if (_thisType is MetadataType metadataType &&  !metadataType.IsBeforeFieldInit
                 && (!_method.IsStaticConstructor && _method.Signature.IsStatic || _method.IsConstructor || (_thisType.IsValueType && !_method.Signature.IsStatic)) 
                 && _compilation.TypeSystemContext.HasLazyStaticConstructor(metadataType))
             {

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -212,6 +212,17 @@ internal static class Program
         var testMdArrayInstantiation = new int[2, 2];
         EndTest(testMdArrayInstantiation != null && testMdArrayInstantiation.GetLength(0) == 2 && testMdArrayInstantiation.GetLength(1) == 2);
 
+        StartTest("Multi-dimension array get/set test");
+        testMdArrayInstantiation[0, 0] = 1;
+        testMdArrayInstantiation[0, 1] = 2;
+        testMdArrayInstantiation[1, 0] = 3;
+        testMdArrayInstantiation[1, 1] = 4;
+        EndTest(testMdArrayInstantiation[0, 0] == 1 
+                && testMdArrayInstantiation[0, 1] == 2
+                && testMdArrayInstantiation[1, 0] == 3
+                && testMdArrayInstantiation[1, 1] == 4);
+
+
         FloatDoubleTest();
 
         StartTest("long comparison");


### PR DESCRIPTION
Enables get and set operations on multidimensional arrays.  Fixes https://github.com/dotnet/corert/issues/6263