### PR TITLE
Fix ProjectN build break

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -104,7 +104,7 @@
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <LangVersion>latest</LangVersion>
-    <LangVersion Condition="'$(SkipImportRoslynProps)' != 'true'">8.0</LangVersion>
+    <LangVersion Condition="'$(SkipImportRoslynProps)' != 'true' or '$(IsProjectNLibrary)' == 'true'">8.0</LangVersion>
     <UseSharedCompilation>true</UseSharedCompilation>
     <DebugType Condition="'$(IsProjectNLibrary)' != 'true'">portable</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
We need to specify SkipImportRoslynProps because we don't want to include the props file from a bogus file path below, but we do want the 8.0 LangVersion treatment in ProjectN. Since this line is temporary until Roslyn decides that 8.0 is in fact the latest version, I don't feel too bad about this.