### PR TITLE
Make binary serialization work

### DIFF
--- a/src/Common/src/TypeSystem/Ecma/EcmaField.Serialization.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaField.Serialization.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem.Ecma
+{
+    partial class EcmaField
+    {
+        public override bool IsNotSerialized
+        {
+            get
+            {
+                return (GetFieldFlags(FieldFlags.BasicMetadataCache | FieldFlags.NotSerialized) & FieldFlags.NotSerialized) != 0;
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Ecma/EcmaField.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaField.cs
@@ -21,6 +21,7 @@ namespace Internal.TypeSystem.Ecma
             public const int InitOnly               = 0x0004;
             public const int Literal                = 0x0008;
             public const int HasRva                 = 0x0010;
+            public const int NotSerialized          = 0x0020;
 
             public const int AttributeMetadataCache = 0x0100;
             public const int ThreadStatic           = 0x0200;
@@ -135,6 +136,9 @@ namespace Internal.TypeSystem.Ecma
 
                 if ((fieldAttributes & FieldAttributes.HasFieldRVA) != 0)
                     flags |= FieldFlags.HasRva;
+
+                if ((fieldAttributes & FieldAttributes.NotSerialized) != 0)
+                    flags |= FieldFlags.NotSerialized;
 
                 flags |= FieldFlags.BasicMetadataCache;
             }

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.Serialization.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.Serialization.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+namespace Internal.TypeSystem.Ecma
+{
+    partial class EcmaType
+    {
+        public override bool IsSerializable
+        {
+            get
+            {
+                return (_typeDefinition.Attributes & TypeAttributes.Serializable) != 0;
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Serialization/FieldDesc.Serialization.cs
+++ b/src/Common/src/TypeSystem/Serialization/FieldDesc.Serialization.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    // Additional members of FieldDesc related to serialization.
+    partial class FieldDesc
+    {
+        /// <summary>
+        /// Gets a value indicating whether this field is not serialized.
+        /// specially.
+        /// </summary>
+        public virtual bool IsNotSerialized
+        {
+            get
+            {
+                return false;
+            }
+        }
+    }
+
+    partial class FieldForInstantiatedType
+    {
+        public override bool IsNotSerialized
+        {
+            get
+            {
+                return _fieldDef.IsNotSerialized;
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Serialization/TypeDesc.Serialization.cs
+++ b/src/Common/src/TypeSystem/Serialization/TypeDesc.Serialization.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class TypeDesc
+    {
+        /// <summary>
+        /// Gets a value indicating whether this type is serializable.
+        /// </summary>
+        public virtual bool IsSerializable
+        {
+            get
+            {
+                return false;
+            }
+        }
+    }
+
+    partial class InstantiatedType
+    {
+        public override bool IsSerializable
+        {
+            get
+            {
+                return _typeDef.IsSerializable;
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/BlockedInternalsBlockingPolicy.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/BlockedInternalsBlockingPolicy.cs
@@ -157,7 +157,7 @@ namespace ILCompiler
         {
             _blockedTypes = new BlockedTypeHashtable(_blockedModules);
 
-            ArrayOfTType = context.SystemModule.GetType("System", "Array`1");
+            ArrayOfTType = context.SystemModule.GetType("System", "Array`1", false);
             SerializationInfoType = context.SystemModule.GetType("System.Runtime.Serialization", "SerializationInfo", false);
             ISerializableType = context.SystemModule.GetType("System.Runtime.Serialization", "ISerializable", false);
         }

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -304,6 +304,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.CodeGen.cs">
       <Link>Ecma\EcmaField.CodeGen.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.Serialization.cs">
+      <Link>Ecma\EcmaField.Serialization.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaGenericParameter.Sorting.cs">
       <Link>Ecma\EcmaGenericParameter.Sorting.cs</Link>
     </Compile>
@@ -312,6 +315,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaModule.Sorting.cs">
       <Link>Ecma\EcmaModule.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaType.Serialization.cs">
+      <Link>Ecma\EcmaType.Serialization.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaType.Sorting.cs">
       <Link>Ecma\EcmaType.Sorting.cs</Link>
@@ -522,6 +528,12 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Interop\IL\NativeStructType.cs">
       <Link>TypeSystem\Interop\IL\NativeStructType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Serialization\FieldDesc.Serialization.cs">
+      <Link>TypeSystem\CodeGen\FieldDesc.Serialization.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Serialization\TypeDesc.Serialization.cs">
+      <Link>TypeSystem\CodeGen\TypeDesc.Serialization.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Sorting\FieldDesc.Sorting.cs">
       <Link>TypeSystem\Sorting\FieldDesc.Sorting.cs</Link>

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -468,7 +468,7 @@ namespace ILCompiler
 
             MetadataBlockingPolicy mdBlockingPolicy = _noMetadataBlocking 
                     ? (MetadataBlockingPolicy)new NoMetadataBlockingPolicy() 
-                    : new BlockedInternalsBlockingPolicy();
+                    : new BlockedInternalsBlockingPolicy(typeSystemContext);
 
             ManifestResourceBlockingPolicy resBlockingPolicy = new NoManifestResourceBlockingPolicy();
 

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -59,7 +59,11 @@
     <Compile Include="..\..\Common\src\TypeSystem\CodeGen\TypeDesc.CodeGen.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\CodeGen\FieldDesc.CodeGen.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.CodeGen.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.Serialization.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaType.Serialization.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\NativeFormat\NativeFormatField.CodeGen.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Serialization\TypeDesc.Serialization.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Serialization\FieldDesc.Serialization.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ArrayType.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ByRefType.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\DefType.RuntimeDetermined.cs" />

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -59,11 +59,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\CodeGen\TypeDesc.CodeGen.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\CodeGen\FieldDesc.CodeGen.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.CodeGen.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.Serialization.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaType.Serialization.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\NativeFormat\NativeFormatField.CodeGen.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Serialization\TypeDesc.Serialization.cs" />
-    <Compile Include="..\..\Common\src\TypeSystem\Serialization\FieldDesc.Serialization.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ArrayType.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ByRefType.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\DefType.RuntimeDetermined.cs" />


### PR DESCRIPTION
Three parts:

* Expose serialization-related metadata in the type system.
* Poke holes into reflection blocking to make binary serialization work for FX types
* Update the usage based metadata analyzer to scan for binary serialization.

This fixes about 300 failing tests newly exposed in #6987.