### PR TITLE
Fix generation of type forwarder metadata

### DIFF
--- a/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.TypeForwarders.cs
+++ b/src/ILCompiler.MetadataTransform/src/ILCompiler/Metadata/Transform.TypeForwarders.cs
@@ -58,6 +58,11 @@ namespace ILCompiler.Metadata
                             Version = assemblyRef.Version,
                         };
 
+                        if ((assemblyRef.Flags & AssemblyFlags.PublicKey) != 0)
+                            refName.SetPublicKey(reader.GetBlobBytes(assemblyRef.PublicKeyOrToken));
+                        else
+                            refName.SetPublicKeyToken(reader.GetBlobBytes(assemblyRef.PublicKeyOrToken));
+
                         result = new TypeForwarder
                         {
                             Name = HandleString(name),


### PR DESCRIPTION
We were not setting the public key/token for the reference.