### PR TITLE
Add tests for CPAOT method handle lookup

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -215,7 +215,7 @@ namespace ILCompiler.DependencyAnalysis
                     constrainedType: null,
                     method.Token,
                     isUnboxingStub: false,
-                    isInstantiatingStub: false,
+                    isInstantiatingStub: method.Method.HasInstantiation,
                     signatureContext));
         }
 


### PR DESCRIPTION
This is the remains of my method handle PR after rebasing against Tomas' very similar change.

* Test a variety of method handle lookups

* Generic methods need an instantiating stub in their signature when looking up their method handle.