### PR TITLE
[CPAOT] Fix GC Ref Map Emission for uncompilable methods

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
@@ -68,7 +68,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 // Require compilation of the canonical version for instantiating stubs
                 MethodDesc canonMethod = _method.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
                 ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
-                ISymbolNode canonMethodNode = r2rFactory.MethodEntrypoint(
+                ISymbolNode canonMethodNode = r2rFactory.ImportedMethodNode(
                     canonMethod,
                     constrainedType: null,
                     originalMethod: canonMethod,

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -103,22 +103,17 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         public IMethodNode MethodEntrypoint(
-            MethodDesc targetMethod, 
-            TypeDesc constrainedType, 
+            MethodDesc targetMethod,
+            TypeDesc constrainedType,
             MethodDesc originalMethod,
             ModuleToken methodToken,
             bool isUnboxingStub,
             bool isInstantiatingStub,
             SignatureContext signatureContext)
         {
-            if (targetMethod == originalMethod)
-            {
-                constrainedType = null;
-            }
-
             if (!CompilationModuleGroup.ContainsMethodBody(targetMethod, false))
             {
-                return ImportedMethodNode(constrainedType != null ? originalMethod : targetMethod, constrainedType, methodToken, isUnboxingStub, isInstantiatingStub, signatureContext);
+                return ImportedMethodNode(targetMethod, constrainedType, originalMethod, methodToken, isUnboxingStub, isInstantiatingStub, signatureContext);
             }
 
             return _methodEntrypoints.GetOrAdd(targetMethod, (m) =>
@@ -131,6 +126,8 @@ namespace ILCompiler.DependencyAnalysis
 
         private IMethodNode CreateMethodEntrypointNode(MethodWithToken targetMethod, bool isUnboxingStub, bool isInstantiatingStub, SignatureContext signatureContext)
         {
+            Debug.Assert(CompilationModuleGroup.ContainsMethodBody(targetMethod.Method, false));
+
             MethodDesc localMethod = targetMethod.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
 
             TypeAndMethod localMethodKey = new TypeAndMethod(localMethod.OwningType, localMethod, default(ModuleToken), isUnboxingStub: false, isInstantiatingStub: false);
@@ -141,14 +138,55 @@ namespace ILCompiler.DependencyAnalysis
                 _localMethodCache.Add(localMethodKey, localMethodNode);
             }
 
-            return new LocalMethodImport(
-                this,
-                ReadyToRunFixupKind.READYTORUN_FIXUP_MethodEntry,
-                targetMethod,
-                localMethodNode,
-                isUnboxingStub,
-                isInstantiatingStub,
-                signatureContext);
+            return localMethodNode;
+        }
+
+        public IMethodNode ImportedMethodNode(
+            MethodDesc targetMethod,
+            TypeDesc constrainedType,
+            MethodDesc originalMethod,
+            ModuleToken methodToken,
+            bool isUnboxingStub,
+            bool isInstantiatingStub,
+            SignatureContext signatureContext)
+        {
+            if (targetMethod == originalMethod)
+            {
+                constrainedType = null;
+            }
+
+            IMethodNode methodImport;
+            TypeAndMethod key = new TypeAndMethod(constrainedType, targetMethod, methodToken, isUnboxingStub, isInstantiatingStub);
+            if (!_importMethods.TryGetValue(key, out methodImport))
+            {
+                if (!CompilationModuleGroup.ContainsMethodBody(targetMethod, false))
+                {
+                    // First time we see a given external method - emit indirection cell and the import entry
+                    methodImport = new ExternalMethodImport(
+                        this,
+                        ReadyToRunFixupKind.READYTORUN_FIXUP_MethodEntry,
+                        targetMethod,
+                        constrainedType,
+                        methodToken,
+                        isUnboxingStub,
+                        isInstantiatingStub,
+                        signatureContext);
+                }
+                else
+                {
+                    methodImport = new LocalMethodImport(
+                        this,
+                        ReadyToRunFixupKind.READYTORUN_FIXUP_MethodEntry,
+                        new MethodWithToken(targetMethod, methodToken),
+                        (MethodWithGCInfo)MethodEntrypoint(targetMethod, constrainedType, originalMethod, methodToken, isUnboxingStub, isInstantiatingStub, signatureContext),
+                        isUnboxingStub,
+                        isInstantiatingStub,
+                        signatureContext);
+                }
+                _importMethods.Add(key, methodImport);
+            }
+
+            return methodImport;
         }
 
         public IEnumerable<MethodWithGCInfo> EnumerateCompiledMethods()
@@ -249,7 +287,7 @@ namespace ILCompiler.DependencyAnalysis
             MethodFixupSignature signature;
             if (!perFixupKindMap.TryGetValue(key, out signature))
             {
-                signature = new MethodFixupSignature(fixupKind, methodDesc, constrainedType, 
+                signature = new MethodFixupSignature(fixupKind, methodDesc, constrainedType,
                     methodToken, signatureContext, isUnboxingStub, isInstantiatingStub);
                 perFixupKindMap.Add(key, signature);
             }
@@ -373,34 +411,6 @@ namespace ILCompiler.DependencyAnalysis
             graph.AddRoot(Header, "ReadyToRunHeader is always generated");
 
             MetadataManager.AttachToDependencyGraph(graph);
-        }
-
-        public IMethodNode ImportedMethodNode(
-            MethodDesc targetMethod, 
-            TypeDesc constrainedType,
-            ModuleToken methodToken,
-            bool isUnboxingStub,
-            bool isInstantiatingStub,
-            SignatureContext signatureContext)
-        {
-            IMethodNode methodImport;
-            TypeAndMethod key = new TypeAndMethod(constrainedType, targetMethod, methodToken, isUnboxingStub, isInstantiatingStub);
-            if (!_importMethods.TryGetValue(key, out methodImport))
-            {
-                // First time we see a given external method - emit indirection cell and the import entry
-                ExternalMethodImport indirectionCell = new ExternalMethodImport(
-                    this,
-                    ReadyToRunFixupKind.READYTORUN_FIXUP_MethodEntry,
-                    targetMethod,
-                    constrainedType,
-                    methodToken,
-                    isUnboxingStub,
-                    isInstantiatingStub,
-                    signatureContext);
-                _importMethods.Add(key, indirectionCell);
-                methodImport = indirectionCell;
-            }
-            return methodImport;
         }
 
         protected override IEETypeNode CreateNecessaryTypeNode(TypeDesc type)

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1156,7 +1156,7 @@ namespace Internal.JitInterface
 
                         // READYTORUN: FUTURE: Direct calls if possible
                         pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
-                            _compilation.NodeFactory.MethodEntrypoint(methodToCall, constrainedType, originalMethod,
+                            _compilation.NodeFactory.ImportedMethodNode(methodToCall, constrainedType, originalMethod,
                             new ModuleToken(_tokenContext, pResolvedToken.token),
                             isUnboxingStub: false,
                             isInstantiatingStub: useInstantiatingStub,


### PR DESCRIPTION
`ReadyToRunCodegenNodeFactory` always wraps method entry points in an import helper cell. This is not correct when simply asking that a method be compiled such as when rooting methods for compilation. Separate the two concepts so it's possible to ask for either a method's code to be added to the graph (`MethodEntryPoint`) so we can express that we want a method to be compiled, and `ImportedMethodNode` which will wrap the entrypoint with a method import cell. `ImportedMethodNode` should be used at callsites where the import is actually needed.

With this fix, we no longer root method import cells for every method at the beginning of compilation; their presence should now rely on the calling method compiling successfully. Methods that refer to the indeterminate sized `Vector<T>` will no longer leave orphaned method imports with gc ref maps that can't compute the size of that type.

This fixes compilation of microsoft.aspnetcore.server.kestrel.core in the WebAPI workload.
