### PR TITLE
Fix spurious duplicate symbol in Microsoft.EntityFrameworkCore.Design

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -134,7 +134,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 RuntimeDeterminedTypeHelper.WriteTo(_fieldArgument, sb);
             }
             sb.Append(" (");
-            sb.Append(_methodContext.ToString());
+            _methodContext.AppendMangledName(nameMangler, sb);
             sb.Append(")");
         }
 

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Text;
 
 using Internal.Text;
 using Internal.TypeSystem;
@@ -69,7 +68,6 @@ namespace Internal.JitInterface
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            StringBuilder output = new StringBuilder();
             if (Context is MethodDesc contextAsMethod)
             {
                 sb.Append(nameMangler.GetMangledMethodName(contextAsMethod));

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -5,7 +5,9 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
@@ -65,7 +67,18 @@ namespace Internal.JitInterface
 
         public override int GetHashCode() => Context.GetHashCode();
 
-        public override string ToString() => Context.ToString();
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            StringBuilder output = new StringBuilder();
+            if (Context is MethodDesc contextAsMethod)
+            {
+                sb.Append(nameMangler.GetMangledMethodName(contextAsMethod));
+            }
+            else
+            {
+                sb.Append(nameMangler.GetMangledTypeName(ContextType));
+            }
+        }
     }
 
     public class RequiresRuntimeJitException : Exception


### PR DESCRIPTION
Thanks to help from Michal I have discovered that two structurally
different methods on instantiated types can have identical textual
representation as the type / method definition can contain references
to different generic argument indices that just happen to resolve
to the same types in the instantiated entity. Based on Michal's
suggestion I have changed context method formating to use the
NameMangler formatting methods that take care of this issue.

Thanks

Tomas