### PR TITLE
wasm: fix for Initobj fails to compile for structs with double fields

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -3428,7 +3428,7 @@ namespace Internal.IL
                 LLVM.BuildStore(_builder, LLVM.ConstInt(llvmType, 0, LLVMMisc.False), valueEntry.ValueAsType(LLVM.PointerType(llvmType, 0), _builder));
             else if (llvmType.TypeKind == LLVMTypeKind.LLVMPointerTypeKind)
                 LLVM.BuildStore(_builder, LLVM.ConstNull(llvmType), valueEntry.ValueAsType(LLVM.PointerType(llvmType, 0), _builder));
-            else if (llvmType.TypeKind == LLVMTypeKind.LLVMFloatTypeKind)
+            else if (llvmType.TypeKind == LLVMTypeKind.LLVMFloatTypeKind || llvmType.TypeKind == LLVMTypeKind.LLVMDoubleTypeKind)
                 LLVM.BuildStore(_builder, LLVM.ConstReal(llvmType, 0.0), valueEntry.ValueAsType(LLVM.PointerType(llvmType, 0), _builder));
             else
                 throw new NotImplementedException();

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -276,7 +276,7 @@ internal static class Program
 
         TestDispose();
 
-        TestGenericStruct();
+        TestInitObjDouble();
 
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
@@ -939,12 +939,11 @@ internal static class Program
         EndTest(disposable.Disposed);
     }
 
-    private static void TestGenericStruct()
+    private static void TestInitObjDouble()
     {
-        object t = new ValueTuple<int, int>();
-        object t2 = new ValueTuple<int, string>();
-        var hash = t.GetHashCode();
-        var hash2 = t2.GetHashCode();
+        StartTest("Init struct with double field test");
+        StructWithDouble strt = new StructWithDouble();
+        EndTest(strt.DoubleField == 0d);
     }
 
     [DllImport("*")]
@@ -1135,6 +1134,11 @@ public sealed class MySealedClass
         Program.PrintLine(_data.ToString());
         return _data.ToString();
     }
+}
+
+public struct StructWithDouble
+{
+    public double DoubleField;
 }
 
 public class Gen<T>

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Collections;
 
 #if PLATFORM_WINDOWS
 using CpObj;

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Collections;
 
 #if PLATFORM_WINDOWS
 using CpObj;
@@ -274,6 +275,8 @@ internal static class Program
         TestThreadStaticsForSingleThread();
 
         TestDispose();
+
+        TestGenericStruct();
 
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
@@ -934,6 +937,14 @@ internal static class Program
         {
         }
         EndTest(disposable.Disposed);
+    }
+
+    private static void TestGenericStruct()
+    {
+        object t = new ValueTuple<int, int>();
+        object t2 = new ValueTuple<int, string>();
+        var hash = t.GetHashCode();
+        var hash2 = t2.GetHashCode();
     }
 
     [DllImport("*")]


### PR DESCRIPTION
There was no path for initialising double fields in structs so the following struct failed to compile the Initobj call:
```
public struct StructWithDouble
{
    public double DoubleField;
}
```
This PR adds double support for Initobj opcode.