### PR TITLE
Fix CPAOT build of three more ASP.NET assemblies

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -80,13 +80,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 sb.Append(" [INST]");
             }
             sb.Append(": ");
-            sb.Append(_methodDesc.Signature.ReturnType.ToString());
-            sb.Append(" ");
-            sb.Append(_methodDesc.ToString());
+            sb.Append(nameMangler.GetMangledMethodName(_methodDesc));
             if (_constrainedType != null)
             {
                 sb.Append(" @ ");
-                sb.Append(_constrainedType.ToString());
+                sb.Append(nameMangler.GetMangledTypeName(_constrainedType));
             }
             if (!_methodToken.IsNull)
             {

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -150,7 +150,8 @@ namespace ILCompiler.DependencyAnalysis
             bool isInstantiatingStub,
             SignatureContext signatureContext)
         {
-            if (targetMethod == originalMethod)
+            bool isLocalMethod = CompilationModuleGroup.ContainsMethodBody(targetMethod, false);
+            if (targetMethod == originalMethod || isLocalMethod)
             {
                 constrainedType = null;
             }
@@ -159,7 +160,7 @@ namespace ILCompiler.DependencyAnalysis
             TypeAndMethod key = new TypeAndMethod(constrainedType, targetMethod, methodToken, isUnboxingStub, isInstantiatingStub);
             if (!_importMethods.TryGetValue(key, out methodImport))
             {
-                if (!CompilationModuleGroup.ContainsMethodBody(targetMethod, false))
+                if (!isLocalMethod)
                 {
                     // First time we see a given external method - emit indirection cell and the import entry
                     methodImport = new ExternalMethodImport(

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -589,6 +589,10 @@ namespace Internal.JitInterface
                     id = ReadyToRunHelper.EndCatch;
                     break;
 
+                case CorInfoHelpFunc.CORINFO_HELP_INITCLASS:
+                case CorInfoHelpFunc.CORINFO_HELP_INITINSTCLASS:
+                    throw new RequiresRuntimeJitException(ftnNum.ToString());
+
                 default:
                     throw new NotImplementedException(ftnNum.ToString());
             }
@@ -1463,6 +1467,13 @@ namespace Internal.JitInterface
 
                 pResult.lookup.constLookup = CreateConstLookupToSymbol(symbolNode);
             }
+        }
+
+        private CORINFO_METHOD_STRUCT_* embedMethodHandle(CORINFO_METHOD_STRUCT_* handle, ref void* ppIndirection)
+        {
+            // TODO: READYTORUN FUTURE: Handle this case correctly
+            MethodDesc methodDesc = HandleToObject(handle);
+            throw new RequiresRuntimeJitException("embedMethodHandle: " + methodDesc.ToString());
         }
     }
 }

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1413,5 +1413,23 @@ namespace Internal.JitInterface
 
             ComputeLookup(ref pResolvedToken, target, helperId, ref pResult.lookup);
         }
+
+        private CORINFO_METHOD_STRUCT_* embedMethodHandle(CORINFO_METHOD_STRUCT_* handle, ref void* ppIndirection)
+        {
+            MethodDesc method = HandleToObject(handle);
+            ISymbolNode methodHandleSymbol = _compilation.NodeFactory.RuntimeMethodHandle(method);
+            CORINFO_METHOD_STRUCT_* result = (CORINFO_METHOD_STRUCT_*)ObjectToHandle(methodHandleSymbol);
+
+            if (methodHandleSymbol.RepresentsIndirectionCell)
+            {
+                ppIndirection = result;
+                return null;
+            }
+            else
+            {
+                ppIndirection = null;
+                return result;
+            }
+        }
     }
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2513,24 +2513,6 @@ namespace Internal.JitInterface
         private CORINFO_CLASS_STRUCT_* embedClassHandle(CORINFO_CLASS_STRUCT_* handle, ref void* ppIndirection)
         { throw new NotImplementedException("embedClassHandle"); }
 
-        private CORINFO_METHOD_STRUCT_* embedMethodHandle(CORINFO_METHOD_STRUCT_* handle, ref void* ppIndirection)
-        {
-            MethodDesc method = HandleToObject(handle);
-            ISymbolNode methodHandleSymbol = _compilation.NodeFactory.RuntimeMethodHandle(method);
-            CORINFO_METHOD_STRUCT_* result = (CORINFO_METHOD_STRUCT_*)ObjectToHandle(methodHandleSymbol);
-
-            if (methodHandleSymbol.RepresentsIndirectionCell)
-            {
-                ppIndirection = result;
-                return null;
-            }
-            else
-            {
-                ppIndirection = null;
-                return result;
-            }
-        }
-
         private CORINFO_FIELD_STRUCT_* embedFieldHandle(CORINFO_FIELD_STRUCT_* handle, ref void* ppIndirection)
         { throw new NotImplementedException("embedFieldHandle"); }
 


### PR DESCRIPTION
1) throw "requires runtime JIT" on INITCLASS / INITINSTCLASS like
Crossgen does;

2) throw "requires runtime JIT" on embedMethodHandle like Crossgen
does;

3) Apply GetMangledMethodName in MethodFixupSignature to fix
spurious symbol name matches.

4) In ImportedMethodNode, suppress constrained type for local methods;
otherwise we could end up with two different TypeAndMethod keys
(because of the different constrained type) but we ended up
producing an identical LocalMethodImport in both cases.

Thanks

Tomas