### PR TITLE
Produce full vtables in CPAOT

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -112,7 +112,7 @@ namespace ILCompiler
 
         public override bool ShouldProduceFullVTable(TypeDesc type)
         {
-            return false;
+            return true;
         }
 
         public override bool ShouldPromoteToFullType(TypeDesc type)


### PR DESCRIPTION
I believe it's inappropriate to try to "optimize" the VTable
as it's not us, it's the CoreCLR runtime that actually emits the
vtable based on type metadata. In contrast to full AOT, we're not
required to produce the complete code graph and so we currently
don't need the detailed VirtualMethodUse tracking that is required
for lazy vtable construction to work properly.

This change fixes CPAOT build of System.Private.CoreLib, hopefully
the last remaining issue in CoreCLR framework and ASP.NET assembly
builds.

Thanks

Tomas