### PR TITLE
[SuperIlc] Pass through unmanaged assets during compilation

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -41,7 +41,7 @@ namespace ReadyToRun.SuperIlc
                 new Option(new [] {"--input-directory", "-in"}, "Folder containing assemblies to optimize", new Argument<DirectoryInfo>().ExistingOnly());
 
             Option OutputDirectory() =>
-                new Option(new [] {"--output-directory", "-out"}, "Folder to emit compiled assemblies", new Argument<DirectoryInfo>());
+                new Option(new [] {"--output-directory", "-out"}, "Folder to emit compiled assemblies", new Argument<DirectoryInfo>().LegalFilePathsOnly());
 
             Option UseCrossgen() =>
                 new Option("--crossgen", "Compile with CoreCLR Crossgen", new Argument<bool>());

--- a/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -29,7 +29,7 @@ class CrossgenRunner : CompilerRunner
         yield return "/platform_assemblies_paths";
         
         StringBuilder sb = new StringBuilder();
-        sb.Append(_outputPath + (_referenceFolders.Count > 0 ? ";" : ""));
+        sb.Append(_inputPath + (_referenceFolders.Count > 0 ? ";" : ""));
         sb.AppendJoin(';', _referenceFolders);
         yield return sb.ToString();
     }


### PR DESCRIPTION
Improve quality of life by passing through to the output all inputs that aren't managed assemblies. This also includes the input assembly if we're unable to successfully compile the assembly, which is useful during CPAOT workload bring-up. If the input folder is a an published with `dotnet publish --self-contained` and contains the runtime, this results in a nice runnable output folder.