### PR TITLE
Add scripts to set up CI with Azure Pipelines for Windows builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,64 @@
+# Setting batch to true, triggers one build at a time.
+# if there is a push while a build in progress, it will wait,
+# until the running build finishes, and produce a build with all the changes
+# that happened during the last build.
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+
+pr:
+- master
+
+jobs:
+
+##   The following is the matrix of test runs that we have. This is
+##   duplicated for each os/arch combination in platform-matrix.yml.
+
+##
+##   Product build       Test build              Test run
+##   (Azure DevOps)      (Azure DevOps)          (Azure DevOps)
+##
+##   ###########################################################################################
+##
+##   Debug   ----------> Inner  -----------------> simple CoreRT test (single file & multimodule)
+##                             \ ----------------> CoreCLR Top200
+##                             \-----------------> CoreFX
+##                             \-----------------> CoreCLR ReadyToRun
+##
+##
+##           \---------> Outer  -----------------> simple CoreRT test (single file & multimodule)
+##                             \-----------------> CoreCLR Pri0 KnownGood (Windows only)
+##                             \-----------------> CoreFX
+##
+##   Release ----------> Inner  -----------------> simple CoreRT test (single file & multimodule)
+##           |
+##           \---------> Outer  -----------------> simple CoreRT test (single file & multimodule)
+##
+##
+
+##
+## Templates used to define jobs:
+## Please update this if the factoring changes.
+##
+## This file defines the set of jobs in a platform-agnostic manner,
+## using the platform-matrix.yml template. This will create one job
+## for each platform from the passed-in jobTemplate (either a build
+## job or a test job). The build-job.yml template
+## uses xplat-job.yml to handle some of the common logic for
+## abstracting over platforms. Finally, xplat-job.yml uses the arcade
+## base.yml job template, which sets up telemetry and signing support.
+
+## azure-pipelines.yml -> platform-matrix.yml -------> build-job.yml -------> xplat-job.yml -> base.yml
+##                                            |  (passed-in jobTemplate)  |                    (arcade)
+
+
+#
+# Debug build (Pull request)
+#
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'corert-ci')) }}:
+  - template: eng/platform-matrix.yml
+    parameters:
+      jobTemplate: build-job.yml
+      buildConfig: debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,3 +64,14 @@ jobs:
       buildConfig: debug
       jobParameters:
         timeoutInMinutes: 180
+
+#
+# Release build (Pull request)
+#
+- ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'corert-ci')) }}:
+  - template: eng/platform-matrix.yml
+    parameters:
+      jobTemplate: build-job.yml
+      buildConfig: release
+      jobParameters:
+        timeoutInMinutes: 180

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,4 +62,5 @@ jobs:
     parameters:
       jobTemplate: build-job.yml
       buildConfig: debug
-      timeoutInMinutes: 180
+      jobParameters:
+        timeoutInMinutes: 180

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,3 +62,4 @@ jobs:
     parameters:
       jobTemplate: build-job.yml
       buildConfig: debug
+      timeoutInMinutes: 180

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -26,6 +26,13 @@ jobs:
 
     steps:
 
+    # Install native dependencies
+    # TODO: add installation logic for non Windows platorms
+    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      # Necessary to install python
+      - script: eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
+        displayName: Install native dependencies
+
     # Build
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - script: build.cmd $(buildConfig) skiptests

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -1,0 +1,34 @@
+parameters:
+  buildConfig: ''
+  archType: ''
+  osGroup: ''
+  osIdentifier: ''
+  timeoutInMinutes: ''
+
+### Product build
+jobs:
+- template: xplat-job.yml
+  parameters:
+    buildConfig: ${{ parameters.buildConfig }}
+    archType: ${{ parameters.archType }}
+    osGroup: ${{ parameters.osGroup }}
+    osIdentifier: ${{ parameters.osIdentifier }}
+
+    # Compute job name from template parameters
+    name: ${{ format('build_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+    displayName: ${{ format('Build {0} {1} {2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+
+    variables:
+    - name: osIdentifier
+      value: ${{ parameters.osIdentifier }}
+
+    steps:
+
+    # Build
+    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      - script: build.cmd $(buildConfig) skiptests
+        displayName: Build product
+
+

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -33,13 +33,23 @@ jobs:
       - script: eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
         displayName: Install native dependencies
 
-    # Build
-    - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      # Build
       - script: build.cmd $(buildConfig) skiptests
         displayName: Build product
       - script: tests\runtest.cmd $(buildConfig)
         displayName: Run simple CoreRT tests
       - script: tests\runtest.cmd $(buildConfig) /multimodule
         displayName: Run simple CoreRT tests in the MultiModule mode
+      - script: tests\runtest.cmd $(buildConfig) /coreclr Top200
+        displayName: Run CoreCLR Top200 tests
 
-
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'xUnit'
+        testResultsFiles: '**/testResults.xml'
+        searchFolder: '$(Build.SourcesDirectory)'
+        mergeTestResults: true
+        failTaskOnFailedTests: true
+        testRunTitle: ${{ format('{0} {1} {2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+        buildPlatform: ${{ parameters.osGroup }}
+        buildConfiguration: $(buildConfig)

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -37,5 +37,9 @@ jobs:
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       - script: build.cmd $(buildConfig) skiptests
         displayName: Build product
+      - script: tests\runtest.cmd $(buildConfig)
+        displayName: Run simple CoreRT tests
+      - script: tests\runtest.cmd $(buildConfig) /multimodule
+        displayName: Run simple CoreRT tests in the MultiModule mode
 
 

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -38,10 +38,13 @@ jobs:
         displayName: Build product
       - script: tests\runtest.cmd $(buildConfig)
         displayName: Run simple CoreRT tests
-      - script: tests\runtest.cmd $(buildConfig) /multimodule
-        displayName: Run simple CoreRT tests in the MultiModule mode
-      - script: tests\runtest.cmd $(buildConfig) /coreclr Top200
-        displayName: Run CoreCLR Top200 tests
+      - ${{ if eq(parameters.buildConfig, 'Debug') }}:
+        - script: tests\runtest.cmd $(buildConfig) /multimodule
+          displayName: Run simple CoreRT tests in the MultiModule mode
+        - script: tests\runtest.cmd $(buildConfig) /coreclr ReadyToRun /mode ReadyToRun
+          displayName: Run basic ReadyToRun tests
+        - script: tests\runtest.cmd $(buildConfig) /coreclr Top200
+          displayName: Run CoreCLR Top200 tests
 
     - task: PublishTestResults@2
       inputs:

--- a/eng/common/init-tools-native.cmd
+++ b/eng/common/init-tools-native.cmd
@@ -1,0 +1,3 @@
+@echo off
+powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0init-tools-native.ps1""" %*"
+exit /b %ErrorLevel%

--- a/eng/common/init-tools-native.ps1
+++ b/eng/common/init-tools-native.ps1
@@ -1,0 +1,128 @@
+<#
+.SYNOPSIS
+Entry point script for installing native tools
+
+.DESCRIPTION
+Reads $RepoRoot\global.json file to determine native assets to install
+and executes installers for those tools
+
+.PARAMETER BaseUri
+Base file directory or Url from which to acquire tool archives
+
+.PARAMETER InstallDirectory
+Directory to install native toolset.  This is a command-line override for the default
+Install directory precedence order:
+- InstallDirectory command-line override
+- NETCOREENG_INSTALL_DIRECTORY environment variable
+- (default) %USERPROFILE%/.netcoreeng/native
+
+.PARAMETER Clean
+Switch specifying to not install anything, but cleanup native asset folders
+
+.PARAMETER Force
+Clean and then install tools
+
+.PARAMETER DownloadRetries
+Total number of retry attempts
+
+.PARAMETER RetryWaitTimeInSeconds
+Wait time between retry attempts in seconds
+
+.PARAMETER GlobalJsonFile
+File path to global.json file
+
+.NOTES
+#>
+[CmdletBinding(PositionalBinding=$false)]
+Param (
+  [string] $BaseUri = "https://netcorenativeassets.blob.core.windows.net/resource-packages/external",
+  [string] $InstallDirectory,
+  [switch] $Clean = $False,
+  [switch] $Force = $False,
+  [int] $DownloadRetries = 5,
+  [int] $RetryWaitTimeInSeconds = 30,
+  [string] $GlobalJsonFile = "$PSScriptRoot\..\..\global.json"
+)
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference="Stop"
+
+Import-Module -Name (Join-Path $PSScriptRoot "native\CommonLibrary.psm1")
+
+try {
+  # Define verbose switch if undefined
+  $Verbose = $VerbosePreference -Eq "Continue"
+
+  $EngCommonBaseDir = Join-Path $PSScriptRoot "native\"
+  $NativeBaseDir = $InstallDirectory
+  if (!$NativeBaseDir) {
+    $NativeBaseDir = CommonLibrary\Get-NativeInstallDirectory
+  }
+  $Env:CommonLibrary_NativeInstallDir = $NativeBaseDir
+  $InstallBin = Join-Path $NativeBaseDir "bin"
+  $InstallerPath = Join-Path $EngCommonBaseDir "install-tool.ps1"
+
+  # Process tools list
+  Write-Host "Processing $GlobalJsonFile"
+  If (-Not (Test-Path $GlobalJsonFile)) {
+    Write-Host "Unable to find '$GlobalJsonFile'"
+    exit 0
+  }
+  $NativeTools = Get-Content($GlobalJsonFile) -Raw |
+                    ConvertFrom-Json |
+                    Select-Object -Expand "native-tools" -ErrorAction SilentlyContinue
+  if ($NativeTools) {
+    $NativeTools.PSObject.Properties | ForEach-Object {
+      $ToolName = $_.Name
+      $ToolVersion = $_.Value
+      $LocalInstallerCommand = $InstallerPath
+      $LocalInstallerCommand += " -ToolName $ToolName"
+      $LocalInstallerCommand += " -InstallPath $InstallBin"
+      $LocalInstallerCommand += " -BaseUri $BaseUri"
+      $LocalInstallerCommand += " -CommonLibraryDirectory $EngCommonBaseDir"
+      $LocalInstallerCommand += " -Version $ToolVersion"
+
+      if ($Verbose) {
+        $LocalInstallerCommand += " -Verbose"
+      }
+      if (Get-Variable 'Force' -ErrorAction 'SilentlyContinue') {
+        if($Force) {
+          $LocalInstallerCommand += " -Force"
+        }
+      }
+      if ($Clean) {
+        $LocalInstallerCommand += " -Clean"
+      }
+
+      Write-Verbose "Installing $ToolName version $ToolVersion"
+      Write-Verbose "Executing '$LocalInstallerCommand'"
+      Invoke-Expression "$LocalInstallerCommand"
+      if ($LASTEXITCODE -Ne "0") {
+        Write-Error "Execution failed"
+        exit 1
+      }
+    }
+  }
+  else {
+    Write-Host "No native tools defined in global.json"
+    exit 0
+  }
+
+  if ($Clean) {
+    exit 0
+  }
+  if (Test-Path $InstallBin) {
+    Write-Host "Native tools are available from" (Convert-Path -Path $InstallBin)
+    Write-Host "##vso[task.prependpath]$(Convert-Path -Path $InstallBin)"
+  }
+  else {
+    Write-Error "Native tools install directory does not exist, installation failed"
+    exit 1
+  }
+  exit 0
+}
+catch {
+  Write-Host $_
+  Write-Host $_.Exception
+  exit 1
+}

--- a/eng/common/native/CommonLibrary.psm1
+++ b/eng/common/native/CommonLibrary.psm1
@@ -1,0 +1,358 @@
+<#
+.SYNOPSIS
+Helper module to install an archive to a directory
+
+.DESCRIPTION
+Helper module to download and extract an archive to a specified directory
+
+.PARAMETER Uri
+Uri of artifact to download
+
+.PARAMETER InstallDirectory
+Directory to extract artifact contents to
+
+.PARAMETER Force
+Force download / extraction if file or contents already exist. Default = False
+
+.PARAMETER DownloadRetries
+Total number of retry attempts. Default = 5
+
+.PARAMETER RetryWaitTimeInSeconds
+Wait time between retry attempts in seconds. Default = 30
+
+.NOTES
+Returns False if download or extraction fail, True otherwise
+#>
+function DownloadAndExtract {
+  [CmdletBinding(PositionalBinding=$false)]
+  Param (
+    [Parameter(Mandatory=$True)]
+    [string] $Uri,
+    [Parameter(Mandatory=$True)]
+    [string] $InstallDirectory,
+    [switch] $Force = $False,
+    [int] $DownloadRetries = 5,
+    [int] $RetryWaitTimeInSeconds = 30
+  )
+  # Define verbose switch if undefined
+  $Verbose = $VerbosePreference -Eq "Continue"
+
+  $TempToolPath = CommonLibrary\Get-TempPathFilename -Path $Uri
+
+  # Download native tool
+  $DownloadStatus = CommonLibrary\Get-File -Uri $Uri `
+                                           -Path $TempToolPath `
+                                           -DownloadRetries $DownloadRetries `
+                                           -RetryWaitTimeInSeconds $RetryWaitTimeInSeconds `
+                                           -Force:$Force `
+                                           -Verbose:$Verbose
+
+  if ($DownloadStatus -Eq $False) {
+    Write-Error "Download failed"
+    return $False
+  }
+
+  # Extract native tool
+  $UnzipStatus = CommonLibrary\Expand-Zip -ZipPath $TempToolPath `
+                                          -OutputDirectory $InstallDirectory `
+                                          -Force:$Force `
+                                          -Verbose:$Verbose
+
+  if ($UnzipStatus -Eq $False) {
+    Write-Error "Unzip failed"
+    return $False
+  }
+  return $True
+}
+
+<#
+.SYNOPSIS
+Download a file, retry on failure
+
+.DESCRIPTION
+Download specified file and retry if attempt fails
+
+.PARAMETER Uri
+Uri of file to download. If Uri is a local path, the file will be copied instead of downloaded
+
+.PARAMETER Path
+Path to download or copy uri file to
+
+.PARAMETER Force
+Overwrite existing file if present. Default = False
+
+.PARAMETER DownloadRetries
+Total number of retry attempts. Default = 5
+
+.PARAMETER RetryWaitTimeInSeconds
+Wait time between retry attempts in seconds Default = 30
+
+#>
+function Get-File {
+  [CmdletBinding(PositionalBinding=$false)]
+  Param (
+    [Parameter(Mandatory=$True)]
+    [string] $Uri,
+    [Parameter(Mandatory=$True)]
+    [string] $Path,
+    [int] $DownloadRetries = 5,
+    [int] $RetryWaitTimeInSeconds = 30,
+    [switch] $Force = $False
+  )
+  $Attempt = 0
+
+  if ($Force) {
+    if (Test-Path $Path) {
+      Remove-Item $Path -Force
+    }
+  }
+  if (Test-Path $Path) {
+    Write-Host "File '$Path' already exists, skipping download"
+    return $True
+  }
+
+  $DownloadDirectory = Split-Path -ErrorAction Ignore -Path "$Path" -Parent
+  if (-Not (Test-Path $DownloadDirectory)) {
+    New-Item -path $DownloadDirectory -force -itemType "Directory" | Out-Null
+  }
+
+  if (Test-Path -IsValid -Path $Uri) {
+    Write-Verbose "'$Uri' is a file path, copying file to '$Path'"
+    Copy-Item -Path $Uri -Destination $Path
+    return $?
+  }
+  else {
+    Write-Verbose "Downloading $Uri"
+    while($Attempt -Lt $DownloadRetries)
+    {
+      try {
+        Invoke-WebRequest -UseBasicParsing -Uri $Uri -OutFile $Path
+        Write-Verbose "Downloaded to '$Path'"
+        return $True
+      }
+      catch {
+        $Attempt++
+        if ($Attempt -Lt $DownloadRetries) {
+          $AttemptsLeft = $DownloadRetries - $Attempt
+          Write-Warning "Download failed, $AttemptsLeft attempts remaining, will retry in $RetryWaitTimeInSeconds seconds"
+          Start-Sleep -Seconds $RetryWaitTimeInSeconds
+        }
+        else {
+          Write-Error $_
+          Write-Error $_.Exception
+        }
+      }
+    }
+  }
+
+  return $False
+}
+
+<#
+.SYNOPSIS
+Generate a shim for a native tool
+
+.DESCRIPTION
+Creates a wrapper script (shim) that passes arguments forward to native tool assembly
+
+.PARAMETER ShimName
+The name of the shim
+
+.PARAMETER ShimDirectory
+The directory where shims are stored
+
+.PARAMETER ToolFilePath
+Path to file that shim forwards to
+
+.PARAMETER Force
+Replace shim if already present.  Default = False
+
+.NOTES
+Returns $True if generating shim succeeds, $False otherwise
+#>
+function New-ScriptShim {
+  [CmdletBinding(PositionalBinding=$false)]
+  Param (
+    [Parameter(Mandatory=$True)]
+    [string] $ShimName,
+    [Parameter(Mandatory=$True)]
+    [string] $ShimDirectory,
+    [Parameter(Mandatory=$True)]
+    [string] $ToolFilePath,
+    [Parameter(Mandatory=$True)]
+    [string] $BaseUri,
+    [switch] $Force
+  )
+  try {
+    Write-Verbose "Generating '$ShimName' shim"
+
+    if (-Not (Test-Path $ToolFilePath)){
+      Write-Error "Specified tool file path '$ToolFilePath' does not exist"
+      return $False
+    }
+
+    # WinShimmer is a small .NET Framework program that creates .exe shims to bootstrapped programs
+    # Many of the checks for installed programs expect a .exe extension for Windows tools, rather
+    # than a .bat or .cmd file.
+    # Source: https://github.com/dotnet/arcade/tree/master/src/WinShimmer
+    if (-Not (Test-Path "$ShimDirectory\WinShimmer\winshimmer.exe")) {
+      $InstallStatus = DownloadAndExtract -Uri "$BaseUri/windows/winshimmer/WinShimmer.zip" `
+                                          -InstallDirectory $ShimDirectory\WinShimmer `
+                                          -Force:$Force `
+                                          -DownloadRetries 2 `
+                                          -RetryWaitTimeInSeconds 5 `
+                                          -Verbose:$Verbose
+    }
+
+    if ((Test-Path (Join-Path $ShimDirectory "$ShimName.exe"))) {
+      Write-Host "$ShimName.exe already exists; replacing..."
+      Remove-Item (Join-Path $ShimDirectory "$ShimName.exe")
+    }
+
+    Invoke-Expression "$ShimDirectory\WinShimmer\winshimmer.exe $ShimName $ToolFilePath $ShimDirectory"
+    return $True
+  }
+  catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    return $False
+  }
+}
+
+<#
+.SYNOPSIS
+Returns the machine architecture of the host machine
+
+.NOTES
+Returns 'x64' on 64 bit machines
+ Returns 'x86' on 32 bit machines
+#>
+function Get-MachineArchitecture {
+  $ProcessorArchitecture = $Env:PROCESSOR_ARCHITECTURE
+  $ProcessorArchitectureW6432 = $Env:PROCESSOR_ARCHITEW6432
+  if($ProcessorArchitecture -Eq "X86")
+  {
+    if(($ProcessorArchitectureW6432 -Eq "") -Or
+       ($ProcessorArchitectureW6432 -Eq "X86")) {
+        return "x86"
+    }
+    $ProcessorArchitecture = $ProcessorArchitectureW6432
+  }
+  if (($ProcessorArchitecture -Eq "AMD64") -Or
+      ($ProcessorArchitecture -Eq "IA64") -Or
+      ($ProcessorArchitecture -Eq "ARM64")) {
+    return "x64"
+  }
+  return "x86"
+}
+
+<#
+.SYNOPSIS
+Get the name of a temporary folder under the native install directory
+#>
+function Get-TempDirectory {
+  return Join-Path (Get-NativeInstallDirectory) "temp/"
+}
+
+function Get-TempPathFilename {
+  [CmdletBinding(PositionalBinding=$false)]
+  Param (
+    [Parameter(Mandatory=$True)]
+    [string] $Path
+  )
+  $TempDir = CommonLibrary\Get-TempDirectory
+  $TempFilename = Split-Path $Path -leaf
+  $TempPath = Join-Path $TempDir $TempFilename
+  return $TempPath
+}
+
+<#
+.SYNOPSIS
+Returns the base directory to use for native tool installation
+
+.NOTES
+Returns the value of the NETCOREENG_INSTALL_DIRECTORY if that environment variable
+is set, or otherwise returns an install directory under the %USERPROFILE%
+#>
+function Get-NativeInstallDirectory {
+  $InstallDir = $Env:NETCOREENG_INSTALL_DIRECTORY
+  if (!$InstallDir) {
+    $InstallDir = Join-Path $Env:USERPROFILE ".netcoreeng/native/"
+  }
+  return $InstallDir
+}
+
+<#
+.SYNOPSIS
+Unzip an archive
+
+.DESCRIPTION
+Powershell module to unzip an archive to a specified directory
+
+.PARAMETER ZipPath (Required)
+Path to archive to unzip
+
+.PARAMETER OutputDirectory (Required)
+Output directory for archive contents
+
+.PARAMETER Force
+Overwrite output directory contents if they already exist
+
+.NOTES
+- Returns True and does not perform an extraction if output directory already exists but Overwrite is not True.
+- Returns True if unzip operation is successful
+- Returns False if Overwrite is True and it is unable to remove contents of OutputDirectory
+- Returns False if unable to extract zip archive
+#>
+function Expand-Zip {
+  [CmdletBinding(PositionalBinding=$false)]
+  Param (
+    [Parameter(Mandatory=$True)]
+    [string] $ZipPath,
+    [Parameter(Mandatory=$True)]
+    [string] $OutputDirectory,
+    [switch] $Force
+  )
+
+  Write-Verbose "Extracting '$ZipPath' to '$OutputDirectory'"
+  try {
+    if ((Test-Path $OutputDirectory) -And (-Not $Force)) {
+      Write-Host "Directory '$OutputDirectory' already exists, skipping extract"
+      return $True
+    }
+    if (Test-Path $OutputDirectory) {
+      Write-Verbose "'Force' is 'True', but '$OutputDirectory' exists, removing directory"
+      Remove-Item $OutputDirectory -Force -Recurse
+      if ($? -Eq $False) {
+        Write-Error "Unable to remove '$OutputDirectory'"
+        return $False
+      }
+    }
+    if (-Not (Test-Path $OutputDirectory)) {
+      New-Item -path $OutputDirectory -Force -itemType "Directory" | Out-Null
+    }
+
+    Add-Type -assembly "system.io.compression.filesystem"
+    [io.compression.zipfile]::ExtractToDirectory("$ZipPath", "$OutputDirectory")
+    if ($? -Eq $False) {
+      Write-Error "Unable to extract '$ZipPath'"
+      return $False
+    }
+  }
+  catch {
+    Write-Host $_
+    Write-Host $_.Exception
+
+    return $False
+  }
+  return $True
+}
+
+export-modulemember -function DownloadAndExtract
+export-modulemember -function Expand-Zip
+export-modulemember -function Get-File
+export-modulemember -function Get-MachineArchitecture
+export-modulemember -function Get-NativeInstallDirectory
+export-modulemember -function Get-TempDirectory
+export-modulemember -function Get-TempPathFilename
+export-modulemember -function New-ScriptShim

--- a/eng/common/native/common-library.sh
+++ b/eng/common/native/common-library.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+function GetNativeInstallDirectory {
+  local install_dir
+
+  if [[ -z $NETCOREENG_INSTALL_DIRECTORY ]]; then
+    install_dir=$HOME/.netcoreeng/native/
+  else
+    install_dir=$NETCOREENG_INSTALL_DIRECTORY
+  fi
+
+  echo $install_dir
+  return 0
+}
+
+function GetTempDirectory {
+
+  echo $(GetNativeInstallDirectory)temp/
+  return 0
+}
+
+function ExpandZip {
+  local zip_path=$1
+  local output_directory=$2
+  local force=${3:-false}
+
+  echo "Extracting $zip_path to $output_directory"
+  if [[ -d $output_directory ]] && [[ $force = false ]]; then
+    echo "Directory '$output_directory' already exists, skipping extract"
+    return 0
+  fi
+
+  if [[ -d $output_directory ]]; then
+    echo "'Force flag enabled, but '$output_directory' exists. Removing directory"
+    rm -rf $output_directory
+    if [[ $? != 0 ]]; then
+      echo Unable to remove '$output_directory'>&2
+      return 1
+    fi
+  fi
+
+  echo "Creating directory: '$output_directory'"
+  mkdir -p $output_directory
+
+  echo "Extracting archive"
+  tar -xf $zip_path -C $output_directory
+  if [[ $? != 0 ]]; then
+    echo "Unable to extract '$zip_path'" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+function GetCurrentOS {
+  local unameOut="$(uname -s)"
+  case $unameOut in
+    Linux*)     echo "Linux";;
+    Darwin*)    echo "MacOS";;
+  esac
+  return 0
+}
+
+function GetFile {
+  local uri=$1
+  local path=$2
+  local force=${3:-false}
+  local download_retries=${4:-5}
+  local retry_wait_time_seconds=${5:-30}
+
+  if [[ -f $path ]]; then
+    if [[ $force = false ]]; then
+      echo "File '$path' already exists. Skipping download"
+      return 0
+    else
+      rm -rf $path
+    fi
+  fi
+
+  if [[ -f $uri ]]; then
+    echo "'$uri' is a file path, copying file to '$path'"
+    cp $uri $path
+    return $?
+  fi
+
+  echo "Downloading $uri"
+  # Use curl if available, otherwise use wget
+  if command -v curl > /dev/null; then
+    curl "$uri" -sSL --retry $download_retries --retry-delay $retry_wait_time_seconds --create-dirs -o "$path" --fail
+  else
+    wget -q -O "$path" "$uri" --tries="$download_retries"
+  fi
+
+  return $?
+}
+
+function GetTempPathFileName {
+  local path=$1
+
+  local temp_dir=$(GetTempDirectory)
+  local temp_file_name=$(basename $path)
+  echo $temp_dir$temp_file_name
+  return 0
+}
+
+function DownloadAndExtract {
+  local uri=$1
+  local installDir=$2
+  local force=${3:-false}
+  local download_retries=${4:-5}
+  local retry_wait_time_seconds=${5:-30}
+
+  local temp_tool_path=$(GetTempPathFileName $uri)
+
+  echo "downloading to: $temp_tool_path"
+
+  # Download file
+  GetFile "$uri" "$temp_tool_path" $force $download_retries $retry_wait_time_seconds
+  if [[ $? != 0 ]]; then
+    echo "Failed to download '$uri' to '$temp_tool_path'." >&2
+    return 1
+  fi
+
+  # Extract File
+  echo "extracting from  $temp_tool_path to $installDir"
+  ExpandZip "$temp_tool_path" "$installDir" $force $download_retries $retry_wait_time_seconds
+  if [[ $? != 0 ]]; then
+    echo "Failed to extract '$temp_tool_path' to '$installDir'." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+function NewScriptShim {
+  local shimpath=$1
+  local tool_file_path=$2
+  local force=${3:-false}
+
+  echo "Generating '$shimpath' shim"
+  if [[ -f $shimpath ]]; then
+    if [[ $force = false ]]; then
+      echo "File '$shimpath' already exists." >&2
+      return 1
+    else
+      rm -rf $shimpath
+    fi
+  fi
+  
+  if [[ ! -f $tool_file_path ]]; then
+    echo "Specified tool file path:'$tool_file_path' does not exist" >&2
+    return 1
+  fi
+
+  local shim_contents=$'#!/usr/bin/env bash\n'
+  shim_contents+="SHIMARGS="$'$1\n'
+  shim_contents+="$tool_file_path"$' $SHIMARGS\n'
+
+  # Write shim file
+  echo "$shim_contents" > $shimpath
+
+  chmod +x $shimpath
+
+  echo "Finished generating shim '$shimpath'"
+
+  return $?
+}
+

--- a/eng/common/native/install-cmake.sh
+++ b/eng/common/native/install-cmake.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+source="${BASH_SOURCE[0]}"
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
+. $scriptroot/common-library.sh
+
+base_uri=
+install_path=
+version=
+clean=false
+force=false
+download_retries=5
+retry_wait_time_seconds=30
+
+while (($# > 0)); do
+  lowerI="$(echo $1 | awk '{print tolower($0)}')"
+  case $lowerI in
+    --baseuri)
+      base_uri=$2
+      shift 2
+      ;;
+    --installpath)
+      install_path=$2
+      shift 2
+      ;;
+    --version)
+      version=$2
+      shift 2
+      ;;
+    --clean)
+      clean=true
+      shift 1
+      ;;
+    --force)
+      force=true
+      shift 1
+      ;;
+    --downloadretries)
+      download_retries=$2
+      shift 2
+      ;;
+    --retrywaittimeseconds)
+      retry_wait_time_seconds=$2
+      shift 2
+      ;;
+    --help)
+      echo "Common settings:"
+      echo "  --baseuri <value>        Base file directory or Url wrom which to acquire tool archives"
+      echo "  --installpath <value>    Base directory to install native tool to"
+      echo "  --clean                  Don't install the tool, just clean up the current install of the tool"
+      echo "  --force                  Force install of tools even if they previously exist"
+      echo "  --help                   Print help and exit"
+      echo ""
+      echo "Advanced settings:"
+      echo "  --downloadretries        Total number of retry attempts"
+      echo "  --retrywaittimeseconds   Wait time between retry attempts in seconds"
+      echo ""
+      exit 0
+      ;;
+  esac
+done
+
+tool_name="cmake"
+tool_os=$(GetCurrentOS)
+tool_folder=$(echo $tool_os | awk '{print tolower($0)}')
+tool_arch="x86_64"
+tool_name_moniker="$tool_name-$version-$tool_os-$tool_arch"
+tool_install_directory="$install_path/$tool_name/$version"
+tool_file_path="$tool_install_directory/$tool_name_moniker/bin/$tool_name"
+shim_path="$install_path/$tool_name.sh"
+uri="${base_uri}/$tool_folder/cmake/$tool_name_moniker.tar.gz"
+
+# Clean up tool and installers
+if [[ $clean = true ]]; then
+  echo "Cleaning $tool_install_directory"
+  if [[ -d $tool_install_directory ]]; then
+    rm -rf $tool_install_directory
+  fi
+
+  echo "Cleaning $shim_path"
+  if [[ -f $shim_path ]]; then
+    rm -rf $shim_path
+  fi
+
+  tool_temp_path=$(GetTempPathFileName $uri)
+  echo "Cleaning $tool_temp_path"
+  if [[ -f $tool_temp_path ]]; then
+    rm -rf $tool_temp_path
+  fi
+
+  exit 0
+fi
+
+# Install tool
+if [[ -f $tool_file_path ]] && [[ $force = false ]]; then
+  echo "$tool_name ($version) already exists, skipping install"
+  exit 0
+fi
+
+DownloadAndExtract $uri $tool_install_directory $force $download_retries $retry_wait_time_seconds
+
+if [[ $? != 0 ]]; then
+  echo "Installation failed" >&2
+  exit 1
+fi
+
+# Generate Shim
+# Always rewrite shims so that we are referencing the expected version
+NewScriptShim $shim_path $tool_file_path true
+
+if [[ $? != 0 ]]; then
+  echo "Shim generation failed" >&2
+  exit 1
+fi
+
+exit 0

--- a/eng/common/native/install-tool.ps1
+++ b/eng/common/native/install-tool.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+Install native tool
+
+.DESCRIPTION
+Install cmake native tool from Azure blob storage
+
+.PARAMETER InstallPath
+Base directory to install native tool to
+
+.PARAMETER BaseUri
+Base file directory or Url from which to acquire tool archives
+
+.PARAMETER CommonLibraryDirectory
+Path to folder containing common library modules
+
+.PARAMETER Force
+Force install of tools even if they previously exist
+
+.PARAMETER Clean
+Don't install the tool, just clean up the current install of the tool
+
+.PARAMETER DownloadRetries
+Total number of retry attempts
+
+.PARAMETER RetryWaitTimeInSeconds
+Wait time between retry attempts in seconds
+
+.NOTES
+Returns 0 if install succeeds, 1 otherwise
+#>
+[CmdletBinding(PositionalBinding=$false)]
+Param (
+  [Parameter(Mandatory=$True)]
+  [string] $ToolName,
+  [Parameter(Mandatory=$True)]
+  [string] $InstallPath,
+  [Parameter(Mandatory=$True)]
+  [string] $BaseUri,
+  [Parameter(Mandatory=$True)]
+  [string] $Version,
+  [string] $CommonLibraryDirectory = $PSScriptRoot,
+  [switch] $Force = $False,
+  [switch] $Clean = $False,
+  [int] $DownloadRetries = 5,
+  [int] $RetryWaitTimeInSeconds = 30
+)
+
+# Import common library modules
+Import-Module -Name (Join-Path $CommonLibraryDirectory "CommonLibrary.psm1")
+
+try {
+  # Define verbose switch if undefined
+  $Verbose = $VerbosePreference -Eq "Continue"
+
+  $Arch = CommonLibrary\Get-MachineArchitecture
+  $ToolOs = "win64"
+  if($Arch -Eq "x32") {
+    $ToolOs = "win32"
+  }
+  $ToolNameMoniker = "$ToolName-$Version-$ToolOs-$Arch"
+  $ToolInstallDirectory = Join-Path $InstallPath "$ToolName\$Version\"
+  $Uri = "$BaseUri/windows/$ToolName/$ToolNameMoniker.zip"
+  $ShimPath = Join-Path $InstallPath "$ToolName.exe"
+
+  if ($Clean) {
+    Write-Host "Cleaning $ToolInstallDirectory"
+    if (Test-Path $ToolInstallDirectory) {
+      Remove-Item $ToolInstallDirectory -Force -Recurse
+    }
+    Write-Host "Cleaning $ShimPath"
+    if (Test-Path $ShimPath) {
+      Remove-Item $ShimPath -Force
+    }
+    $ToolTempPath = CommonLibrary\Get-TempPathFilename -Path $Uri
+    Write-Host "Cleaning $ToolTempPath"
+    if (Test-Path $ToolTempPath) {
+      Remove-Item $ToolTempPath -Force
+    }
+    exit 0
+  }
+
+  # Install tool
+  if ((Test-Path $ToolInstallDirectory) -And (-Not $Force)) {
+    Write-Verbose "$ToolName ($Version) already exists, skipping install"
+  }
+  else {
+    $InstallStatus = CommonLibrary\DownloadAndExtract -Uri $Uri `
+                                                      -InstallDirectory $ToolInstallDirectory `
+                                                      -Force:$Force `
+                                                      -DownloadRetries $DownloadRetries `
+                                                      -RetryWaitTimeInSeconds $RetryWaitTimeInSeconds `
+                                                      -Verbose:$Verbose
+
+    if ($InstallStatus -Eq $False) {
+      Write-Error "Installation failed"
+      exit 1
+    }
+  }
+
+  $ToolFilePath = Get-ChildItem $ToolInstallDirectory -Recurse -Filter "$ToolName.exe" | % { $_.FullName }
+  if (@($ToolFilePath).Length -Gt 1) {
+    Write-Error "There are multiple copies of $ToolName in $($ToolInstallDirectory): `n$(@($ToolFilePath | out-string))"
+    exit 1
+  } elseif (@($ToolFilePath).Length -Lt 1) {
+    Write-Error "$ToolName was not found in $ToolFilePath."
+    exit 1
+  }
+
+  # Generate shim
+  # Always rewrite shims so that we are referencing the expected version
+  $GenerateShimStatus = CommonLibrary\New-ScriptShim -ShimName $ToolName `
+                                                     -ShimDirectory $InstallPath `
+                                                     -ToolFilePath "$ToolFilePath" `
+                                                     -BaseUri $BaseUri `
+                                                     -Force:$Force `
+                                                     -Verbose:$Verbose
+
+  if ($GenerateShimStatus -Eq $False) {
+    Write-Error "Generate shim failed"
+    return 1
+  }
+
+  exit 0
+}
+catch {
+  Write-Host $_
+  Write-Host $_.Exception
+  exit 1
+}

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -1,0 +1,193 @@
+parameters:
+# Job schema parameters - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#job
+  cancelTimeoutInMinutes: ''
+
+  condition: ''
+
+  continueOnError: false
+
+  container: ''
+
+  dependsOn: ''
+
+  displayName: ''
+
+  steps: []
+
+  pool: ''
+
+  strategy: ''
+
+  timeoutInMinutes: ''
+
+  variables: []
+
+  workspace: ''
+
+# Job base template specific parameters
+  # Optional: Enable installing Microbuild plugin
+  #           if 'true', these "variables" must be specified in the variables object or as part of the queue matrix
+  #             _TeamName - the name of your team
+  #             _SignType - 'test' or 'real'
+  enableMicrobuild: false
+
+  # Optional: Include PublishBuildArtifacts task
+  enablePublishBuildArtifacts: false
+
+  # Optional: Enable publishing to the build asset registry
+  enablePublishBuildAssets: false
+
+  # Optional: Include PublishTestResults task
+  enablePublishTestResults: false
+
+  # Optional: enable sending telemetry
+  enableTelemetry: false
+
+  # Optional: define the helix repo for telemeetry (example: 'dotnet/arcade')
+  helixRepo: ''
+
+  # Required: name of the job
+  name: ''
+
+  # Optional: should run as a public build even in the internal project
+  #           if 'true', the build won't run any of the internal only steps, even if it is running in non-public projects.
+  runAsPublic: false
+
+# Internal resources (telemetry, microbuild) can only be accessed from non-public projects,
+# and some (Microbuild) should only be applied to non-PR cases for internal builds.
+
+jobs:
+- job: ${{ parameters.name }}
+
+  ${{ if ne(parameters.cancelTimeoutInMinutes, '') }}:
+    cancelTimeoutInMinutes: ${{ parameters.cancelTimeoutInMinutes }}
+
+  ${{ if ne(parameters.condition, '') }}:
+    condition: ${{ parameters.condition }}
+
+  ${{ if ne(parameters.container, '') }}:
+    container: ${{ parameters.container }}
+
+  ${{ if ne(parameters.continueOnError, '') }}:
+    continueOnError: ${{ parameters.continueOnError }}
+
+  ${{ if ne(parameters.dependsOn, '') }}:
+    dependsOn: ${{ parameters.dependsOn }}
+
+  ${{ if ne(parameters.displayName, '') }}:
+    displayName: ${{ parameters.displayName }}
+
+  ${{ if ne(parameters.pool, '') }}:
+    pool: ${{ parameters.pool }}
+
+  ${{ if ne(parameters.strategy, '') }}:
+    strategy: ${{ parameters.strategy }}
+
+  ${{ if ne(parameters.timeoutInMinutes, '') }}:
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+
+  variables:
+  - ${{ each variable in parameters.variables }}:
+    # handle name-value variable syntax
+    # example:
+    # - name: [key]
+    #   value: [value]
+    - ${{ if ne(variable.name, '') }}:
+      - name: ${{ variable.name }}
+        value: ${{ variable.value }}
+    
+    # handle variable groups
+    - ${{ if ne(variable.group, '') }}:
+      - group: ${{ variable.group }}
+
+    # handle key-value variable syntax.
+    # example:
+    # - [key]: [value]
+    - ${{ if and(eq(variable.name, ''), eq(variable.group, '')) }}:
+      - ${{ each pair in variable }}:
+        - name: ${{ pair.key }}
+          value: ${{ pair.value }}
+
+  ${{ if ne(parameters.workspace, '') }}:
+    workspace: ${{ parameters.workspace }}
+
+  steps:
+  - ${{ if eq(parameters.enableTelemetry, 'true') }}:
+    # Telemetry tasks are built from https://github.com/dotnet/arcade-extensions
+    - task: sendStartTelemetry@0
+      displayName: 'Send Helix Start Telemetry'
+      inputs:
+        helixRepo: ${{ parameters.helixRepo }}
+        buildConfig: $(_BuildConfig)
+        runAsPublic: ${{ parameters.runAsPublic }}
+      continueOnError: ${{ parameters.continueOnError }}
+      condition: always()
+
+  - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
+    - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - task: MicroBuildSigningPlugin@2
+        displayName: Install MicroBuild plugin
+        inputs:
+          signType: $(_SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+        env:
+          TeamName: $(_TeamName)
+        continueOnError: ${{ parameters.continueOnError }}
+        condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
+
+  - ${{ each step in parameters.steps }}:
+    - ${{ step }}
+
+  - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
+    - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - task: MicroBuildCleanup@1
+        displayName: Execute Microbuild cleanup tasks  
+        condition: and(always(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
+        continueOnError: ${{ parameters.continueOnError }}
+        env:
+          TeamName: $(_TeamName)
+
+  - ${{ if eq(parameters.enableTelemetry, 'true') }}:
+    # Telemetry tasks are built from https://github.com/dotnet/arcade-extensions
+    - task: sendEndTelemetry@0
+      displayName: 'Send Helix End Telemetry'
+      continueOnError: ${{ parameters.continueOnError }}
+      condition: always()
+
+  - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Logs
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+        PublishLocation: Container
+        ArtifactName: $(Agent.Os)_$(Agent.JobName)
+      continueOnError: true
+      condition: always()
+
+  - ${{ if eq(parameters.enablePublishTestResults, 'true') }}:
+    - task: PublishTestResults@2
+      displayName: Publish Test Results
+      inputs:
+        testResultsFormat: 'xUnit'
+        testResultsFiles: '*.xml' 
+        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+      continueOnError: true
+      condition: always()
+    
+  - ${{ if and(eq(parameters.enablePublishBuildAssets, true), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - task: CopyFiles@2
+      displayName: Gather Asset Manifests
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/AssetManifest'
+        TargetFolder: '$(Build.StagingDirectory)/AssetManifests'
+      continueOnError: ${{ parameters.continueOnError }}
+      condition: and(succeeded(), eq(variables['_DotNetPublishToBlobFeed'], 'true'))
+    - task: PublishBuildArtifacts@1
+      displayName: Push Asset Manifests
+      inputs:
+        PathtoPublish: '$(Build.StagingDirectory)/AssetManifests'
+        PublishLocation: Container
+        ArtifactName: AssetManifests
+      continueOnError: ${{ parameters.continueOnError }}
+      condition: and(succeeded(), eq(variables['_DotNetPublishToBlobFeed'], 'true'))

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -1,0 +1,66 @@
+parameters:
+  configuration: 'Debug'
+
+  # Optional: condition for the job to run
+  condition: ''
+
+  # Optional: 'true' if future jobs should run even if this job fails
+  continueOnError: false
+
+  # Optional: dependencies of the job
+  dependsOn: ''
+
+  # Optional: Include PublishBuildArtifacts task
+  enablePublishBuildArtifacts: false
+
+  # Optional: A defined YAML pool - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#pool
+  pool: {}
+
+  # Optional: should run as a public build even in the internal project
+  #           if 'true', the build won't run any of the internal only steps, even if it is running in non-public projects.
+  runAsPublic: false
+
+jobs:
+- job: Asset_Registry_Publish
+
+  dependsOn: ${{ parameters.dependsOn }}
+
+  displayName: Publish to Build Asset Registry
+
+  pool: ${{ parameters.pool }}
+
+  variables:
+  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - name: _BuildConfig
+      value: ${{ parameters.configuration }}
+    - group: Publish-Build-Assets
+
+  steps:
+  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - task: DownloadBuildArtifacts@0
+      displayName: Download artifact
+      inputs:
+        artifactName: AssetManifests
+        downloadPath: '$(Build.StagingDirectory)/Download'
+      condition: ${{ parameters.condition }}
+      continueOnError: ${{ parameters.continueOnError }}
+    - task: PowerShell@2
+      displayName: Publish Build Assets
+      inputs:
+        filePath: eng\common\sdk-task.ps1
+        arguments: -task PublishBuildAssets -restore -msbuildEngine dotnet
+          /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
+          /p:BuildAssetRegistryToken=$(MaestroAccessToken)
+          /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+          /p:Configuration=$(_BuildConfig)
+      condition: ${{ parameters.condition }}
+      continueOnError: ${{ parameters.continueOnError }}
+    - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Logs to VSTS
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+          PublishLocation: Container
+          ArtifactName: $(Agent.Os)_PublishBuildAssets
+        continueOnError: true
+        condition: always()      

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -1,0 +1,71 @@
+parameters:
+  # Optional: 'true' if failures in job.yml job should not fail the job
+  continueOnError: false
+
+  # Optional: Enable installing Microbuild plugin
+  #           if 'true', these "variables" must be specified in the variables object or as part of the queue matrix
+  #             _TeamName - the name of your team
+  #             _SignType - 'test' or 'real'
+  enableMicrobuild: false
+
+  # Optional: Include PublishBuildArtifacts task
+  enablePublishBuildArtifacts: false
+
+  # Optional: Enable publishing to the build asset registry
+  enablePublishBuildAssets: false
+
+  # Optional: Include PublishTestResults task
+  enablePublishTestResults: false
+
+  # Optional: enable sending telemetry
+  # if enabled then the 'helixRepo' parameter should also be specified
+  enableTelemetry: false
+
+  # Required: A collection of jobs to run - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#job
+  jobs: []
+
+  # Optional: define the helix repo for telemetry (example: 'dotnet/arcade')
+  helixRepo: ''
+
+  # Optional: Override automatically derived dependsOn value for "publish build assets" job
+  publishBuildAssetsDependsOn: ''
+
+  # Optional: should run as a public build even in the internal project
+  #           if 'true', the build won't run any of the internal only steps, even if it is running in non-public projects.
+  runAsPublic: false
+
+# Internal resources (telemetry, microbuild) can only be accessed from non-public projects,
+# and some (Microbuild) should only be applied to non-PR cases for internal builds.
+
+jobs:
+- ${{ each job in parameters.jobs }}:
+  - template: ../job/job.yml
+    parameters: 
+      # pass along parameters
+      ${{ each parameter in parameters }}:
+        ${{ if ne(parameter.key, 'jobs') }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+      # pass along job properties
+      ${{ each property in job }}:
+        ${{ if ne(property.key, 'job') }}:
+          ${{ property.key }}: ${{ property.value }}
+
+      name: ${{ job.job }}
+
+- ${{ if and(eq(parameters.enablePublishBuildAssets, true), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: ../job/publish-build-assets.yml
+    parameters:
+      continueOnError: ${{ parameters.continueOnError }}
+      dependsOn:
+      - ${{ if ne(parameters.publishBuildAssetsDependsOn, '') }}:
+        - ${{ each job in parameters.publishBuildAssetsDependsOn }}:
+          - ${{ job.job }}
+      - ${{ if eq(parameters.publishBuildAssetsDependsOn, '') }}:
+        - ${{ each job in parameters.jobs }}:
+          - ${{ job.job }}
+      pool:
+        vmImage: vs2017-win2016
+      runAsPublic: ${{ parameters.runAsPublic }}
+      enablePublishBuildArtifacts: ${{ parameters.enablePublishBuildArtifacts }}
+

--- a/eng/common/templates/phases/base.yml
+++ b/eng/common/templates/phases/base.yml
@@ -1,0 +1,130 @@
+parameters:
+  # Optional: Clean sources before building
+  clean: true
+
+  # Optional: Git fetch depth
+  fetchDepth: ''
+
+  # Optional: name of the phase (not specifying phase name may cause name collisions)
+  name: ''
+  # Optional: display name of the phase
+  displayName: ''
+
+  # Optional: condition for the job to run
+  condition: ''
+
+  # Optional: dependencies of the phase
+  dependsOn: ''
+
+  # Required: A defined YAML queue
+  queue: {}
+
+  # Required: build steps
+  steps: []
+
+  # Optional: variables
+  variables: {}
+
+  # Optional: should run as a public build even in the internal project
+  #           if 'true', the build won't run any of the internal only steps, even if it is running in non-public projects.
+  runAsPublic: false
+
+  ## Telemetry variables
+
+  # Optional: enable sending telemetry
+  #           if 'true', these "variables" must be specified in the variables object or as part of the queue matrix
+  #             _HelixBuildConfig - differentiate between Debug, Release, other
+  #             _HelixSource - Example: build/product
+  #             _HelixType - Example: official/dotnet/arcade/$(Build.SourceBranch)
+  enableTelemetry: false
+
+  # Optional: Enable installing Microbuild plugin
+  #           if 'true', these "variables" must be specified in the variables object or as part of the queue matrix
+  #             _TeamName - the name of your team
+  #             _SignType - 'test' or 'real'
+  enableMicrobuild: false
+
+# Internal resources (telemetry, microbuild) can only be accessed from non-public projects,
+# and some (Microbuild) should only be applied to non-PR cases for internal builds.
+
+phases:
+- phase: ${{ parameters.name }}
+
+  ${{ if ne(parameters.displayName, '') }}:
+    displayName: ${{ parameters.displayName }}
+
+  ${{ if ne(parameters.condition, '') }}:
+    condition: ${{ parameters.condition }}
+
+  ${{ if ne(parameters.dependsOn, '') }}:
+    dependsOn: ${{ parameters.dependsOn }}
+
+  queue: ${{ parameters.queue }}
+
+  ${{ if ne(parameters.variables, '') }}:
+    variables:
+      ${{ insert }}: ${{ parameters.variables }}
+
+  steps:
+  - checkout: self
+    clean: ${{ parameters.clean }}
+    ${{ if ne(parameters.fetchDepth, '') }}:
+      fetchDepth: ${{ parameters.fetchDepth }}
+
+  - ${{ if eq(parameters.enableTelemetry, 'true') }}:
+    - template: /eng/common/templates/steps/telemetry-start.yml
+      parameters:
+        buildConfig: $(_HelixBuildConfig)
+        helixSource: $(_HelixSource)
+        helixType: $(_HelixType)
+        runAsPublic: ${{ parameters.runAsPublic }}
+
+  - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
+    # Internal only resource, and Microbuild signing shouldn't be applied to PRs.
+    - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - task: MicroBuildSigningPlugin@2
+        displayName: Install MicroBuild plugin
+        inputs:
+          signType: $(_SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          
+        env:
+          TeamName: $(_TeamName)
+        continueOnError: false
+        condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
+
+  # Run provided build steps
+  - ${{ parameters.steps }}
+
+  - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
+    # Internal only resources
+    - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - task: MicroBuildCleanup@1
+        displayName: Execute Microbuild cleanup tasks  
+        condition: and(always(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
+        env:
+          TeamName: $(_TeamName)
+
+  - ${{ if eq(parameters.enableTelemetry, 'true') }}:
+    - template: /eng/common/templates/steps/telemetry-end.yml
+      parameters:
+        helixSource: $(_HelixSource)
+        helixType: $(_HelixType)
+
+  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - task: CopyFiles@2
+      displayName: Gather Asset Manifests
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/AssetManifest'
+        TargetFolder: '$(Build.StagingDirectory)/AssetManifests'
+      continueOnError: false
+      condition: and(succeeded(), eq(variables['_DotNetPublishToBlobFeed'], 'true'))
+    - task: PublishBuildArtifacts@1
+      displayName: Push Asset Manifests
+      inputs:
+        PathtoPublish: '$(Build.StagingDirectory)/AssetManifests'
+        PublishLocation: Container
+        ArtifactName: AssetManifests
+      continueOnError: false
+      condition: and(succeeded(), eq(variables['_DotNetPublishToBlobFeed'], 'true'))

--- a/eng/common/templates/phases/publish-build-assets.yml
+++ b/eng/common/templates/phases/publish-build-assets.yml
@@ -1,0 +1,49 @@
+parameters:
+  dependsOn: ''
+  queue: {}
+  configuration: 'Debug'
+  condition: succeeded()
+  continueOnError: false
+  runAsPublic: false
+phases:
+  - phase: Asset_Registry_Publish
+    displayName: Publish to Build Asset Registry
+    dependsOn: ${{ parameters.dependsOn }}
+    queue: ${{ parameters.queue }}
+    variables:
+      _BuildConfig: ${{ parameters.configuration }}
+    steps:
+      - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        - task: DownloadBuildArtifacts@0
+          displayName: Download artifact
+          inputs:
+            artifactName: AssetManifests
+            downloadPath: '$(Build.StagingDirectory)/Download'
+          condition: ${{ parameters.condition }}
+          continueOnError: ${{ parameters.continueOnError }}
+        - task: AzureKeyVault@1
+          inputs:
+            azureSubscription: 'DotNet-Engineering-Services_KeyVault'
+            KeyVaultName: EngKeyVault
+            SecretsFilter: 'MaestroAccessToken'
+          condition: ${{ parameters.condition }}
+          continueOnError: ${{ parameters.continueOnError }}
+        - task: PowerShell@2
+          displayName: Publish Build Assets
+          inputs:
+            filePath: eng\common\sdk-task.ps1
+            arguments: -task PublishBuildAssets -restore -msbuildEngine dotnet
+              /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
+              /p:BuildAssetRegistryToken=$(MaestroAccessToken)
+              /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+              /p:Configuration=$(_BuildConfig)
+          condition: ${{ parameters.condition }}
+          continueOnError: ${{ parameters.continueOnError }}
+        - task: PublishBuildArtifacts@1
+          displayName: Publish Logs to VSTS
+          inputs:
+            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+            PublishLocation: Container
+            ArtifactName: $(Agent.Os)_Asset_Registry_Publish
+          continueOnError: true
+          condition: always()

--- a/eng/common/templates/steps/build-reason.yml
+++ b/eng/common/templates/steps/build-reason.yml
@@ -1,0 +1,12 @@
+# build-reason.yml
+# Description: runs steps if build.reason condition is valid.  conditions is a string of valid build reasons 
+# to include steps (',' separated).
+parameters:
+  conditions: ''
+  steps: []
+
+steps:
+  - ${{ if and( not(startsWith(parameters.conditions, 'not')), contains(parameters.conditions, variables['build.reason'])) }}:
+    - ${{ parameters.steps }}
+  - ${{ if and( startsWith(parameters.conditions, 'not'), not(contains(parameters.conditions, variables['build.reason']))) }}:
+    - ${{ parameters.steps }}

--- a/eng/common/templates/steps/helix-publish.yml
+++ b/eng/common/templates/steps/helix-publish.yml
@@ -1,0 +1,51 @@
+parameters:
+  HelixSource: 'pr/dotnet-github-anon-kaonashi-bot'
+  HelixType: ̓'tests/default'
+  HelixBuild: $(Build.BuildNumber)
+  HelixTargetQueues: ''
+  HelixAccessToken: ''
+  HelixPreCommands: ''
+  HelixPostCommands: ''
+  WorkItemDirectory: ''
+  WorkItemCommand: ''
+  CorrelationPayloadDirectory: ''
+  XUnitProjects: ''
+  XUnitTargetFramework: ''
+  XUnitRunnerVersion: ''
+  IncludeDotNetCli: false
+  DotNetCliPackageType: ''
+  DotNetCliVersion: ''
+  EnableXUnitReporter: false
+  WaitForWorkItemCompletion: true
+  condition: succeeded()
+  continueOnError: false
+
+steps:
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: custom
+      projects: eng/common/helixpublish.proj
+      custom: msbuild
+      arguments: '/bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog'
+    displayName: Send job to Helix
+    env:
+      HelixSource: ${{ parameters.HelixSource }}
+      HelixType: ${{ parameters.HelixType }}
+      HelixBuild: ${{ parameters.HelixBuild }}
+      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+      HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      HelixPreCommands: ${{ parameters.HelixPreCommands }}
+      HelixPostCommands: ${{ parameters.HelixPostCommands }}
+      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+      WorkItemCommand: ${{ parameters.WorkItemCommand }}
+      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
+      XUnitProjects: ${{ parameters.XUnitProjects }}
+      XUnitRuntimeTargetFramework: ${{ parameters.XUnitTargetFramework }}
+      XUnitRunnerVersion: ${{ parameters.XUnitRunnerVersion }}
+      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+    condition: ${{ parameters.condition }}
+    continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/templates/steps/run-on-unix.yml
+++ b/eng/common/templates/steps/run-on-unix.yml
@@ -1,0 +1,7 @@
+parameters:
+  agentOs: ''
+  steps: []
+
+steps:
+- ${{ if ne(parameters.agentOs, 'Windows_NT') }}:
+  - ${{ parameters.steps }}

--- a/eng/common/templates/steps/run-on-windows.yml
+++ b/eng/common/templates/steps/run-on-windows.yml
@@ -1,0 +1,7 @@
+parameters:
+  agentOs: ''
+  steps: []
+
+steps:
+- ${{ if eq(parameters.agentOs, 'Windows_NT') }}:
+  - ${{ parameters.steps }}

--- a/eng/common/templates/steps/run-script-ifequalelse.yml
+++ b/eng/common/templates/steps/run-script-ifequalelse.yml
@@ -1,0 +1,33 @@
+parameters:
+  # if parameter1 equals parameter 2, run 'ifScript' command, else run 'elsescript' command
+  parameter1: ''
+  parameter2: ''
+  ifScript: ''
+  elseScript: ''
+
+  # name of script step
+  name: Script
+
+  # display name of script step
+  displayName: If-Equal-Else Script
+
+  # environment
+  env: {}
+
+  # conditional expression for step execution
+  condition: ''
+
+steps:
+- ${{ if and(ne(parameters.ifScript, ''), eq(parameters.parameter1, parameters.parameter2)) }}:
+  - script: ${{ parameters.ifScript }}
+    name: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    env: ${{ parameters.env }}
+    condition: ${{ parameters.condition }}
+
+- ${{ if and(ne(parameters.elseScript, ''), ne(parameters.parameter1, parameters.parameter2)) }}:
+  - script: ${{ parameters.elseScript }}
+    name: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    env: ${{ parameters.env }}
+    condition: ${{ parameters.condition }}

--- a/eng/common/templates/steps/send-to-helix.yml
+++ b/eng/common/templates/steps/send-to-helix.yml
@@ -1,0 +1,81 @@
+parameters:
+  HelixSource: 'pr/default'          # required -- sources must start with pr/, official/, prodcon/, or agent/
+  HelixType: 'tests/default/'        # required -- Helix telemetry which identifies what type of data this is; should include "test" for clarity and must end in '/'
+  HelixBuild: $(Build.BuildNumber)   # required -- the build number Helix will use to identify this -- automatically set to the AzDO build number
+  HelixTargetQueues: ''              # required -- semicolon delimited list of Helix queues to test on; see https://helix.dot.net/api/2018-03-14/info/queues for a list of queues
+  HelixAccessToken: ''               # required -- access token to make Helix API requests; should be provided by the appropriate variable group
+  HelixPreCommands: ''               # optional -- commands to run before Helix work item execution
+  HelixPostCommands: ''              # optional -- commands to run after Helix work item execution
+  WorkItemDirectory: ''              # optional -- a payload directory to zip up and send to Helix; requires WorkItemCommand; incompatible with XUnitProjects
+  WorkItemCommand: ''                # optional -- a command to execute on the payload; requires WorkItemDirectory; incompatible with XUnitProjects
+  WorkItemTimeout: ''                # optional -- a timeout in seconds for the work item command; requires WorkItemDirectory; incompatible with XUnitProjects
+  CorrelationPayloadDirectory: ''    # optional -- a directory to zip up and send to Helix as a correlation payload
+  XUnitProjects: ''                  # optional -- semicolon delimited list of XUnitProjects to parse and send to Helix; requires XUnitRuntimeTargetFramework, XUnitPublishTargetFramework, XUnitRunnerVersion, and IncludeDotNetCli=true
+  XUnitPublishTargetFramework: ''    # optional -- framework to use to publish your xUnit projects
+  XUnitRuntimeTargetFramework: ''    # optional -- framework to use for the xUnit console runner
+  XUnitRunnerVersion: ''             # optional -- version of the xUnit nuget package you wish to use on Helix; required for XUnitProjects
+  IncludeDotNetCli: false            # optional -- true will download a version of the .NET CLI onto the Helix machine as a correlation payload; requires DotNetCliPackageType and DotNetCliVersion
+  DotNetCliPackageType: ''           # optional -- either 'sdk' or 'runtime'; determines whether the sdk or runtime will be sent to Helix; see https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json
+  DotNetCliVersion: ''               # optional -- version of the CLI to send to Helix; based on this: https://raw.githubusercontent.com/dotnet/core/master/release-notes/releases.json
+  EnableXUnitReporter: false         # optional -- true enables XUnit result reporting to Mission Control
+  WaitForWorkItemCompletion: true    # optional -- true will make the task wait until work items have been completed and fail the build if work items fail. False is "fire and forget."
+  IsExternal: false                  # [DEPRECATED] -- doesn't do anything, jobs are external if HelixAccessToken is empty and Creator is set
+  Creator: ''                        # optional -- if the build is external, use this to specify who is sending the job
+  condition: succeeded()             # optional -- condition for step to execute; defaults to succeeded()
+  continueOnError: false             # optional -- determines whether to continue the build if the step errors; defaults to false
+
+steps:
+  - powershell: 'powershell "$env:BUILD_SOURCESDIRECTORY\eng\common\msbuild.ps1 $env:BUILD_SOURCESDIRECTORY\eng\common\helixpublish.proj /restore /t:Test /bl:$env:BUILD_SOURCESDIRECTORY\artifacts\log\$env:BuildConfig\SendToHelix.binlog"'
+    displayName: Send job to Helix (Windows)
+    env:
+      BuildConfig: $(_BuildConfig)
+      HelixSource: ${{ parameters.HelixSource }}
+      HelixType: ${{ parameters.HelixType }}
+      HelixBuild: ${{ parameters.HelixBuild }}
+      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+      HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      HelixPreCommands: ${{ parameters.HelixPreCommands }}
+      HelixPostCommands: ${{ parameters.HelixPostCommands }}
+      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+      WorkItemCommand: ${{ parameters.WorkItemCommand }}
+      WorkItemTimeout: ${{ parameters.WorkItemTimeout }}
+      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
+      XUnitProjects: ${{ parameters.XUnitProjects }}
+      XUnitPublishTargetFramework: ${{ parameters.XUnitPublishTargetFramework }}
+      XUnitRuntimeTargetFramework: ${{ parameters.XUnitRuntimeTargetFramework }}
+      XUnitRunnerVersion: ${{ parameters.XUnitRunnerVersion }}
+      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+      Creator: ${{ parameters.Creator }}
+    condition: and(${{ parameters.condition }}, eq(variables['Agent.Os'], 'Windows_NT'))
+    continueOnError: ${{ parameters.continueOnError }}
+  - script: $BUILD_SOURCESDIRECTORY/eng/common/msbuild.sh $BUILD_SOURCESDIRECTORY/eng/common/helixpublish.proj /restore /t:Test /bl:$BUILD_SOURCESDIRECTORY/artifacts/log/$BuildConfig/SendToHelix.binlog
+    displayName: Send job to Helix (Unix)
+    env:
+      BuildConfig: $(_BuildConfig)
+      HelixSource: ${{ parameters.HelixSource }}
+      HelixType: ${{ parameters.HelixType }}
+      HelixBuild: ${{ parameters.HelixBuild }}
+      HelixTargetQueues: ${{ parameters.HelixTargetQueues }}
+      HelixAccessToken: ${{ parameters.HelixAccessToken }}
+      HelixPreCommands: ${{ parameters.HelixPreCommands }}
+      HelixPostCommands: ${{ parameters.HelixPostCommands }}
+      WorkItemDirectory: ${{ parameters.WorkItemDirectory }}
+      WorkItemCommand: ${{ parameters.WorkItemCommand }}
+      WorkItemTimeout: ${{ parameters.WorkItemTimeout }}
+      CorrelationPayloadDirectory: ${{ parameters.CorrelationPayloadDirectory }}
+      XUnitProjects: ${{ parameters.XUnitProjects }}
+      XUnitPublishTargetFramework: ${{ parameters.XUnitPublishTargetFramework }}
+      XUnitRuntimeTargetFramework: ${{ parameters.XUnitRuntimeTargetFramework }}
+      XUnitRunnerVersion: ${{ parameters.XUnitRunnerVersion }}
+      IncludeDotNetCli: ${{ parameters.IncludeDotNetCli }}
+      DotNetCliPackageType: ${{ parameters.DotNetCliPackageType }}
+      DotNetCliVersion: ${{ parameters.DotNetCliVersion }}
+      EnableXUnitReporter: ${{ parameters.EnableXUnitReporter }}
+      WaitForWorkItemCompletion: ${{ parameters.WaitForWorkItemCompletion }}
+      Creator: ${{ parameters.Creator }}
+    condition: and(${{ parameters.condition }}, ne(variables['Agent.Os'], 'Windows_NT'))
+    continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/templates/steps/telemetry-end.yml
+++ b/eng/common/templates/steps/telemetry-end.yml
@@ -1,0 +1,102 @@
+parameters:
+  maxRetries: 5
+  retryDelay: 10 # in seconds
+
+steps:
+- bash: |
+    if [ "$AGENT_JOBSTATUS" = "Succeeded" ] || [ "$AGENT_JOBSTATUS" = "PartiallySucceeded" ]; then
+      errorCount=0
+    else
+      errorCount=1
+    fi
+    warningCount=0
+
+    curlStatus=1
+    retryCount=0
+    # retry loop to harden against spotty telemetry connections
+    # we don't retry successes and 4xx client errors
+    until [[ $curlStatus -eq 0 || ( $curlStatus -ge 400 && $curlStatus -le 499 ) || $retryCount -ge $MaxRetries ]]
+    do
+      if [ $retryCount -gt 0 ]; then
+        echo "Failed to send telemetry to Helix; waiting $RetryDelay seconds before retrying..."
+        sleep $RetryDelay
+      fi
+
+      # create a temporary file for curl output
+      res=`mktemp`
+
+      curlResult=`
+        curl --verbose --output $res --write-out "%{http_code}"\
+        -H 'Content-Type: application/json' \
+        -H "X-Helix-Job-Token: $Helix_JobToken" \
+        -H 'Content-Length: 0' \
+        -X POST -G "https://helix.dot.net/api/2018-03-14/telemetry/job/build/$Helix_WorkItemId/finish" \
+        --data-urlencode "errorCount=$errorCount" \
+        --data-urlencode "warningCount=$warningCount"`
+      curlStatus=$?
+
+      if [ $curlStatus -eq 0 ]; then
+        if [ $curlResult -gt 299 ] || [ $curlResult -lt 200 ]; then
+          curlStatus=$curlResult
+        fi
+      fi
+
+      let retryCount++
+    done
+
+    if [ $curlStatus -ne 0 ]; then
+      echo "Failed to Send Build Finish information after $retryCount retries"
+      vstsLogOutput="vso[task.logissue type=error;sourcepath=templates/steps/telemetry-end.yml;code=1;]Failed to Send Build Finish information: $curlStatus"
+      echo "##$vstsLogOutput"
+      exit 1
+    fi
+  displayName: Send Unix Build End Telemetry
+  env:
+    # defined via VSTS variables in start-job.sh
+    Helix_JobToken: $(Helix_JobToken)
+    Helix_WorkItemId: $(Helix_WorkItemId)
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
+  condition: and(always(), ne(variables['Agent.Os'], 'Windows_NT'))
+- powershell: |
+    if (($env:Agent_JobStatus -eq 'Succeeded') -or ($env:Agent_JobStatus -eq 'PartiallySucceeded')) {
+      $ErrorCount = 0
+    } else {
+      $ErrorCount = 1
+    }
+    $WarningCount = 0
+
+    # Basic retry loop to harden against server flakiness
+    $retryCount = 0
+    while ($retryCount -lt $env:MaxRetries) {
+      try {
+        Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job/build/$env:Helix_WorkItemId/finish?errorCount=$ErrorCount&warningCount=$WarningCount" -Method Post -ContentType "application/json" -Body "" `
+          -Headers @{ 'X-Helix-Job-Token'=$env:Helix_JobToken }
+        break
+      }
+      catch {
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        if ($statusCode -ge 400 -and $statusCode -le 499) {
+          Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix (status code $statusCode); not retrying (4xx client error)"
+          Write-Host "##vso[task.logissue]error ", $_.Exception.GetType().FullName, $_.Exception.Message
+          exit 1
+        }
+        Write-Host "Failed to send telemetry to Helix (status code $statusCode); waiting $env:RetryDelay seconds before retrying..."
+        $retryCount++
+        sleep $env:RetryDelay
+        continue
+      }
+    }
+
+    if ($retryCount -ge $env:MaxRetries) {
+      Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix after $retryCount retries."
+      exit 1
+    }
+  displayName: Send Windows Build End Telemetry
+  env:
+    # defined via VSTS variables in start-job.ps1
+    Helix_JobToken: $(Helix_JobToken)
+    Helix_WorkItemId: $(Helix_WorkItemId)
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
+  condition: and(always(),eq(variables['Agent.Os'], 'Windows_NT'))

--- a/eng/common/templates/steps/telemetry-start.yml
+++ b/eng/common/templates/steps/telemetry-start.yml
@@ -1,0 +1,241 @@
+parameters:
+  helixSource: 'undefined_defaulted_in_telemetry.yml'
+  helixType: 'undefined_defaulted_in_telemetry.yml'
+  buildConfig: ''
+  runAsPublic: false
+  maxRetries: 5
+  retryDelay: 10 # in seconds
+
+steps:
+- ${{ if and(eq(parameters.runAsPublic, 'false'), not(eq(variables['System.TeamProject'], 'public'))) }}:
+  - task: AzureKeyVault@1
+    inputs:
+      azureSubscription: 'HelixProd_KeyVault'
+      KeyVaultName: HelixProdKV
+      SecretsFilter: 'HelixApiAccessToken'
+    condition: always()
+- bash: |
+    # create a temporary file
+    jobInfo=`mktemp`
+
+    # write job info content to temporary file
+    cat > $jobInfo <<JobListStuff
+    {
+      "QueueId": "$QueueId",
+      "Source": "$Source",
+      "Type": "$Type",
+      "Build": "$Build",
+      "Attempt": "$Attempt",
+      "Properties": {
+        "operatingSystem": "$OperatingSystem",
+        "configuration": "$Configuration"
+      }
+    }
+    JobListStuff
+
+    cat $jobInfo
+
+    # create a temporary file for curl output
+    res=`mktemp`
+
+    accessTokenParameter="?access_token=$HelixApiAccessToken"
+
+    curlStatus=1
+    retryCount=0
+    # retry loop to harden against spotty telemetry connections
+    # we don't retry successes and 4xx client errors
+    until [[ $curlStatus -eq 0 || ( $curlStatus -ge 400 && $curlStatus -le 499 ) || $retryCount -ge $MaxRetries ]]
+    do
+      if [ $retryCount -gt 0 ]; then
+        echo "Failed to send telemetry to Helix; waiting $RetryDelay seconds before retrying..."
+        sleep $RetryDelay
+      fi
+
+      curlResult=`
+        cat $jobInfo |\
+        curl --trace - --verbose --output $res --write-out "%{http_code}" \
+        -H 'Content-Type: application/json' \
+        -X POST "https://helix.dot.net/api/2018-03-14/telemetry/job$accessTokenParameter" -d @-`
+      curlStatus=$?
+
+      if [ $curlStatus -eq 0 ]; then
+        if [ $curlResult -gt 299 ] || [ $curlResult -lt 200 ]; then
+          curlStatus=$curlResult
+        fi
+      fi
+
+      let retryCount++
+    done
+
+    curlResult=`cat $res`
+
+    # validate status of curl command
+    if [ $curlStatus -ne 0 ]; then
+      echo "Failed To Send Job Start information after $retryCount retries"
+      # We have to append the ## vso prefix or vso will pick up the command when it dumps the inline script into the shell
+      vstsLogOutput="vso[task.logissue type=error;sourcepath=telemetry/start-job.sh;code=1;]Failed to Send Job Start information: $curlStatus"
+      echo "##$vstsLogOutput"
+      exit 1
+    fi
+
+    # Set the Helix_JobToken variable
+    export Helix_JobToken=`echo $curlResult | xargs echo` # Strip Quotes
+    echo "##vso[task.setvariable variable=Helix_JobToken;issecret=true;]$Helix_JobToken"
+  displayName: Send Unix Job Start Telemetry
+  env:
+    HelixApiAccessToken: $(HelixApiAccessToken)
+    Source: ${{ parameters.helixSource }}
+    Type: ${{ parameters.helixType }}
+    Build: $(Build.BuildNumber)
+    QueueId: $(Agent.Os)
+    Attempt: 1
+    OperatingSystem: $(Agent.Os)
+    Configuration: ${{ parameters.buildConfig }}
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
+  condition: and(always(), ne(variables['Agent.Os'], 'Windows_NT'))
+- bash: |
+    curlStatus=1
+    retryCount=0
+    # retry loop to harden against spotty telemetry connections
+    # we don't retry successes and 4xx client errors
+    until [[ $curlStatus -eq 0 || ( $curlStatus -ge 400 && $curlStatus -le 499 ) || $retryCount -ge $MaxRetries ]]
+    do
+      if [ $retryCount -gt 0 ]; then
+        echo "Failed to send telemetry to Helix; waiting $RetryDelay seconds before retrying..."
+        sleep $RetryDelay
+      fi
+
+      res=`mktemp`
+      curlResult=`
+        curl --verbose --output $res --write-out "%{http_code}"\
+        -H 'Content-Type: application/json' \
+        -H "X-Helix-Job-Token: $Helix_JobToken" \
+        -H 'Content-Length: 0' \
+        -X POST -G "https://helix.dot.net/api/2018-03-14/telemetry/job/build" \
+        --data-urlencode "buildUri=$BuildUri"`
+      curlStatus=$?
+
+      if [ $curlStatus -eq 0 ]; then
+        if [ $curlResult -gt 299 ] || [ $curlResult -lt 200 ]; then
+          curlStatus=$curlResult
+        fi
+      fi
+
+      curlResult=`cat $res`
+      let retryCount++
+    done
+
+    # validate status of curl command
+    if [ $curlStatus -ne 0 ]; then
+      echo "Failed to Send Build Start information after $retryCount retries"
+      vstsLogOutput="vso[task.logissue type=error;sourcepath=telemetry/build/start.sh;code=1;]Failed to Send Build Start information: $curlStatus"
+      echo "##$vstsLogOutput"
+      exit 1
+    fi
+
+    export Helix_WorkItemId=`echo $curlResult | xargs echo` # Strip Quotes
+    echo "##vso[task.setvariable variable=Helix_WorkItemId]$Helix_WorkItemId"
+  displayName: Send Unix Build Start Telemetry
+  env:
+    BuildUri: $(System.TaskDefinitionsUri)$(System.TeamProject)/_build/index?buildId=$(Build.BuildId)&_a=summary
+    Helix_JobToken: $(Helix_JobToken)
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
+  condition: and(always(), ne(variables['Agent.Os'], 'Windows_NT'))
+
+- powershell: |
+    $jobInfo = [pscustomobject]@{
+      QueueId=$env:QueueId;
+      Source=$env:Source;
+      Type=$env:Type;
+      Build=$env:Build;
+      Attempt=$env:Attempt;
+      Properties=[pscustomobject]@{ operatingSystem=$env:OperatingSystem; configuration=$env:Configuration };
+    }
+
+    $jobInfoJson = $jobInfo | ConvertTo-Json
+
+    if ($env:HelixApiAccessToken) {
+      $accessTokenParameter="?access_token=$($env:HelixApiAccessToken)"
+    }
+    Write-Host "Job Info: $jobInfoJson"
+
+    # Basic retry loop to harden against server flakiness
+    $retryCount = 0
+    while ($retryCount -lt $env:MaxRetries) {
+      try {
+        $jobToken = Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job$($accessTokenParameter)" -Method Post -ContentType "application/json" -Body $jobInfoJson
+        break
+      }
+      catch {
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        if ($statusCode -ge 400 -and $statusCode -le 499) {
+          Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix (status code $statusCode); not retrying (4xx client error)"
+          Write-Host "##vso[task.logissue]error ", $_.Exception.GetType().FullName, $_.Exception.Message
+          exit 1
+        }
+        Write-Host "Failed to send telemetry to Helix (status code $statusCode); waiting $env:RetryDelay seconds before retrying..."
+        $retryCount++
+        sleep $env:RetryDelay
+        continue
+      }
+    }
+
+    if ($retryCount -ge $env:MaxRetries) {
+      Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix after $retryCount retries."
+      exit 1
+    }
+
+    $env:Helix_JobToken = $jobToken
+    Write-Host "##vso[task.setvariable variable=Helix_JobToken;issecret=true;]$env:Helix_JobToken"
+  env:
+    HelixApiAccessToken: $(HelixApiAccessToken)
+    Source: ${{ parameters.helixSource }}
+    Type: ${{ parameters.helixType }}
+    Build: $(Build.BuildNumber)
+    QueueId: $(Agent.Os)
+    Attempt: 1
+    OperatingSystem: $(Agent.Os)
+    Configuration: ${{ parameters.buildConfig }}
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
+  condition: and(always(), eq(variables['Agent.Os'], 'Windows_NT'))
+  displayName: Send Windows Job Start Telemetry
+- powershell: |
+    # Basic retry loop to harden against server flakiness
+    $retryCount = 0
+    while ($retryCount -lt $env:MaxRetries) {
+      try {
+        $workItemId = Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job/build?buildUri=$([Net.WebUtility]::UrlEncode($env:BuildUri))" -Method Post -ContentType "application/json" -Body "" `
+          -Headers @{ 'X-Helix-Job-Token'=$env:Helix_JobToken }
+        break
+      }
+      catch {
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        if ($statusCode -ge 400 -and $statusCode -le 499) {
+          Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix (status code $statusCode); not retrying (4xx client error)"
+          Write-Host "##vso[task.logissue]error ", $_.Exception.GetType().FullName, $_.Exception.Message
+          exit 1
+        }
+        Write-Host "Failed to send telemetry to Helix (status code $statusCode); waiting $env:RetryDelay seconds before retrying..."
+        $retryCount++
+        sleep $env:RetryDelay
+        continue
+      }
+    }
+
+    if ($retryCount -ge $env:MaxRetries) {
+      Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix after $retryCount retries."
+      exit 1
+    }
+
+    $env:Helix_WorkItemId = $workItemId
+    Write-Host "##vso[task.setvariable variable=Helix_WorkItemId]$env:Helix_WorkItemId"
+  displayName: Send Windows Build Start Telemetry
+  env:
+    BuildUri: $(System.TaskDefinitionsUri)$(System.TeamProject)/_build/index?buildId=$(Build.BuildId)&_a=summary
+    Helix_JobToken: $(Helix_JobToken)
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
+  condition: and(always(), eq(variables['Agent.Os'], 'Windows_NT'))

--- a/eng/kill_tasks.cmd
+++ b/eng/kill_tasks.cmd
@@ -1,0 +1,10 @@
+@if not defined _echo @echo off
+setlocal EnableDelayedExpansion
+
+:: Check if VBCSCompiler.exe is running
+tasklist /fi "imagename eq VBCSCompiler.exe" |find ":" > nul
+:: Compiler is running if errorlevel == 1
+if errorlevel 1 (
+	echo Stop VBCSCompiler.exe execution.
+	for /f "tokens=2 delims=," %%F in ('tasklist /nh /fi "imagename eq VBCSCompiler.exe" /fo csv') do taskkill /f /PID %%~F
+)

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -1,0 +1,16 @@
+parameters:
+  jobTemplate: ''
+  buildConfig: ''
+  jobParameters: {}
+
+jobs:
+
+  # Windows x64
+
+- template: ${{ parameters.jobTemplate }}
+  parameters:
+    buildConfig: ${{ parameters.buildConfig }}
+    archType: x64
+    osGroup: Windows_NT
+    osIdentifier: Windows_NT
+    ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/xplat-job.yml
+++ b/eng/xplat-job.yml
@@ -1,0 +1,76 @@
+parameters:
+  buildConfig: ''
+  archType: ''
+  osGroup: ''
+  osIdentifier: ''
+  name: ''
+  displayName: ''
+  condition: ''
+  dependsOn: ''
+  timeoutInMinutes: ''
+
+  # arcade-specific parameters
+  gatherAssetManifests: false
+
+  variables: {} ## any extra variables to add to the defaults defined below
+
+jobs:
+- template: /eng/common/templates/job/job.yml
+  parameters:
+
+    name: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+
+    condition: ${{ parameters.condition }}
+    dependsOn: ${{ parameters.dependsOn }}
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+
+    # Send telemetry for official builds
+    enableTelemetry: ${{ and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}
+    helixRepo: 'dotnet/coreclr'
+
+    enableMicrobuild: false
+
+    pool:
+      ${{ if and(eq(parameters.osGroup, 'Linux'), eq(variables['System.TeamProject'], 'public')) }}:
+        name: dnceng-linux-external-temp
+      ${{ if and(eq(parameters.osGroup, 'OSX'), eq(variables['System.TeamProject'], 'public')) }}:
+        name: Hosted MacOS
+      ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(variables['System.TeamProject'], 'public')) }}:
+        name: dotnet-external-temp
+
+    workspace:
+      clean: all
+
+    ${{ if ne(parameters.containerName, '') }}:
+      container: ${{ parameters.containerName }}
+
+    ${{ if eq(parameters.osGroup, 'Linux') }}:
+      agentOs: Ubuntu
+    ${{ if eq(parameters.osGroup, 'OSX') }}:
+      agentOs: MacOS
+    ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
+      agentOs: Windows_NT
+
+    # Setting this results in the arcade job template including a step
+    # that gathers asset manifests and publishes them to pipeline
+    # storage. Only relevant for build jobs.
+    enablePublishBuildAssets: ${{ parameters.gatherAssetManifests }}
+
+    variables:
+    - name: buildConfig
+      value: ${{ parameters.buildConfig }}
+        
+    - name: archType
+      value: ${{ parameters.archType }}
+
+    - name: osGroup
+      value: ${{ parameters.osGroup }}
+
+    - name: osIdentifier
+      value: ${{ parameters.osIdentifier }}
+      
+    - ${{ each variable in parameters.variables }}:
+      - ${{insert}}: ${{ variable }}
+
+    steps: ${{ parameters.steps }}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,13 @@
+{
+  "tools": {
+    "dotnet": "2.1.401"
+  },
+  "native-tools": {
+    "cmake": "3.11.1",
+    "python": "2.7.15"
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19115.1",
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19115.1"
+  }
+}


### PR DESCRIPTION
All scripts have been copied from the CoreCLR repo and adjusted for CoreRT.

The first goal is enable Windows_NT Debug build without running any tests.