### PR TITLE
Updating the Roslyn toolset to 3.0.0-beta4 and setting LangVersion=preview

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -104,7 +104,7 @@
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <LangVersion>latest</LangVersion>
-    <LangVersion Condition="'$(SkipImportRoslynProps)' != 'true' or '$(IsProjectNLibrary)' == 'true'">8.0</LangVersion>
+    <LangVersion Condition="'$(SkipImportRoslynProps)' != 'true' or '$(IsProjectNLibrary)' == 'true'">preview</LangVersion>
     <UseSharedCompilation>true</UseSharedCompilation>
     <DebugType Condition="'$(IsProjectNLibrary)' != 'true'">portable</DebugType>
   </PropertyGroup>
@@ -271,7 +271,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RoslynVersion>3.0.0-beta3-final</RoslynVersion>
+    <RoslynVersion>3.0.0-beta4-final</RoslynVersion>
     <RoslynPackageName>Microsoft.Net.Compilers</RoslynPackageName>
     <RoslynPackageName Condition="'$(RunningOnCore)' == 'true'">Microsoft.NETCore.Compilers</RoslynPackageName>
     <RoslynPackageDir>$(PackagesDir)/$(RoslynPackageName.ToLower())/$(RoslynVersion)/</RoslynPackageDir>

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -83,7 +83,7 @@ if not [%INIT_TOOLS_ERRORLEVEL%]==[0] (
 
 :: Restore a custom RoslynToolset since we can't trivially update the BuildTools dependency in CoreRT
 echo Configurating RoslynToolset...
-set ROSLYNCOMPILERS_VERSION=3.0.0-beta3-final
+set ROSLYNCOMPILERS_VERSION=3.0.0-beta4-final
 set DEFAULT_RESTORE_ARGS=--no-cache --packages "%PACKAGES_DIR%"
 set INIT_TOOLS_RESTORE_ARGS=%DEFAULT_RESTORE_ARGS% --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json %INIT_TOOLS_RESTORE_ARGS%
 set MSBUILD_PROJECT_CONTENT= ^

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -142,7 +142,7 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
 
         # Restore a custom RoslynToolset since we can't trivially update the BuildTools dependency in CoreRT
         echo "Configuring RoslynToolset..."
-        __ROSLYNCOMPILER_VERSION=3.0.0-beta3-final
+        __ROSLYNCOMPILER_VERSION=3.0.0-beta4-final
         __DEFAULT_RESTORE_ARGS="--no-cache --packages \"${__PACKAGES_DIR}\""
         __INIT_TOOLS_RESTORE_ARGS="${__DEFAULT_RESTORE_ARGS} --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
         __PORTABLETARGETS_PROJECT_CONTENT="


### PR DESCRIPTION
CC. @jaredpar, @agocke, @jkotas, @danmosemsft, @eerhardt, @safern

The beta4 package was published today. This is still required for CoreRT until it can update the associated BuildTools version (https://github.com/dotnet/corert/issues/7032).