### PR TITLE
Treat enums as primitives in auto layout

### DIFF
--- a/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -447,7 +446,7 @@ namespace Internal.TypeSystem
                 }
                 else
                 {                    
-                    Debug.Assert(fieldType.IsPrimitive || fieldType.IsPointer || fieldType.IsFunctionPointer);
+                    Debug.Assert(fieldType.IsPrimitive || fieldType.IsPointer || fieldType.IsFunctionPointer || fieldType.IsEnum);
 
                     var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType, packingSize);
                     instanceNonGCPointerFieldsCount[CalculateLog2(fieldSizeAndAlignment.Size.AsInt)]++;
@@ -686,7 +685,7 @@ namespace Internal.TypeSystem
 
         private static bool IsByValueClass(TypeDesc type)
         {
-            return type.IsValueType && !type.IsPrimitive;
+            return type.IsValueType && !type.IsPrimitive && !type.IsEnum;
         }
 
         private static LayoutInt ComputeBytesUsedInParentType(DefType type)


### PR DESCRIPTION
CoreCLR removes the value type designation for enums when doing type layout. They are treated as a primitive of the enum's underlying type (the default being `System.Int32`). Since value types are placed last in auto layout, this moves enum fields up earlier in the layout.

Match this behavior for CoreRT's auto layout algorithm so that generated code refers to the same offets that will be used at runtime in CPAOT.