### PR TITLE
Remove TypeConverter entries in WebApi sample

### DIFF
--- a/samples/WebApi/rd.xml
+++ b/samples/WebApi/rd.xml
@@ -3,10 +3,5 @@
         <Assembly Name="System.Linq.Expressions">
             <Type Name="System.Linq.Expressions.ExpressionCreator`1[[System.Func`2[[System.Object,System.Private.CoreLib],[System.Object,System.Private.CoreLib]],System.Private.CoreLib]]" Dynamic="Required All" />
         </Assembly>
-        <Assembly Name="System.ComponentModel.TypeConverter">
-            <Type Name="System.ComponentModel.TypeConverter" Dynamic="Required All" />
-            <Type Name="System.ComponentModel.StringConverter" Dynamic="Required All" />
-            <Type Name="System.ComponentModel.Int32Converter" Dynamic="Required All" />
-        </Assembly>
     </Application>
 </Directives>


### PR DESCRIPTION
These didn't appear to be needed last time I was playing with this.

We are basically down to one entry. This entry is especially annoying because it shows up every time someone wants to use LINQ expressions. Couple options:

* Add a really dumb peephole IL scanner to `UsageBasedMetadataManager` a la mono/linker#223
* Decide that we want an actual RD.XML parser. The embedded RD.XML manifest in System.Linq.Expressions has a line that covers this scenario. BUT: RD.XML has the unfortunate property of: not requiring types to be assembly-qualified, and requiring a whole program analysis for a bunch of constructs. Plus my motivation to write yet another type name parser is pretty low.