### PR TITLE
Add scripts to set up CI with Azure Pipelines for OSX

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -27,13 +27,19 @@ jobs:
     steps:
 
     # Install native dependencies
-    # TODO: add installation logic for non Windows platorms
+    # Linux builds use docker images with dependencies preinstalled,
+    # so we only need this step for OSX and Windows.
+    # (TODO: figure out the name of Linux docker images that can be used by CoreRT)
+    - ${{ if eq(parameters.osGroup, 'OSX') }}:
+      - script: sh eng/install-native-dependencies.sh $(osGroup)
+        displayName: Install native dependencies
+
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       # Necessary to install python
       - script: eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
         displayName: Install native dependencies
 
-      # Build
+      # Build and tests on Windows
       - script: build.cmd $(buildConfig) skiptests
         displayName: Build product
       - script: tests\runtest.cmd $(buildConfig)
@@ -44,6 +50,16 @@ jobs:
         - script: tests\runtest.cmd $(buildConfig) /coreclr ReadyToRun /mode ReadyToRun
           displayName: Run basic ReadyToRun tests
         - script: tests\runtest.cmd $(buildConfig) /coreclr Top200
+          displayName: Run CoreCLR Top200 tests
+
+    # Build and tests on non-Windows platforms
+    - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
+      - script: ./build.sh $(buildConfig) skiptests
+        displayName: Build product
+      - script: tests/runtest.sh $(buildConfig)
+        displayName: Run simple CoreRT tests
+      - ${{ if eq(parameters.buildConfig, 'Debug') }}:
+        - script: tests/runtest.sh $(buildConfig) -coredumps /coreclr Top200
           displayName: Run CoreCLR Top200 tests
 
     - task: PublishTestResults@2

--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+if [ "$1" = "Linux" ]; then
+    sudo apt update
+    if [ "$?" != "0" ]; then
+       exit 1;
+    fi
+    sudo apt install cmake llvm-3.9 clang-3.9 lldb-3.9 liblldb-3.9-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libcurl4-openssl-dev libssl-dev libkrb5-dev libnuma-dev
+    if [ "$?" != "0"]; then
+        exit 1;
+    fi
+elif [ "$1" = "OSX" ]; then
+    brew update
+    if [ "$?" != "0" ]; then
+        exit 1;
+    fi
+    brew install icu4c openssl
+    if [ "$?" != "0" ]; then
+        exit 1;
+    fi
+    brew link --force icu4c
+    if [ "$?" != "0" ]; then
+        exit 1;
+    fi
+else
+    echo "Must pass \"Linux\" or \"OSX\" as first argument."
+    exit 1
+fi
+

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -14,3 +14,13 @@ jobs:
     osGroup: Windows_NT
     osIdentifier: Windows_NT
     ${{ insert }}: ${{ parameters.jobParameters }}
+
+# MacOS x64
+
+- template: ${{ parameters.jobTemplate }}
+  parameters:
+    buildConfig: ${{ parameters.buildConfig }}
+    archType: x64
+    osGroup: OSX
+    osIdentifier: OSX
+    ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
This adds support for OSX. To enable CI for Linux I still need to figure out the name of docker containers (or a machine pool) to use. 
The eng/install-native-dependencies.sh file has been copied from the CoreCLR repo.