### PR TITLE
Add scripts to set up CI with Azure Pipelines for Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ pr:
 resources:
   containers:
   - container: ubuntu_1604_x64_build_image
-    image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-10fcdcf-20190208200917
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-10fcdcf-20190208200917
 
 jobs:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,11 @@ trigger:
 pr:
 - master
 
+resources:
+  containers:
+  - container: ubuntu_1604_x64_build_image
+    image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-10fcdcf-20190208200917
+
 jobs:
 
 ##   The following is the matrix of test runs that we have. This is

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -33,7 +33,6 @@ jobs:
     # Install native dependencies
     # Linux builds use docker images with dependencies preinstalled,
     # so we only need this step for OSX and Windows.
-    # (TODO: figure out the name of Linux docker images that can be used by CoreRT)
     - ${{ if eq(parameters.osGroup, 'OSX') }}:
       - script: sh eng/install-native-dependencies.sh $(osGroup)
         displayName: Install native dependencies

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -3,6 +3,7 @@ parameters:
   archType: ''
   osGroup: ''
   osIdentifier: ''
+  containerName: ''
   timeoutInMinutes: ''
 
 ### Product build
@@ -17,6 +18,9 @@ jobs:
     # Compute job name from template parameters
     name: ${{ format('build_{0}_{1}_{2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
     displayName: ${{ format('Build {0} {1} {2}', parameters.osIdentifier, parameters.archType, parameters.buildConfig) }}
+
+    # Note that the containers are resources defined in azure-pipelines.yml
+    containerName: ${{ parameters.containerName }}
 
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
@@ -63,6 +67,7 @@ jobs:
           displayName: Run CoreCLR Top200 tests
 
     - task: PublishTestResults@2
+      condition: succeededOrFailed()
       inputs:
         testResultsFormat: 'xUnit'
         testResultsFiles: '**/testResults.xml'

--- a/eng/platform-matrix.yml
+++ b/eng/platform-matrix.yml
@@ -24,3 +24,14 @@ jobs:
     osGroup: OSX
     osIdentifier: OSX
     ${{ insert }}: ${{ parameters.jobParameters }}
+
+# Linux x64
+
+- template: ${{ parameters.jobTemplate }}
+  parameters:
+    buildConfig: ${{ parameters.buildConfig }}
+    archType: x64
+    osGroup: Linux
+    osIdentifier: Linux
+    containerName: ubuntu_1604_x64_build_image
+    ${{ insert }}: ${{ parameters.jobParameters }}


### PR DESCRIPTION
This adds support for building and testing Pull Requests in Ubuntu docker containers. Note that docker images have all required dependencies preinstalled.