### PR TITLE
Binplace ILCompiler build task into separate directory

### DIFF
--- a/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/pkg/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -33,8 +33,8 @@
     </File>
 
     <!-- This assembly is needed so the build tasks can be resolved and run from the metapackage -->
-    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\tools\\ILCompiler.Build.Tasks.dll">
-      <TargetPath>tools</TargetPath>
+    <File Include="$(BaseOutputPath)\$(OSPlatformConfig)\tools\\netstandard\\*">
+      <TargetPath>tools\netstandard</TargetPath>
     </File>
   </ItemGroup>
 

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <IlcBuildTasksPath Condition="'$(IlcBuildTasksPath)' == ''">$(MSBuildThisFileDirectory)..\tools\ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>
+    <IlcBuildTasksPath Condition="'$(IlcBuildTasksPath)' == ''">$(MSBuildThisFileDirectory)..\tools\netstandard\ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>
     
     <!--
       Prevent dotnet CLI from deploying the CoreCLR shim executable since we produce

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -130,7 +130,7 @@ See the LICENSE file in the project root for more information.
     <PropertyGroup>
       <!-- Define paths used in build targets to point to the runtime-specific ILCompiler implementation -->
       <IlcPath Condition="'$(IlcPath)' == ''">$(RuntimePackagePath)</IlcPath>
-      <IlcBuildTasksPath>$(RuntimePackagePath)\tools\ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>
+      <IlcBuildTasksPath>$(RuntimePackagePath)\tools\netstandard\ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>
       <!-- Set defaults for unspecified properties -->
     </PropertyGroup>
     

--- a/src/ILCompiler.Build.Tasks/src/ILCompiler.Build.Tasks.csproj
+++ b/src/ILCompiler.Build.Tasks/src/ILCompiler.Build.Tasks.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>ILCompiler</RootNamespace>
     <AssemblyName>ILCompiler.Build.Tasks</AssemblyName>
     <TargetFramework>netstandard1.3</TargetFramework>
-    <OutputPath>$(BaseOutputPath)$(OSPlatformConfig)/tools</OutputPath>
+    <OutputPath>$(BaseOutputPath)$(OSPlatformConfig)/tools/netstandard</OutputPath>
     <!-- Workaround for https://github.com/dotnet/corert/issues/6306 -->
     <SkipSigning>true</SkipSigning>
   </PropertyGroup>
@@ -13,15 +13,23 @@
     <Compile Include="ComputeManagedAssemblies.cs" />
   </ItemGroup>
   <ItemGroup>
-  <PackageReference Include="Microsoft.Build.Framework">
-    <Version>15.3.409</Version>
-  </PackageReference>
-  <PackageReference Include="Microsoft.Build.Utilities.Core">
-    <Version>15.3.409</Version>
-  </PackageReference>
-  <PackageReference Include="System.Reflection.Metadata">
-    <Version>$(SystemReflectionMetadataVersion)</Version>
-  </PackageReference>
+    <PackageReference Include="Microsoft.Build.Framework">
+      <Version>15.3.409</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Utilities.Core">
+      <Version>15.3.409</Version>
+    </PackageReference>
+    <PackageReference Include="System.Reflection.Metadata">
+      <Version>$(SystemReflectionMetadataVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\packages\system.reflection.metadata\1.4.3\lib\netstandard1.1\System.Reflection.Metadata.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\..\packages\system.collections.immutable\1.3.2\lib\netstandard1.0\System.Collections.Immutable.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" Condition="'$(IsProjectNLibrary)' != 'true'" />
 </Project>


### PR DESCRIPTION
This allows the build task to carry own copy of its dependencies that are not AOT compiled and work on both .NET Framework and .NET Core

Contributes to #6773