### PR TITLE
Replace Delegate.CreateDelegate

### DIFF
--- a/src/System.Private.CoreLib/shared/System/AppDomain.cs
+++ b/src/System.Private.CoreLib/shared/System/AppDomain.cs
@@ -4,6 +4,7 @@
 
 #pragma warning disable CS0067 // events are declared but not used
 
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
@@ -398,10 +399,12 @@ namespace System
                         if (s_getUnauthenticatedPrincipal == null)
                         {
                             Type type = Type.GetType("System.Security.Principal.GenericPrincipal, System.Security.Claims", throwOnError: true);
+                            MethodInfo mi = type.GetMethod("GetDefaultInstance", BindingFlags.NonPublic | BindingFlags.Static);
+                            Debug.Assert(mi != null);
                             // Don't throw PNSE if null like for WindowsPrincipal as UnauthenticatedPrincipal should
                             // be available on all platforms.
                             Volatile.Write(ref s_getUnauthenticatedPrincipal,
-                                (Func<IPrincipal>)Delegate.CreateDelegate(typeof(Func<IPrincipal>), type, "GetDefaultInstance"));
+                                (Func<IPrincipal>)mi.CreateDelegate(typeof(Func<IPrincipal>)));
                         }
 
                         principal = s_getUnauthenticatedPrincipal();
@@ -411,9 +414,13 @@ namespace System
                         if (s_getWindowsPrincipal == null)
                         {
                             Type type = Type.GetType("System.Security.Principal.WindowsPrincipal, System.Security.Principal.Windows", throwOnError: true);
+                            MethodInfo mi = type.GetMethod("GetDefaultInstance", BindingFlags.NonPublic | BindingFlags.Static);
+                            if (mi == null)
+                            {
+                                throw new PlatformNotSupportedException(SR.PlatformNotSupported_Principal);
+                            }
                             Volatile.Write(ref s_getWindowsPrincipal,
-                                (Func<IPrincipal>)Delegate.CreateDelegate(typeof(Func<IPrincipal>), type, "GetDefaultInstance", ignoreCase: false, throwOnBindFailure: false)
-                                ?? throw new PlatformNotSupportedException(SR.PlatformNotSupported_Principal));
+                                (Func<IPrincipal>)mi.CreateDelegate(typeof(Func<IPrincipal>)));
                         }
 
                         principal = s_getWindowsPrincipal();

--- a/src/System.Private.CoreLib/shared/System/ComponentModel/DefaultValueAttribute.cs
+++ b/src/System.Private.CoreLib/shared/System/ComponentModel/DefaultValueAttribute.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Reflection;
 using System.Threading;
 
 namespace System.ComponentModel
@@ -64,7 +65,8 @@ namespace System.ComponentModel
                     if (s_convertFromInvariantString == null)
                     {
                         Type typeDescriptorType = Type.GetType("System.ComponentModel.TypeDescriptor, System.ComponentModel.TypeConverter", throwOnError: false);
-                        Volatile.Write(ref s_convertFromInvariantString, typeDescriptorType == null ? new object() : Delegate.CreateDelegate(typeof(Func<Type, string, object>), typeDescriptorType, "ConvertFromInvariantString", ignoreCase: false));
+                        MethodInfo mi = typeDescriptorType?.GetMethod("ConvertFromInvariantString", BindingFlags.NonPublic | BindingFlags.Static);
+                        Volatile.Write(ref s_convertFromInvariantString, mi == null ? new object() : mi.CreateDelegate(typeof(Func<Type, string, object>)));
                     }
 
                     if (!(s_convertFromInvariantString is Func<Type, string, object> convertFromInvariantString))

--- a/src/System.Private.CoreLib/shared/System/ComponentModel/DefaultValueAttribute.cs
+++ b/src/System.Private.CoreLib/shared/System/ComponentModel/DefaultValueAttribute.cs
@@ -72,7 +72,14 @@ namespace System.ComponentModel
                     if (!(s_convertFromInvariantString is Func<Type, string, object> convertFromInvariantString))
                         return false;
 
-                    conversionResult = convertFromInvariantString(typeToConvert, stringValue);
+                    try
+                    {
+                        conversionResult = convertFromInvariantString(typeToConvert, stringValue);
+                    }
+                    catch
+                    {
+                        return false;
+                    }
 
                     return true;
                 }

--- a/tests/TopN.CoreFX.Windows.issues.json
+++ b/tests/TopN.CoreFX.Windows.issues.json
@@ -1001,10 +1001,6 @@
             "classes": null,
             "methods": [
                 {
-                    "name": "System.ComponentModel.Tests.DefaultValueAttributeTests.Ctor",
-                    "reason": "Reflection pattern cannot be detected"
-                },
-                {
                     "name": "System.Tests.TimeSpanTests.Total_Days_Hours_Minutes_Seconds_Milliseconds",
                     "reason": "outdated"
                 },


### PR DESCRIPTION
Replacing this with a pattern that is easier to statically analyze. We use the GetType/GetMethod/CreateDelegate pattern in several places already.