### PR TITLE
Temporary disable running the KnownGood set of CoreCLR tests

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -56,9 +56,10 @@ jobs:
 
     - name: coreCLRTestSet
       value: 'Top200'
-    - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-      - name: coreCLRTestSet
-        value: 'KnownGood'
+    # Temporary disable running the KnownGood set because it times out in CI
+    # - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    #   - name: coreCLRTestSet
+    #     value: 'KnownGood'
 
     steps:
 


### PR DESCRIPTION
These tests currently take too long to finish and, as a result,
test jobs just time out. In addition, we do not have (and never had)
an extended known good set of CoreCLR tests for Linux and OSX.