### PR TITLE
[WIP] Temporary increase time out for the KnownGood set of CoreCLR tests

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -30,7 +30,7 @@ jobs:
     # Note that the containers are resources defined in azure-pipelines.yml
     containerName: ${{ parameters.containerName }}
 
-    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    timeoutInMinutes: 360
 
     variables:
     - name: osIdentifier
@@ -55,7 +55,7 @@ jobs:
         value: '-'
 
     - name: coreCLRTestSet
-      value: 'Top200'
+      value: 'KnownGood'
     # Temporary disable running the KnownGood set because it times out in CI
     # - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     #   - name: coreCLRTestSet
@@ -97,7 +97,7 @@ jobs:
     - ${{ if contains(parameters.testScenarios, 'CoreCLR') }}:
       - script: $(testScriptName) $(buildConfig) $(testParameterPrefix)coreclr $(coreCLRTestSet)
         displayName: Run CoreCLR $(coreCLRTestSet) tests
-        enabled: ${{ eq(parameters.buildConfig, 'Debug') }}
+        enabled: ${{ and(eq(parameters.buildConfig, 'Debug'), ne(parameters.osGroup, 'OSX')) }}
 
     - ${{ if contains(parameters.testScenarios, 'CoreFX') }}:
       - script: $(testScriptName) $(buildConfig) $(testParameterPrefix)corefx

--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -95,7 +95,7 @@ jobs:
         enabled: ${{ and(eq(parameters.buildConfig, 'Debug'), eq(parameters.osGroup, 'Windows_NT')) }}
 
     - ${{ if contains(parameters.testScenarios, 'CoreCLR') }}:
-      - script: $(testScriptName) $(buildConfig) $(testParameterPrefix)coreclr $(coreCLRTestSet)
+      - script: $(testScriptName) $(buildConfig) $(testParameterPrefix)coreclr $(coreCLRTestSet) $(testParameterPrefix)multimodule
         displayName: Run CoreCLR $(coreCLRTestSet) tests
         enabled: ${{ and(eq(parameters.buildConfig, 'Debug'), ne(parameters.osGroup, 'OSX')) }}
 

--- a/tests/CoreCLR/runtest/runtest.sh
+++ b/tests/CoreCLR/runtest/runtest.sh
@@ -711,7 +711,9 @@ if [ `uname` = "NetBSD" ]; then
 else
     NumProc=$(getconf _NPROCESSORS_ONLN)
 fi
-((maxProcesses = $NumProc * 3 / 2)) # long tests delay process creation, use a few more processors
+echo "Processor Count: $NumProc"
+((maxProcesses = $NumProc * 3 / 2 + 1)) # long tests delay process creation, use a few more processors
+echo  "Max Process Count: $maxProcesses"
 
 ((nextProcessIndex = 0))
 ((processCount = 0))

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -221,8 +221,8 @@ run_coreclr_tests()
         CoreRT_TestSelectionArg=
     fi
 
-    echo ./runtest.sh --testRootDir=${CoreRT_TestExtRepo} --coreOverlayDir=${CoreRT_TestRoot}/CoreCLR ${CoreRT_TestSelectionArg} --logdir=$__LogDir --disableEventLogging
-    ./runtest.sh --testRootDir=${CoreRT_TestExtRepo} --coreOverlayDir=${CoreRT_TestRoot}/CoreCLR ${CoreRT_TestSelectionArg} --logdir=$__LogDir --disableEventLogging
+    echo ./runtest.sh --testRootDir=${CoreRT_TestExtRepo} --coreOverlayDir=${CoreRT_TestRoot}/CoreCLR ${CoreRT_TestSelectionArg} --logdir=$__LogDir --disableEventLogging --show-time
+    ./runtest.sh --testRootDir=${CoreRT_TestExtRepo} --coreOverlayDir=${CoreRT_TestRoot}/CoreCLR ${CoreRT_TestSelectionArg} --logdir=$__LogDir --disableEventLogging --show-time
 }
 
 run_corefx_tests()

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -221,8 +221,8 @@ run_coreclr_tests()
         CoreRT_TestSelectionArg=
     fi
 
-    echo ./runtest.sh --testRootDir=${CoreRT_TestExtRepo} --coreOverlayDir=${CoreRT_TestRoot}/CoreCLR ${CoreRT_TestSelectionArg} --logdir=$__LogDir --disableEventLogging --show-time
-    ./runtest.sh --testRootDir=${CoreRT_TestExtRepo} --coreOverlayDir=${CoreRT_TestRoot}/CoreCLR ${CoreRT_TestSelectionArg} --logdir=$__LogDir --disableEventLogging --show-time
+    echo ./runtest.sh --testRootDir=${CoreRT_TestExtRepo} --coreOverlayDir=${CoreRT_TestRoot}/CoreCLR ${CoreRT_TestSelectionArg} --logdir=$__LogDir --disableEventLogging
+    ./runtest.sh --testRootDir=${CoreRT_TestExtRepo} --coreOverlayDir=${CoreRT_TestRoot}/CoreCLR ${CoreRT_TestSelectionArg} --logdir=$__LogDir --disableEventLogging
 }
 
 run_corefx_tests()


### PR DESCRIPTION
Check how long it takes to run the KnowGood set of tests on Windows and
Linux. In addition, find a list of all failing tests.