### PR TITLE
Harden reflection scanner against invalid IL

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILReader.cs
+++ b/src/Common/src/TypeSystem/IL/ILReader.cs
@@ -48,11 +48,17 @@ namespace Internal.IL
 
         public byte ReadILByte()
         {
+            if (_currentOffset + 1 > _ilBytes.Length)
+                ThrowHelper.ThrowInvalidProgramException();
+
             return _ilBytes[_currentOffset++];
         }
 
         public UInt16 ReadILUInt16()
         {
+            if (_currentOffset + 2 > _ilBytes.Length)
+                ThrowHelper.ThrowInvalidProgramException();
+
             UInt16 val = (UInt16)(_ilBytes[_currentOffset] + (_ilBytes[_currentOffset + 1] << 8));
             _currentOffset += 2;
             return val;
@@ -60,6 +66,9 @@ namespace Internal.IL
 
         public UInt32 ReadILUInt32()
         {
+            if (_currentOffset + 4 > _ilBytes.Length)
+                ThrowHelper.ThrowInvalidProgramException();
+
             UInt32 val = (UInt32)(_ilBytes[_currentOffset] + (_ilBytes[_currentOffset + 1] << 8) + (_ilBytes[_currentOffset + 2] << 16) + (_ilBytes[_currentOffset + 3] << 24));
             _currentOffset += 4;
             return val;
@@ -105,6 +114,8 @@ namespace Internal.IL
             ILOpcode opcode = (ILOpcode)_ilBytes[_currentOffset];
             if (opcode == ILOpcode.prefix1)
             {
+                if (_currentOffset + 2 > _ilBytes.Length)
+                    ThrowHelper.ThrowInvalidProgramException();
                 opcode = (ILOpcode)(0x100 + _ilBytes[_currentOffset + 1]);
             }
 
@@ -113,6 +124,9 @@ namespace Internal.IL
 
         public void Skip(ILOpcode opcode)
         {
+            if (!opcode.IsValid())
+                ThrowHelper.ThrowInvalidProgramException();
+
             if (opcode != ILOpcode.switch_)
             {
                 int opcodeSize = (byte)opcode != (int)opcode ? 2 : 1;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionMethodBodyScanner.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionMethodBodyScanner.cs
@@ -53,8 +53,11 @@ namespace ILCompiler.DependencyAnalysis
 
                     case ILOpcode.call:
                     case ILOpcode.callvirt:
-                        MethodDesc method = (MethodDesc)methodIL.GetObject(reader.ReadILToken());
-                        HandleCall(ref list, factory, methodIL, method, ref tracker);
+                        var method = methodIL.GetObject(reader.ReadILToken()) as MethodDesc;
+                        if (method != null)
+                        {
+                            HandleCall(ref list, factory, methodIL, method, ref tracker);
+                        }
                         break;
 
                     default:


### PR DESCRIPTION
Should help with the KnownGood test failures seen in #7157.

The `IsValid` check in `Skip` should be all that's needed to fix the observed failures, but I went ahead and hardened it against other invalid situations (end of body in the middle of an instruction, or bad calls).