### PR TITLE
SuperIlc show compile failures

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
@@ -67,7 +67,7 @@ namespace ReadyToRun.SuperIlc
             outputDirectory.Create();
 
             bool success = true;
-            List<string> _failedCompilationAssemblies = new List<string>();
+            List<string> failedCompilationAssemblies = new List<string>();
             int successfulCompileCount = 0;
 
             // Copy unmanaged files (runtime, native dependencies, resources, etc)
@@ -83,7 +83,7 @@ namespace ReadyToRun.SuperIlc
                     else
                     {
                         success = false;
-                        _failedCompilationAssemblies.Add(file);
+                        failedCompilationAssemblies.Add(file);
 
                         // On compile failure, pass through the input IL assembly so the output is still usable
                         File.Copy(file, Path.Combine(outputDirectory.FullName, Path.GetFileName(file)));
@@ -96,12 +96,12 @@ namespace ReadyToRun.SuperIlc
                 }
             }
 
-            Console.WriteLine($"Compiled {successfulCompileCount} assemblies.");
+            Console.WriteLine($"Compiled {successfulCompileCount}/{successfulCompileCount + failedCompilationAssemblies.Count} assemblies.");
 
-            if (_failedCompilationAssemblies.Count > 0)
+            if (failedCompilationAssemblies.Count > 0)
             {
-                Console.WriteLine($"Could not compile the following assemblies:");
-                foreach (var assembly in _failedCompilationAssemblies)
+                Console.WriteLine($"Failed to compile {failedCompilationAssemblies.Count} assemblies:");
+                foreach (var assembly in failedCompilationAssemblies)
                 {
                     Console.WriteLine(assembly);
                 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -82,9 +82,9 @@ public abstract class CompilerRunner
         }
     }
 
-    // <input>\a.dll -> <output>\a.ni.dll
+    // <input>\a.dll -> <output>\a.dll
     protected string GetOutputFileName(string assemblyFileName) =>
-        Path.Combine(_outputPath, $"{Path.GetFileNameWithoutExtension(assemblyFileName)}.ni{Path.GetExtension(assemblyFileName)}"); 
+        Path.Combine(_outputPath, $"{Path.GetFileName(assemblyFileName)}"); 
     protected string GetResponseFileName(string assemblyFileName) =>
         Path.Combine(_outputPath, $"{Path.GetFileNameWithoutExtension(assemblyFileName)}.{Path.GetFileNameWithoutExtension(CompilerFileName)}.rsp");
 }


### PR DESCRIPTION
Couple small quality of life improvements:
* After compiling all assemblies, write a list of compilation failures to the console
* Emit ready-to-run images without the `.ni` part of the extension. This was initially useful so we knew which images were R2R but the CoreCLR loader expects the app host in a .NET Core app to be a .dll and Crossgen doesn't use `.ni` anymore.