### PR TITLE
Fix protocol between UsageBased and AnalysisBased metadata managers

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/AnalysisBasedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/AnalysisBasedMetadataManager.cs
@@ -53,14 +53,6 @@ namespace ILCompiler
                 Debug.Assert((refMethod.Category & MetadataCategory.RuntimeMapping) == 0
                     || (_reflectableTypes[refMethod.Entity.OwningType] & MetadataCategory.RuntimeMapping) != 0);
                 _reflectableMethods.Add(refMethod.Entity, refMethod.Category);
-
-                MethodDesc canonMethod = refMethod.Entity.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                if (refMethod.Entity != canonMethod)
-                {
-                    if (!_reflectableMethods.TryGetValue(canonMethod, out MetadataCategory category))
-                        category = 0;
-                    _reflectableMethods[canonMethod] = category | refMethod.Category;
-                }
             }
 
             foreach (var refField in reflectableFields)
@@ -92,6 +84,9 @@ namespace ILCompiler
                 // GetMetadataCategory relies on that.
                 Debug.Assert((GetMetadataCategory(refMethod.Entity.GetTypicalMethodDefinition()) & MetadataCategory.Description)
                     == (GetMetadataCategory(refMethod.Entity) & MetadataCategory.Description));
+
+                // Canonical form of the method needs to agree with the logical form
+                Debug.Assert(GetMetadataCategory(refMethod.Entity) == GetMetadataCategory(refMethod.Entity.GetCanonMethodTarget(CanonicalFormKind.Specific)));
             }
 
             foreach (var refField in reflectableFields)

--- a/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
@@ -375,8 +375,7 @@ namespace ILCompiler
 
             foreach (var method in GetCompiledMethods())
             {
-                if (!method.IsCanonicalMethod(CanonicalFormKind.Specific) &&
-                    !IsReflectionBlocked(method))
+                if (!IsReflectionBlocked(method))
                 {
                     if ((reflectableTypes[method.OwningType] & MetadataCategory.RuntimeMapping) != 0)
                         reflectableMethods[method] |= MetadataCategory.RuntimeMapping;


### PR DESCRIPTION
In #7042 I made it possible to express reflectability of something purely based on canonical code presence (so if e.g. `Foo<__Canon>..ctor` is compiled, `Foo<__Canon>..ctor` should be considered reflectable). Previously we only considered reflectability of concrete instantiations.

This was not reflected in the protocol between usage based and analysis based metadata managers: usage based manager was forgetting to tell the analysis based metadata manager about canonical bodies. As a result, places that relied on marking canonical bodies to make things reflectable (such as RD.XML and `--rootallapplicationassemblies`) were not getting that behavior when IL scanner was involved (optimized builds).

Fixes #7169.