### PR TITLE
Don't root reflection-blocked types and methods

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionMethodBodyScanner.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionMethodBodyScanner.cs
@@ -89,7 +89,8 @@ namespace ILCompiler.DependencyAnalysis
                         string name = tracker.GetLastString();
                         if (name != null
                             && methodIL.OwningMethod.OwningType is MetadataType mdType
-                            && ResolveType(name, mdType.Module, out TypeDesc type, out ModuleDesc referenceModule))
+                            && ResolveType(name, mdType.Module, out TypeDesc type, out ModuleDesc referenceModule)
+                            && !factory.MetadataManager.IsReflectionBlocked(type))
                         {
                             const string reason = "Type.GetType";
                             list = list ?? new DependencyList();
@@ -111,7 +112,8 @@ namespace ILCompiler.DependencyAnalysis
                         string name = tracker.GetLastString();
                         TypeDesc type = tracker.GetLastType();
                         if (name != null
-                            && type != null)
+                            && type != null
+                            && !factory.MetadataManager.IsReflectionBlocked(type))
                         {
                             if (type.IsGenericDefinition)
                             {
@@ -124,7 +126,8 @@ namespace ILCompiler.DependencyAnalysis
                             }
 
                             MethodDesc reflectedMethod = type.GetMethod(name, null);
-                            if (reflectedMethod != null)
+                            if (reflectedMethod != null
+                                && !factory.MetadataManager.IsReflectionBlocked(reflectedMethod))
                             {
                                 if (reflectedMethod.HasInstantiation)
                                 {


### PR DESCRIPTION
Noticed this while working on the previous fix.

Reflection scanner correctly detects reflection light up here:

https://github.com/dotnet/corert/blob/132884042966b874c830c6012e7293d70148b933/src/System.Private.CoreLib/shared/System/Resources/ResourceReader.cs#L796-L799

But since `CreateUntypedDelegate` is reflection blocked, the generated method body is useless. This then shows up as a diff between scanning phase and compilation phase (usage based metadata analyzer won't pass this additional root to the compilation phase, because the method is not a reflection root - it's compiled, but not reflection visible).