### PR TITLE
Factor numeric constant parsing out of ParseConstantValue

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -326,49 +326,61 @@ namespace System.Reflection.Runtime.General
             return value;
         }
 
+        public static Object ParseConstantNumericValue(this Handle handle, MetadataReader reader)
+        {
+            HandleType handleType = handle.HandleType;
+            switch (handleType)
+            {
+                case HandleType.ConstantBooleanValue:
+                    return handle.ToConstantBooleanValueHandle(reader).GetConstantBooleanValue(reader).Value;
+                case HandleType.ConstantCharValue:
+                    return handle.ToConstantCharValueHandle(reader).GetConstantCharValue(reader).Value;
+                case HandleType.ConstantByteValue:
+                    return handle.ToConstantByteValueHandle(reader).GetConstantByteValue(reader).Value;
+                case HandleType.ConstantSByteValue:
+                    return handle.ToConstantSByteValueHandle(reader).GetConstantSByteValue(reader).Value;
+                case HandleType.ConstantInt16Value:
+                    return handle.ToConstantInt16ValueHandle(reader).GetConstantInt16Value(reader).Value;
+                case HandleType.ConstantUInt16Value:
+                    return handle.ToConstantUInt16ValueHandle(reader).GetConstantUInt16Value(reader).Value;
+                case HandleType.ConstantInt32Value:
+                    return handle.ToConstantInt32ValueHandle(reader).GetConstantInt32Value(reader).Value;
+                case HandleType.ConstantUInt32Value:
+                    return handle.ToConstantUInt32ValueHandle(reader).GetConstantUInt32Value(reader).Value;
+                case HandleType.ConstantInt64Value:
+                    return handle.ToConstantInt64ValueHandle(reader).GetConstantInt64Value(reader).Value;
+                case HandleType.ConstantUInt64Value:
+                    return handle.ToConstantUInt64ValueHandle(reader).GetConstantUInt64Value(reader).Value;
+                case HandleType.ConstantSingleValue:
+                    return handle.ToConstantSingleValueHandle(reader).GetConstantSingleValue(reader).Value;
+                case HandleType.ConstantDoubleValue:
+                    return handle.ToConstantDoubleValueHandle(reader).GetConstantDoubleValue(reader).Value;
+                default:
+                    throw new BadImageFormatException();
+            }
+        }
+
         public static Exception TryParseConstantValue(this Handle handle, MetadataReader reader, out Object value)
         {
             HandleType handleType = handle.HandleType;
             switch (handleType)
             {
                 case HandleType.ConstantBooleanValue:
-                    value = handle.ToConstantBooleanValueHandle(reader).GetConstantBooleanValue(reader).Value;
+                case HandleType.ConstantCharValue:
+                case HandleType.ConstantByteValue:
+                case HandleType.ConstantSByteValue:
+                case HandleType.ConstantInt16Value:
+                case HandleType.ConstantUInt16Value:
+                case HandleType.ConstantInt32Value:
+                case HandleType.ConstantUInt32Value:
+                case HandleType.ConstantInt64Value:
+                case HandleType.ConstantUInt64Value:
+                case HandleType.ConstantSingleValue:
+                case HandleType.ConstantDoubleValue:
+                    value = handle.ParseConstantNumericValue(reader);
                     return null;
                 case HandleType.ConstantStringValue:
                     value = handle.ToConstantStringValueHandle(reader).GetConstantStringValue(reader).Value;
-                    return null;
-                case HandleType.ConstantCharValue:
-                    value = handle.ToConstantCharValueHandle(reader).GetConstantCharValue(reader).Value;
-                    return null;
-                case HandleType.ConstantByteValue:
-                    value = handle.ToConstantByteValueHandle(reader).GetConstantByteValue(reader).Value;
-                    return null;
-                case HandleType.ConstantSByteValue:
-                    value = handle.ToConstantSByteValueHandle(reader).GetConstantSByteValue(reader).Value;
-                    return null;
-                case HandleType.ConstantInt16Value:
-                    value = handle.ToConstantInt16ValueHandle(reader).GetConstantInt16Value(reader).Value;
-                    return null;
-                case HandleType.ConstantUInt16Value:
-                    value = handle.ToConstantUInt16ValueHandle(reader).GetConstantUInt16Value(reader).Value;
-                    return null;
-                case HandleType.ConstantInt32Value:
-                    value = handle.ToConstantInt32ValueHandle(reader).GetConstantInt32Value(reader).Value;
-                    return null;
-                case HandleType.ConstantUInt32Value:
-                    value = handle.ToConstantUInt32ValueHandle(reader).GetConstantUInt32Value(reader).Value;
-                    return null;
-                case HandleType.ConstantInt64Value:
-                    value = handle.ToConstantInt64ValueHandle(reader).GetConstantInt64Value(reader).Value;
-                    return null;
-                case HandleType.ConstantUInt64Value:
-                    value = handle.ToConstantUInt64ValueHandle(reader).GetConstantUInt64Value(reader).Value;
-                    return null;
-                case HandleType.ConstantSingleValue:
-                    value = handle.ToConstantSingleValueHandle(reader).GetConstantSingleValue(reader).Value;
-                    return null;
-                case HandleType.ConstantDoubleValue:
-                    value = handle.ToConstantDoubleValueHandle(reader).GetConstantDoubleValue(reader).Value;
                     return null;
                 case HandleType.TypeDefinition:
                 case HandleType.TypeReference:


### PR DESCRIPTION
Salvages the usable part of #5455.

After looking at the Enum code in CoreCLR, Enum APIs already only work on runtime types, so that pull request can be made simpler (no need for a `LowLevelEnumInfo`). I'll look into that one weekend.