### PR TITLE
Add infrastructure to remove framework features

### DIFF
--- a/src/ILCompiler/desktop/desktop.csproj
+++ b/src/ILCompiler/desktop/desktop.csproj
@@ -70,6 +70,9 @@
     <Compile Include="..\src\EcmaOnlyDebugInformationProvider.cs">
       <Link>EcmaOnlyDebugInformationProvider.cs</Link>
     </Compile>
+    <Compile Include="..\src\RemovingILProvider.cs">
+      <Link>RemovingILProvider.cs</Link>
+    </Compile>
     <Compile Include="..\src\ApplicationAssemblyRootProvider.cs">
       <Link>ApplicationAssemblyRootProvider.cs</Link>
     </Compile>

--- a/src/ILCompiler/src/ILCompiler.csproj
+++ b/src/ILCompiler/src/ILCompiler.csproj
@@ -43,6 +43,7 @@
     <Compile Include="..\..\Common\src\CommandLine\CommandLineHelpers.cs">
       <Link>CommandLine\CommandLineHelpers.cs</Link>
     </Compile>
+    <Compile Include="RemovingILProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="ilc.runtimeconfig.json">

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -479,9 +479,10 @@ namespace ILCompiler
                     removedFeatures |= RemovedFeature.FrameworkResources;
             }
 
-            ILProvider ilProvider = null;
+            ILProvider ilProvider = _isReadyToRunCodeGen ? (ILProvider)new ReadyToRunILProvider() : new CoreRTILProvider();
+
             if (removedFeatures != 0)
-                ilProvider = new RemovingILProvider(new CoreRTILProvider(), removedFeatures);
+                ilProvider = new RemovingILProvider(ilProvider, removedFeatures);
 
             var stackTracePolicy = _emitStackTraceData ?
                 (StackTraceEmissionPolicy)new EcmaMethodStackTraceEmissionPolicy() : new NoStackTraceEmissionPolicy();
@@ -518,7 +519,7 @@ namespace ILCompiler
                     _metadataLogFileName,
                     stackTracePolicy,
                     invokeThunkGenerationPolicy,
-                    ilProvider ?? new CoreRTILProvider(),
+                    ilProvider,
                     metadataGenerationOptions);
             }
             else
@@ -536,8 +537,7 @@ namespace ILCompiler
 
             useScanner &= !_noScanner;
 
-            if (ilProvider != null)
-                builder.UseILProvider(ilProvider);
+            builder.UseILProvider(ilProvider);
 
             ILScanResults scanResults = null;
             if (useScanner)

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.CommandLine;
 using System.Runtime.InteropServices;
+
+using Internal.IL;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
@@ -69,6 +71,8 @@ namespace ILCompiler
         private IReadOnlyList<string> _appContextSwitches = Array.Empty<string>();
 
         private IReadOnlyList<string> _runtimeOptions = Array.Empty<string>();
+
+        private IReadOnlyList<string> _removedFeatures = Array.Empty<string>();
 
         private bool _help;
 
@@ -176,6 +180,7 @@ namespace ILCompiler
                 syntax.DefineOptionList("initassembly", ref _initAssemblies, "Assembly(ies) with a library initializer");
                 syntax.DefineOptionList("appcontextswitch", ref _appContextSwitches, "System.AppContext switches to set");
                 syntax.DefineOptionList("runtimeopt", ref _runtimeOptions, "Runtime options to set");
+                syntax.DefineOptionList("removefeature", ref _removedFeatures, "Framework features to remove");
 
                 syntax.DefineOption("targetarch", ref _targetArchitectureStr, "Target architecture for cross compilation");
                 syntax.DefineOption("targetos", ref _targetOSStr, "Target OS for cross compilation");
@@ -465,6 +470,19 @@ namespace ILCompiler
             if (!_isCppCodegen && !_isWasmCodegen)
                 builder.UsePInvokePolicy(new ConfigurablePInvokePolicy(typeSystemContext.Target));
 
+            RemovedFeature removedFeatures = 0;
+            foreach (string feature in _removedFeatures)
+            {
+                if (feature == "EventSource")
+                    removedFeatures |= RemovedFeature.Etw;
+                else if (feature == "FrameworkStrings")
+                    removedFeatures |= RemovedFeature.FrameworkResources;
+            }
+
+            ILProvider ilProvider = null;
+            if (removedFeatures != 0)
+                ilProvider = new RemovingILProvider(new CoreRTILProvider(), removedFeatures);
+
             var stackTracePolicy = _emitStackTraceData ?
                 (StackTraceEmissionPolicy)new EcmaMethodStackTraceEmissionPolicy() : new NoStackTraceEmissionPolicy();
 
@@ -472,7 +490,8 @@ namespace ILCompiler
                     ? (MetadataBlockingPolicy)new NoMetadataBlockingPolicy() 
                     : new BlockedInternalsBlockingPolicy(typeSystemContext);
 
-            ManifestResourceBlockingPolicy resBlockingPolicy = new NoManifestResourceBlockingPolicy();
+            ManifestResourceBlockingPolicy resBlockingPolicy = (removedFeatures & RemovedFeature.FrameworkResources) != 0 ?
+                new FrameworkStringResourceBlockingPolicy() : (ManifestResourceBlockingPolicy)new NoManifestResourceBlockingPolicy();
 
             UsageBasedMetadataGenerationOptions metadataGenerationOptions = UsageBasedMetadataGenerationOptions.AnonymousTypeHeuristic;
             if (_completeTypesMetadata)
@@ -499,7 +518,7 @@ namespace ILCompiler
                     _metadataLogFileName,
                     stackTracePolicy,
                     invokeThunkGenerationPolicy,
-                    new Internal.IL.CoreRTILProvider(),
+                    ilProvider ?? new CoreRTILProvider(),
                     metadataGenerationOptions);
             }
             else
@@ -516,6 +535,9 @@ namespace ILCompiler
                 (_optimizationMode != OptimizationMode.None && !_isCppCodegen && !_isWasmCodegen && !_isReadyToRunCodeGen && !_multiFile);
 
             useScanner &= !_noScanner;
+
+            if (ilProvider != null)
+                builder.UseILProvider(ilProvider);
 
             ILScanResults scanResults = null;
             if (useScanner)

--- a/src/ILCompiler/src/RemovingILProvider.cs
+++ b/src/ILCompiler/src/RemovingILProvider.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.IL;
+using Internal.IL.Stubs;
+using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    public class RemovingILProvider : ILProvider
+    {
+        private readonly ILProvider _baseILProvider;
+        private readonly RemovedFeature _removedFeature;
+
+        public RemovingILProvider(ILProvider baseILProvider, RemovedFeature feature)
+        {
+            _baseILProvider = baseILProvider;
+            _removedFeature = feature;
+        }
+
+        public override MethodIL GetMethodIL(MethodDesc method)
+        {
+            switch (GetAction(method))
+            {
+                case RemoveAction.Nothing:
+                    return _baseILProvider.GetMethodIL(method);
+
+                case RemoveAction.ConvertToStub:
+                    if (method.Signature.ReturnType.IsVoid)
+                        return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
+                    else if (method.Signature.ReturnType.Category == TypeFlags.Boolean)
+                        return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.ldc_i4_0, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
+                    else
+                        goto default;
+
+                case RemoveAction.ConvertToTrueStub:
+                    return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.ldc_i4_1, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
+
+                case RemoveAction.ConvertToGetResourceStringStub:
+                    return new ILStubMethodIL(method, new byte[] {
+                        (byte)ILOpcode.ldarg_0,
+                        (byte)ILOpcode.ret },
+                        Array.Empty<LocalVariableDefinition>(), null);
+
+                case RemoveAction.ConvertToThrow:
+                    return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.ldnull, (byte)ILOpcode.throw_ }, Array.Empty<LocalVariableDefinition>(), null);
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        private RemoveAction GetAction(MethodDesc method)
+        {
+            TypeDesc owningType = method.OwningType;
+
+            if (!method.Signature.IsStatic)
+            {
+                if ((_removedFeature & RemovedFeature.Etw) != 0 && IsEventSourceType(owningType))
+                {
+                    if (method.IsConstructor)
+                        return RemoveAction.ConvertToStub;
+
+                    if (method.Name == "IsEnabled" || method.IsFinalizer || method.Name == "Dispose")
+                        return RemoveAction.ConvertToStub;
+
+                    return RemoveAction.ConvertToThrow;
+                }
+                else if ((_removedFeature & RemovedFeature.Etw) != 0 && IsEventSourceImplementation(owningType))
+                {
+                    if (method.IsFinalizer)
+                        return RemoveAction.ConvertToStub;
+
+                    if (method.IsConstructor)
+                        return RemoveAction.ConvertToStub;
+
+                    if (method.HasCustomAttribute("System.Diagnostics.Tracing", "NonEventAttribute"))
+                        return RemoveAction.Nothing;
+
+                    return RemoveAction.ConvertToThrow;
+                }
+            }
+            else
+            {
+                if ((_removedFeature & RemovedFeature.FrameworkResources) != 0 && owningType is MetadataType mdType &&
+                    mdType.Name == "SR" && mdType.Namespace == "System")
+                {
+                    if (method.Name == "UsingResourceKeys")
+                        return RemoveAction.ConvertToTrueStub;
+                    else if (method.Name == "GetResourceString" && method.Signature.Length == 2)
+                        return RemoveAction.ConvertToGetResourceStringStub;
+
+                    return RemoveAction.Nothing;
+                }
+            }
+
+            return RemoveAction.Nothing;
+        }
+
+        private object _eventSourceType;
+        private bool IsEventSourceType(TypeDesc type)
+        {
+            if (_eventSourceType == null)
+                _eventSourceType = type.Context.SystemModule.GetType("System.Diagnostics.Tracing", "EventSource") ?? new object();
+
+            return Object.ReferenceEquals(type, _eventSourceType);
+        }
+        
+        private bool IsEventSourceImplementation(TypeDesc type)
+        {
+            try
+            {
+                TypeDesc baseType = type.BaseType;
+                while (baseType != null)
+                {
+                    if (IsEventSourceImplementation(baseType))
+                        return true;
+                    baseType = baseType.BaseType;
+                }
+            }
+            catch (TypeSystemException)
+            {
+            }
+
+            return false;
+        }
+
+        private enum RemoveAction
+        {
+            Nothing,
+            ConvertToStub,
+            ConvertToThrow,
+
+            ConvertToTrueStub,
+            ConvertToGetResourceStringStub,
+        }
+    }
+
+    [Flags]
+    public enum RemovedFeature
+    {
+        Etw = 0x1,
+        FrameworkResources = 0x2,
+    }
+}


### PR DESCRIPTION
This makes it possible to remove framework features that add a big pile of junk code and data to the output: ETW instrumentation, and ResourceManager.

Long term, we will probably want IL Linker to do this, but given the level of funding for CoreRT, interest in making IL Linker play well with other things that hook into the build flow, etc., it's easier to just put this functionality into the CoreRT compiler for now. This is sufficiently "on the side" within the compiler that I'm not too worried about it. It's the same as the temporary RD.XML parser.

I don't expect this to grow beyond one more thing: removal of globalization code.

With this, Hello world goes from 4,187,136 bytes, to 3,798,016 bytes (ETW removed) to 3,364,352 bytes (ETW & resource manager removed).