### PR TITLE
Fix the last remaining compilation error in ASP.NET assemblies

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -275,8 +275,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // ReportPointersFromValueType
             if (type.IsByRefLike)
             {
-                // TODO: FindByRefPointersInByRefLikeObject
-                throw new NotImplementedException();
+                FindByRefPointerOffsetsInByRefLikeObject(type, argDest, delta, frame);
             }
 
             Debug.Assert(type is DefType);
@@ -286,6 +285,26 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 if (!field.IsStatic)
                 {
                     GcScanRoots(field.FieldType, argDest, field.Offset.AsInt, frame);
+                }
+            }
+        }
+
+        private void FindByRefPointerOffsetsInByRefLikeObject(TypeDesc type, ArgDestination argDest, int delta, CORCOMPILE_GCREFMAP_TOKENS[] frame)
+        {
+            if (type.IsByRefLike)
+            {
+                argDest.GcMark(frame, delta, interior: true);
+                return;
+            }
+
+            foreach (FieldDesc field in type.GetFields())
+            {
+                if (!field.IsLiteral && 
+                    !field.IsStatic && 
+                    field.FieldType.IsValueType && 
+                    field.FieldType.IsByRefLike)
+                {
+                    FindByRefPointerOffsetsInByRefLikeObject(field.FieldType, argDest, delta + field.Offset.AsInt, frame);
                 }
             }
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -291,7 +291,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private void FindByRefPointerOffsetsInByRefLikeObject(TypeDesc type, ArgDestination argDest, int delta, CORCOMPILE_GCREFMAP_TOKENS[] frame)
         {
-            if (type.IsByRefLike)
+            if (type.IsByReferenceOfT || type.IsByRef)
             {
                 argDest.GcMark(frame, delta, interior: true);
                 return;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -299,11 +299,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             foreach (FieldDesc field in type.GetFields())
             {
-                if (!field.IsLiteral && 
-                    !field.IsStatic && 
-                    field.FieldType.IsValueType && 
-                    field.FieldType.IsByRefLike)
+                if (!field.IsStatic && field.FieldType.IsByRefLike)
                 {
+                    Debug.Assert(field.FieldType.IsValueType);
                     FindByRefPointerOffsetsInByRefLikeObject(field.FieldType, argDest, delta + field.Offset.AsInt, frame);
                 }
             }


### PR DESCRIPTION
This change fixes the build of ASP.NET S.P.Corelib which needs
GC ref map construction for ByRefLike types - I skipped this
corner case in my initial implementation with a TODO throw.

Thanks

Tomas