### PR TITLE
SuperIlc improvements, part #1

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
@@ -63,7 +63,7 @@ namespace ReadyToRun.SuperIlc
                     || ex is IOException
                 )
                 {
-                    Console.WriteLine($"Error: Could not delete output folder {outputDirectory.FullName}. {ex.Message}");
+                    Console.WriteLine($"Error: Could not delete output folder {runnerOutputPath}. {ex.Message}");
                     return 1;
                 }
             }
@@ -130,7 +130,6 @@ namespace ReadyToRun.SuperIlc
                     return true;
 
                 parentInfo = parentInfo.Parent;
-
             }
 
             return false;

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
@@ -31,8 +31,7 @@ namespace ReadyToRun.SuperIlc
 
             if (outputDirectory == null)
             {
-                Console.WriteLine("--output-directory is a required argument.");
-                return 1;
+                outputDirectory = inputDirectory;
             }
 
             if (OutputPathIsParentOfInputPath(inputDirectory, outputDirectory))
@@ -79,7 +78,7 @@ namespace ReadyToRun.SuperIlc
                 if (ComputeManagedAssemblies.IsManaged(file))
                 {
                     ProcessInfo compilationToRun = runner.CompilationProcess(file);
-                    compilationToRun.Data = file;
+                    compilationToRun.InputFileName = file;
                     compilationsToRun.Add(compilationToRun);
                 }
                 else
@@ -103,9 +102,8 @@ namespace ReadyToRun.SuperIlc
                 }
                 else
                 {
-                    string file = (string)processInfo.Data;
-                    File.Copy(file, Path.Combine(runnerOutputPath, Path.GetFileName(file)));
-                    failedCompilationAssemblies.Add(file);
+                    File.Copy(processInfo.InputFileName, Path.Combine(runnerOutputPath, Path.GetFileName(processInfo.InputFileName)));
+                    failedCompilationAssemblies.Add(processInfo.InputFileName);
                 }
             }
 
@@ -125,9 +123,6 @@ namespace ReadyToRun.SuperIlc
 
         static bool OutputPathIsParentOfInputPath(DirectoryInfo inputPath, DirectoryInfo outputPath)
         {
-            if (inputPath == outputPath)
-                return true;
-
             DirectoryInfo parentInfo = inputPath.Parent;
             while (parentInfo != null)
             {

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -38,7 +38,7 @@ public abstract class CompilerRunner
         processInfo.ProcessPath = Path.Combine(_compilerPath, CompilerFileName);
         processInfo.Arguments = $"@{responseFile}";
         processInfo.UseShellExecute = false;
-        processInfo.LogPath = Path.Combine(_outputPath, Path.GetFileNameWithoutExtension(assemblyFileName) + ".log");
+        processInfo.LogPath = Path.ChangeExtension(outputFileName, ".log");
 
         return processInfo;
     }

--- a/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Execute a given number of mutually independent build subprocesses represented by an array of
+/// command lines with a given degree of parallelization.
+/// </summary>
+public sealed class ParallelRunner
+{
+    /// <summary>
+    /// Helper class for launching mutually independent build subprocesses in parallel.
+    /// It supports launching the processes and optionally redirecting their standard and
+    /// error output streams to prevent them from interleaving in the final build output log.
+    /// Multiple instances of this class representing the individual running processes
+    /// can exist at the same time.
+    /// </summmary>
+    class ProcessSlot
+    {
+        /// <summary>
+        /// Process slot index (used for diagnostic purposes)
+        /// </summary>
+        readonly int _slotIndex;
+
+        /// <summary>
+        /// Event used to report that a process has exited
+        /// </summary>
+        readonly AutoResetEvent _processExitEvent;
+
+        /// <summary>
+        /// Process object
+        /// </summary>
+        ProcessRunner _processRunner;
+
+        /// <summary>
+        /// Constructor stores global slot parameters and initializes the slot state machine
+        /// </summary>
+        /// <param name="slotIndex">Process slot index used for diagnostic purposes</param>
+        /// <param name="processExitEvent">Event used to report process exit</param>
+        public ProcessSlot(int slotIndex, AutoResetEvent processExitEvent)
+        {
+            _slotIndex = slotIndex;
+            _processExitEvent = processExitEvent;
+        }
+
+        /// <summary>
+        /// Launch a new process.
+        /// </summary>
+        /// <param name="processInfo">application to execute</param>
+        /// <param name="processIndex">Numeric index used to prefix messages pertaining to this process in the console output</param>
+        public void Launch(ProcessInfo processInfo, int processIndex)
+        {
+            Debug.Assert(_processRunner == null);
+            Console.WriteLine($"{processIndex}: launching: {processInfo.ProcessPath} {processInfo.Arguments}");
+
+            _processRunner = new ProcessRunner(processInfo, processIndex, _processExitEvent);
+        }
+
+        public bool IsAvailable()
+        {
+            if (_processRunner == null)
+            {
+                return true;
+            }
+            if (!_processRunner.IsAvailable())
+            {
+                return false;
+            }
+            _processRunner.Dispose();
+            _processRunner = null;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Execute a given set of mutually independent build commands with the default
+    /// degree of parallelism.
+    /// </summary>
+    /// <param name="processesToRun">Processes to execute in parallel</param>
+    public static void Run(IEnumerable<ProcessInfo> processesToRun)
+    {
+        Run(processesToRun, degreeOfParallelism: Environment.ProcessorCount);
+    }
+
+    /// <summary>
+    /// Execute a given set of mutually independent build commands with given degree of
+    /// parallelism.
+    /// </summary>
+    /// <param name="processesToRun">Processes to execute in parallel</param>
+    /// <param name="degreeOfParallelism">Maximum number of processes to execute in parallel</param>
+    public static void Run(IEnumerable<ProcessInfo> processesToRun, int degreeOfParallelism)
+    {
+        int processCount = processesToRun.Count();
+        if (processCount < degreeOfParallelism)
+        {
+            // We never need a higher DOP than the number of process to execute
+            degreeOfParallelism = processCount;
+        }
+
+        using (AutoResetEvent processExitEvent = new AutoResetEvent(initialState: false))
+        {
+            ProcessSlot[] processSlots = new ProcessSlot[degreeOfParallelism];
+            for (int index = 0; index < degreeOfParallelism; index++)
+            {
+                processSlots[index] = new ProcessSlot(index, processExitEvent);
+            }
+
+            int processIndex = 0;
+            foreach (ProcessInfo processInfo in processesToRun)
+            {
+                // Allocate a process slot, potentially waiting on the exit event
+                // when all slots are busy (running)
+                ProcessSlot freeSlot = null;
+                do
+                {
+                    foreach (ProcessSlot slot in processSlots)
+                    {
+                        if (slot.IsAvailable())
+                        {
+                            freeSlot = slot;
+                            break;
+                        }
+                    }
+                    if (freeSlot == null)
+                    {
+                        // All slots are busy - wait for a process to finish
+                        processExitEvent.WaitOne();
+                    }
+                }
+                while (freeSlot == null);
+
+                freeSlot.Launch(processInfo, ++processIndex);
+            }
+
+            // We have launched all the commands, now wait for all processes to finish
+            bool activeProcessesExist;
+            do
+            {
+                activeProcessesExist = false;
+                foreach (ProcessSlot slot in processSlots)
+                {
+                    if (!slot.IsAvailable())
+                    {
+                        activeProcessesExist = true;
+                    }
+                }
+                if (activeProcessesExist)
+                {
+                    processExitEvent.WaitOne();
+                }
+            }
+            while (activeProcessesExist);
+        }
+    }
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -1,0 +1,220 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class ProcessInfo
+{
+    /// <summary>
+    /// 10 minutes should be plenty for a CPAOT / Crossgen compilation.
+    /// </summary>
+    public const int DefaultTimeout = 600 * 1000;
+
+    public string ProcessPath;
+    public string Arguments;
+    public bool UseShellExecute;
+    public string LogPath;
+    public int TimeoutMilliseconds = DefaultTimeout;
+    public int ExpectedExitCode;
+    public object Data;
+
+    public bool Finished;
+    public bool Succeeded;
+    public bool TimedOut;
+    public int DurationMilliseconds;
+    public int ExitCode;
+}
+
+public class ProcessRunner : IDisposable
+{
+    public const int StateIdle = 0;
+    public const int StateRunning = 1;
+    public const int StateFinishing = 2;
+
+    public const int TimeoutExitCode = -103;
+
+    private readonly ProcessInfo _processInfo;
+
+    private readonly AutoResetEvent _processExitEvent;
+
+    private readonly int _processIndex;
+
+    private Process _process;
+
+    private readonly Stopwatch _stopwatch;
+
+    /// <summary>
+    /// This is actually a boolean flag but we're using int to let us use CPU-native interlocked exchange.
+    /// </summary>
+    private int _state;
+
+    private TextWriter _logWriter;
+
+    private CancellationTokenSource _cancellationTokenSource;
+
+    public ProcessRunner(ProcessInfo processInfo, int processIndex, AutoResetEvent processExitEvent)
+    {
+        _processInfo = processInfo;
+        _processIndex = processIndex;
+        _processExitEvent = processExitEvent;
+
+        CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+        _cancellationTokenSource = cancellationTokenSource;
+
+        _stopwatch = new Stopwatch();
+        _stopwatch.Start();
+        _state = StateIdle;
+
+        _logWriter = new StreamWriter(_processInfo.LogPath);
+
+        ProcessStartInfo psi = new ProcessStartInfo()
+        {
+            FileName = _processInfo.ProcessPath,
+            Arguments = _processInfo.Arguments,
+            UseShellExecute = _processInfo.UseShellExecute,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        _process = new Process();
+        _process.StartInfo = psi;
+        _process.EnableRaisingEvents = true;
+        _process.Exited += new EventHandler(ExitEventHandler);
+
+        Interlocked.Exchange(ref _state, StateRunning);
+
+        _process.Start();
+
+        _process.OutputDataReceived += new DataReceivedEventHandler(StandardOutputEventHandler);
+        _process.BeginOutputReadLine();
+
+        _process.ErrorDataReceived += new DataReceivedEventHandler(StandardErrorEventHandler);
+        _process.BeginErrorReadLine();
+
+        Task.Run(() =>
+        {
+            try
+            {
+                Task.Delay(_processInfo.TimeoutMilliseconds, cancellationTokenSource.Token).Wait();
+                StopProcessAtomic();
+            }
+            catch (TaskCanceledException)
+            {
+                // Ignore cancellation
+            }
+        });
+    }
+
+    public void Dispose()
+    {
+        CleanupProcess();
+    }
+
+    private void CleanupProcess()
+    {
+        if (_cancellationTokenSource != null)
+        {
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource = null;
+        }
+
+        if (_process != null)
+        {
+            _process.Dispose();
+            _process = null;
+        }
+
+        if (_logWriter != null)
+        {
+            _logWriter.Dispose();
+            _logWriter = null;
+        }
+    }
+
+    private void ExitEventHandler(object sender, EventArgs eventArgs)
+    {
+        StopProcessAtomic();
+    }
+
+    private void StopProcessAtomic()
+    {
+        if (Interlocked.CompareExchange(ref _state, StateFinishing, StateRunning) != StateRunning)
+        {
+            return;
+        }
+
+        _cancellationTokenSource.Cancel();
+
+        bool success;
+        if (_process.WaitForExit(0))
+        {
+            _processInfo.ExitCode = _process.ExitCode;
+            success = (_processInfo.ExitCode == _processInfo.ExpectedExitCode);
+            if (success)
+            {
+                Console.WriteLine(
+                    $"{_processIndex}: succeeded in {_processInfo.DurationMilliseconds} msecs; " +
+                    $"exit code {_processInfo.ExitCode}: {_processInfo.ProcessPath} {_processInfo.Arguments}");
+                _processInfo.Succeeded = true;
+            }
+            else
+            {
+                Console.Error.WriteLine(
+                    $"{_processIndex}: failed in {_processInfo.DurationMilliseconds} msecs; " +
+                    $"exit code {_processInfo.ExitCode}, expected{_processInfo.ExpectedExitCode}: " +
+                    $"{_processInfo.ProcessPath} {_processInfo.Arguments}");
+            }
+        }
+        else
+        {
+            _process.Kill();
+            _processInfo.ExitCode = TimeoutExitCode;
+            _processInfo.TimedOut = true;
+            success = false;
+            Console.Error.WriteLine(
+                $"{_processIndex}: timed out in {_processInfo.DurationMilliseconds} msecs: " +
+                $"{_processInfo.ProcessPath} {_processInfo.Arguments}");
+        }
+
+        _processInfo.Finished = true;
+        _processInfo.DurationMilliseconds = (int)_stopwatch.ElapsedMilliseconds;
+
+        _logWriter.Close();
+
+        CleanupProcess();
+
+        Interlocked.Exchange(ref _state, StateIdle);
+        _processExitEvent?.Set();
+    }
+
+    private void StandardOutputEventHandler(object sender, DataReceivedEventArgs eventArgs)
+    {
+        if (!string.IsNullOrEmpty(eventArgs.Data))
+        {
+            _logWriter.WriteLine(eventArgs.Data);
+            Console.Out.WriteLine(_processIndex.ToString() + ": " + eventArgs.Data);
+        }
+    }
+
+    private void StandardErrorEventHandler(object sender, DataReceivedEventArgs eventArgs)
+    {
+        if (!string.IsNullOrEmpty(eventArgs.Data))
+        {
+            _logWriter.WriteLine(eventArgs.Data);
+            Console.Error.WriteLine(_processIndex.ToString() + ": " + eventArgs.Data);
+        }
+    }
+
+    public bool IsAvailable()
+    {
+        return _state == StateIdle;
+    }
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -165,6 +165,8 @@ public class ProcessRunner : IDisposable
 
         _cancellationTokenSource.Cancel();
 
+        _processInfo.DurationMilliseconds = (int)_stopwatch.ElapsedMilliseconds;
+
         bool success;
         if (_process.WaitForExit(0))
         {
@@ -204,7 +206,6 @@ public class ProcessRunner : IDisposable
         }
 
         _processInfo.Finished = true;
-        _processInfo.DurationMilliseconds = (int)_stopwatch.ElapsedMilliseconds;
 
         _logWriter.Flush();
         _logWriter.Close();

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -23,7 +23,7 @@ public class ProcessInfo
     public string LogPath;
     public int TimeoutMilliseconds = DefaultTimeout;
     public int ExpectedExitCode;
-    public object Data;
+    public string InputFileName;
 
     public bool Finished;
     public bool Succeeded;


### PR DESCRIPTION
This change enables parallelization of ILC compilation when building
multiple assemblies. For the CoreCLR framework I'm observing about
3~4 times compilation time speedup (about 33 seconds where
previously I was observing about 120 seconds with SuperIlc and
about 180 seconds with the legacy scripts).

Thanks

Tomas