### PR TITLE
Run CoreFX tests single threaded

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -100,7 +100,7 @@ jobs:
         enabled: ${{ eq(parameters.buildConfig, 'Debug') }}
 
     - ${{ if contains(parameters.testScenarios, 'CoreFX') }}:
-      - script: $(testScriptName) $(buildConfig) $(testParameterPrefix)corefx
+      - script: $(testScriptName) $(buildConfig) $(testParameterPrefix)corefx $(testParameterPrefix)singlethread
         displayName: Run CoreFX tests
         enabled: ${{ eq(parameters.buildConfig, 'Debug') }}
 

--- a/tests/CoreFX/build-and-run-test.cmd
+++ b/tests/CoreFX/build-and-run-test.cmd
@@ -53,15 +53,20 @@ if errorlevel 1 (
     exit /b 1
 )
 
+set ExtraXUnitArgs=
+if "%CoreRT_SingleThreaded%"=="true" (
+    set ExtraXUnitArgs=-parallel none
+)
+
 echo Executing %TestFileName% - writing logs to %XunitLogDir%\%TestFileName%\%CoreRT_TestLogFileName%
-echo To repro directly, run call %TestFolder%\native\%TestExecutable% %TestFolder%\%TestFileName%.dll @"%TestFolder%\%TestFileName%.rsp" -xml %XunitLogDir%\%TestFileName%\%CoreRT_TestLogFileName% -notrait category=nonnetcoreapptests -notrait category=nonwindowstests  -notrait category=failing
+echo To repro directly, run call %TestFolder%\native\%TestExecutable% %TestFolder%\%TestFileName%.dll @"%TestFolder%\%TestFileName%.rsp" -xml %XunitLogDir%\%TestFileName%\%CoreRT_TestLogFileName% -notrait category=nonnetcoreapptests -notrait category=nonwindowstests  -notrait category=failing %ExtraXUnitArgs%
 
 if not exist "%TestFolder%\native\%TestExecutable%".exe (
     echo ERROR:Native binary not found Unable to run test.
     exit /b 1
 )
 
-call %TestFolder%\native\%TestExecutable% %TestFolder%\%TestFileName%.dll @"%TestFolder%\%TestFileName%.rsp" -xml %XunitLogDir%\%TestFileName%\%CoreRT_TestLogFileName% -notrait category=nonnetcoreapptests -notrait category=nonwindowstests  -notrait category=failing
+call %TestFolder%\native\%TestExecutable% %TestFolder%\%TestFileName%.dll @"%TestFolder%\%TestFileName%.rsp" -xml %XunitLogDir%\%TestFileName%\%CoreRT_TestLogFileName% -notrait category=nonnetcoreapptests -notrait category=nonwindowstests  -notrait category=failing %ExtraXUnitArgs%
 set TestExitCode=!ERRORLEVEL!
 
 exit /b %TestExitCode%

--- a/tests/CoreFX/corerun
+++ b/tests/CoreFX/corerun
@@ -53,8 +53,13 @@ if [ ! -d "${LogDir}/${TestFileName}" ]; then
     mkdir -p "${LogDir}/${TestFileName}"
 fi
 
+local ExtraXUnitArgs=""
+if [[ $CoreRT_SingleThreaded == 1 ]]; then
+    ExtraXUnitArgs="-parallel none"
+fi
+
 echo Executing ${TestFileName} - writing logs to ${LogDir}/${TestFileName}/testResults.xml
-echo To repro directly, run ${TestFolderName}/native/${TestExecutable} ${TestFolderName}/${TestFileName}.dll @${TestFolderName}/${TestFileName}.rsp -xml ${LogDir}/${TestFileName}/testResults.xml -notrait category=nonnetcoreapptests -notrait category=${OSCategory}  -notrait category=failing
+echo To repro directly, run ${TestFolderName}/native/${TestExecutable} ${TestFolderName}/${TestFileName}.dll @${TestFolderName}/${TestFileName}.rsp -xml ${LogDir}/${TestFileName}/testResults.xml -notrait category=nonnetcoreapptests -notrait category=${OSCategory}  -notrait category=failing ${ExtraXUnitArgs}
 chmod +x ${TestFolderName}/native/${TestExecutable} 
 
 case "$(uname -s)" in 
@@ -72,7 +77,7 @@ case "$(uname -s)" in
     ;;
 esac
 
-${TestFolderName}/native/${TestExecutable} ${TestFolderName}/${TestFileName}.dll @${TestFolderName}/${TestFileName}.rsp -xml ${LogDir}/${TestFileName}/testResults.xml -notrait category=nonnetcoreapptests -notrait category=${OSCategory}  -notrait category=failing
+${TestFolderName}/native/${TestExecutable} ${TestFolderName}/${TestFileName}.dll @${TestFolderName}/${TestFileName}.rsp -xml ${LogDir}/${TestFileName}/testResults.xml -notrait category=nonnetcoreapptests -notrait category=${OSCategory}  -notrait category=failing ${ExtraXUnitArgs}
 export __exitcode=$?
 
 exit ${__exitcode}

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -15,6 +15,7 @@ set CoreRT_CoreCLRTargetsFile=
 set CoreRT_TestLogFileName=testResults.xml
 set CoreRT_TestName=*
 set CoreRT_GCStressLevel=
+set CoreRT_SingleThreaded=
 
 :ArgLoop
 if "%1" == "" goto :ArgsDone
@@ -58,6 +59,7 @@ if /i "%1" == "/test" (set CoreRT_TestName=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/runtest" (set CoreRT_TestRun=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/dotnetclipath" (set CoreRT_CliDir=%2&shift&shift&goto ArgLoop)
 if /i "%1" == "/multimodule" (set CoreRT_MultiFileConfiguration=MultiModule&shift&goto ArgLoop)
+if /i "%1" == "/singlethread" (set CoreRT_SingleThreaded=true&shift&goto ArgLoop)
 if /i "%1" == "/determinism" (set CoreRT_DeterminismMode=true&shift&goto ArgLoop)
 if /i "%1" == "/nocleanup" (set CoreRT_NoCleanup=true&shift&goto ArgLoop)
 if /i "%1" == "/r2rframework" (set CoreRT_R2RFramework=true&shift&goto ArgLoop)
@@ -78,6 +80,7 @@ echo     /corefx      : Download and run the CoreFX repo tests
 echo     /coreclrsingletest ^<absolute\path\to\test.exe^>
 echo                   : Run a single CoreCLR repo test
 echo     /multimodule  : Compile the framework as a .lib and link tests against it (only supports ryujit)
+echo     /singlethread : Run tests on a single thread (avoid parallel test execution)
 echo     /determinism  : Compile the test twice with randomized dependency node mark stack to validate
 echo                      compiler determinism in multi-threaded compilation.
 echo     /nocleanup    : Do not delete compiled test artifacts after running each test

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -9,6 +9,7 @@ usage()
     echo "    -corefx       : Download and run the CoreFX repo tests"
     echo "    -coreclr      : Download and run the CoreCLR repo tests"
     echo "    -multimodule  : Compile the framework as a .so and link tests against it (ryujit only)"
+    echo "    -singlethread : Run tests on a single thread (avoid parallel execution)"
     echo "    -coredumps    : [For CI use] Enables core dump generation, and analyzes and possibly stores/uploads"
     echo "                      dumps collected during test run."
     echo ""
@@ -236,6 +237,8 @@ run_corefx_tests()
     export CoreRT_TestingUtilitiesOutputDir
     export CoreRT_CliBinDir
 
+    export CoreRT_SingleThreaded
+
     if [ ! -d "${CoreRT_TestExtRepo_CoreFX}" ]; then
         mkdir -p ${CoreRT_TestExtRepo_CoreFX}
     fi
@@ -309,6 +312,7 @@ CoreRT_CrossLinkerFlags=
 CoreRT_CrossBuild=0
 CoreRT_EnableCoreDumps=0
 CoreRT_TestName=*
+CoreRT_SingleThreaded=
 
 while [ "$1" != "" ]; do
         lowerI="$(echo $1 | awk '{print tolower($0)}')"
@@ -379,10 +383,12 @@ while [ "$1" != "" ]; do
             ;;
         -corefx)
             CoreRT_RunCoreFXTests=true;
-            shift
             ;;
         -multimodule)
             CoreRT_MultiFileConfiguration=MultiModule;
+            ;;
+        -singlethread)
+            CoreRT_SingleThreaded=1;
             ;;
         -coredumps)
             CoreRT_EnableCoreDumps=1


### PR DESCRIPTION
Might help us avoid `abort trap 6` that has been plaguing the CI (#7118).

Disabling parallel execution everywhere because it doesn't have big impact on test execution time and helps keep the changes to build-job.yml short.