### PR TITLE
Get CoreCLR tests from Azure

### DIFF
--- a/tests/CoreCLRTestsNativeArtifacts_Linux.txt
+++ b/tests/CoreCLRTestsNativeArtifacts_Linux.txt
@@ -1,1 +1,1 @@
-https://ci.dot.net/job/dotnet_coreclr/job/master/job/debug_ubuntu/1667/artifact/bin/obj/Linux.x64.Debug/tests/*zip*/tests.zip
+https://cloudcijobs.blob.core.windows.net/corertci/CoreCLRTests/2019_03_20/Linux/tests.zip

--- a/tests/CoreCLRTestsNativeArtifacts_OSX.txt
+++ b/tests/CoreCLRTestsNativeArtifacts_OSX.txt
@@ -1,1 +1,1 @@
-https://ci.dot.net/job/dotnet_coreclr/job/master/job/debug_osx10.12/653/artifact/bin/obj/OSX.x64.Debug/tests/*zip*/tests.zip
+https://cloudcijobs.blob.core.windows.net/corertci/CoreCLRTests/2019_03_20/MacOS/tests.zip

--- a/tests/CoreCLRTestsURL.txt
+++ b/tests/CoreCLRTestsURL.txt
@@ -1,1 +1,1 @@
-https://ci.dot.net/job/dotnet_coreclr/job/master/job/x64_checked_windows_nt_innerloop_prtest/839/artifact/bin/tests/tests.zip
+https://cloudcijobs.blob.core.windows.net/corertci/CoreCLRTests/2019_03_20/Windows/tests.zip


### PR DESCRIPTION
Jenkins saved build artifacts are likely to be deleted as we move to AzDO. Move them all to the cloudcijobs account and update URL pointers in the repo.