### PR TITLE
 Implement GetConservativeUpperBoundForOutgoingArgs for Unix

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -100,7 +100,7 @@ jobs:
         enabled: ${{ eq(parameters.buildConfig, 'Debug') }}
 
     - ${{ if contains(parameters.testScenarios, 'CoreFX') }}:
-      - script: $(testScriptName) $(buildConfig) $(testParameterPrefix)corefx $(testParameterPrefix)singlethread
+      - script: $(testScriptName) $(buildConfig) $(testParameterPrefix)corefx
         displayName: Run CoreFX tests
         enabled: ${{ eq(parameters.buildConfig, 'Debug') }}
 

--- a/src/Native/Runtime/StackFrameIterator.cpp
+++ b/src/Native/Runtime/StackFrameIterator.cpp
@@ -912,7 +912,7 @@ struct UniversalTransitionStackFrame
 private:
     Fp128 m_fpArgRegs[8];                   // ChildSP+000 CallerSP-0D0 (0x80 bytes)    (xmm0-xmm7)
     UIntNative m_returnBlock[2];            // ChildSP+080 CallerSP-050 (0x10 bytes)
-    UIntNative m_intArgRegs[4];             // ChildSP+090 CallerSP-040 (0x30 bytes)    (rdi,rsi,rcx,rdx,r8,r9)
+    UIntNative m_intArgRegs[6];             // ChildSP+090 CallerSP-040 (0x30 bytes)    (rdi,rsi,rcx,rdx,r8,r9)
     UIntNative m_alignmentPad;              // ChildSP+0C0 CallerSP-010 (0x8 bytes)
     UIntNative m_callerRetaddr;             // ChildSP+0C8 CallerSP-008 (0x8 bytes)
     UIntNative m_stackPassedArgs[1];        // ChildSP+0D0 CallerSP+000 (unknown size)

--- a/src/Native/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/Native/Runtime/unix/UnixNativeCodeManager.cpp
@@ -187,7 +187,7 @@ UIntNative UnixNativeCodeManager::GetConservativeUpperBoundForOutgoingArgs(Metho
 
     if ((unwindBlockFlags & UBF_FUNC_REVERSE_PINVOKE) != 0)
     {
-        // Reverse PInvoke transition should on the main function body only
+        // Reverse PInvoke transition should be on the main function body only
         assert(pNativeMethodInfo->pMainLSDA == pNativeMethodInfo->pLSDA);
 
         if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) != 0)
@@ -220,8 +220,9 @@ UIntNative UnixNativeCodeManager::GetConservativeUpperBoundForOutgoingArgs(Metho
         bool result = VirtualUnwind(&localRegisterSet);
         assert(result);
 
-        // All common ABIs have outgoing arguments are under caller SP (minus slot reserved for return address).
-        // There are ABI-specific optimizations that could applied to 
+        // All common ABIs have outgoing arguments under caller SP (minus slot reserved for return address).
+        // There are ABI-specific optimizations that could applied here, but they are not worth the complexity
+        // given that this path is used rarely.
         upperBound = dac_cast<TADDR>(localRegisterSet.GetSP() - sizeof(TADDR));
     }
 
@@ -243,7 +244,7 @@ bool UnixNativeCodeManager::UnwindStackFrame(MethodInfo *    pMethodInfo,
 
     if ((unwindBlockFlags & UBF_FUNC_REVERSE_PINVOKE) != 0)
     {
-        // Reverse PInvoke transition should on the main function body only
+        // Reverse PInvoke transition should be on the main function body only
         assert(pNativeMethodInfo->pMainLSDA == pNativeMethodInfo->pLSDA);
 
         if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) != 0)

--- a/src/Native/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/Native/Runtime/unix/UnixNativeCodeManager.cpp
@@ -173,9 +173,59 @@ void UnixNativeCodeManager::EnumGcRefs(MethodInfo *    pMethodInfo,
 
 UIntNative UnixNativeCodeManager::GetConservativeUpperBoundForOutgoingArgs(MethodInfo * pMethodInfo, REGDISPLAY * pRegisterSet)
 {
-    // @TODO: CORERT: GetConservativeUpperBoundForOutgoingArgs
-    assert(false);
-    return false;
+    // Return value
+    UIntNative upperBound;
+
+    UnixNativeMethodInfo * pNativeMethodInfo = (UnixNativeMethodInfo *)pMethodInfo;
+
+    PTR_UInt8 p = pNativeMethodInfo->pMainLSDA;
+
+    uint8_t unwindBlockFlags = *p++;
+
+    if ((unwindBlockFlags & UBF_FUNC_HAS_ASSOCIATED_DATA) != 0)
+        p += sizeof(int32_t);
+
+    if ((unwindBlockFlags & UBF_FUNC_REVERSE_PINVOKE) != 0)
+    {
+        // Reverse PInvoke transition should on the main function body only
+        assert(pNativeMethodInfo->pMainLSDA == pNativeMethodInfo->pLSDA);
+
+        if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) != 0)
+            p += sizeof(int32_t);
+
+        GcInfoDecoder decoder(GCInfoToken(p), DECODE_REVERSE_PINVOKE_VAR);
+        INT32 slot = decoder.GetReversePInvokeFrameStackSlot();
+        assert(slot != NO_REVERSE_PINVOKE_FRAME);
+
+        TADDR basePointer = NULL;
+        UINT32 stackBasedRegister = decoder.GetStackBaseRegister();
+        if (stackBasedRegister == NO_STACK_BASE_REGISTER)
+        {
+            basePointer = dac_cast<TADDR>(pRegisterSet->GetSP());
+        }
+        else
+        {
+            basePointer = dac_cast<TADDR>(pRegisterSet->GetFP());
+        }
+
+        // Reverse PInvoke case.  The embedded reverse PInvoke frame is guaranteed to reside above
+        // all outgoing arguments.
+        upperBound = (UIntNative)dac_cast<TADDR>(basePointer + slot);
+    }
+    else
+    {
+        // The passed in pRegisterSet should be left intact
+        REGDISPLAY localRegisterSet = *pRegisterSet;
+
+        bool result = VirtualUnwind(&localRegisterSet);
+        assert(result);
+
+        // All common ABIs have outgoing arguments are under caller SP (minus slot reserved for return address).
+        // There are ABI-specific optimizations that could applied to 
+        upperBound = dac_cast<TADDR>(localRegisterSet.GetSP() - sizeof(TADDR));
+    }
+
+    return upperBound;
 }
 
 bool UnixNativeCodeManager::UnwindStackFrame(MethodInfo *    pMethodInfo,

--- a/src/Native/Runtime/windows/CoffNativeCodeManager.cpp
+++ b/src/Native/Runtime/windows/CoffNativeCodeManager.cpp
@@ -475,7 +475,7 @@ bool CoffNativeCodeManager::UnwindStackFrame(MethodInfo *    pMethodInfo,
 
     if ((unwindBlockFlags & UBF_FUNC_REVERSE_PINVOKE) != 0)
     {
-        // Reverse PInvoke transition should on the main function body only
+        // Reverse PInvoke transition should be on the main function body only
         assert(pNativeMethodInfo->mainRuntimeFunction == pNativeMethodInfo->runtimeFunction);
 
         if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) != 0)


### PR DESCRIPTION
Fixes #7118 