### PR TITLE
Integrating test execution into SuperIlc and other improvements

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/Application.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/Application.cs
@@ -31,7 +31,7 @@ namespace ReadyToRun.SuperIlc
 
             _compilations = new List<ProcessInfo[]>();
 
-            ;            foreach (string file in _compilationInputFiles)
+            foreach (string file in _compilationInputFiles)
             {
                 ProcessInfo[] fileCompilations = new ProcessInfo[(int)CompilerIndex.Count];
                 foreach (CompilerRunner runner in compilerRunners)

--- a/tests/src/tools/ReadyToRun.SuperIlc/Application.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/Application.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace ReadyToRun.SuperIlc
+{
+    public class Application
+    {
+        private List<string> _compilationInputFiles;
+
+        private string  _mainExecutable;
+
+        private readonly List<ProcessInfo[]> _compilations;
+
+        private readonly ProcessInfo[] _execution;
+
+        public Application(
+            List<string> compilationInputFiles, 
+            string mainExecutable, 
+            IEnumerable<CompilerRunner> compilerRunners, 
+            string coreRunPath)
+        {
+            _compilationInputFiles = compilationInputFiles;
+            _mainExecutable = mainExecutable;
+
+            _compilations = new List<ProcessInfo[]>();
+
+            ;            foreach (string file in _compilationInputFiles)
+            {
+                ProcessInfo[] fileCompilations = new ProcessInfo[(int)CompilerIndex.Count];
+                foreach (CompilerRunner runner in compilerRunners)
+                {
+                    ProcessInfo compilationProcess = runner.CompilationProcess(file);
+                    fileCompilations[(int)runner.Index] = compilationProcess;
+                }
+                _compilations.Add(fileCompilations);
+            }
+
+            if (_mainExecutable != null && !string.IsNullOrEmpty(coreRunPath))
+            {
+                _execution = new ProcessInfo[(int)CompilerIndex.Count];
+
+                foreach (CompilerRunner runner in compilerRunners)
+                {
+                    HashSet<string> modules = new HashSet<string>();
+                    HashSet<string> folders = new HashSet<string>();
+
+                    modules.Add(_mainExecutable);
+                    modules.UnionWith(_compilationInputFiles);
+                    folders.Add(Path.GetDirectoryName(_mainExecutable).ToLower());
+                    folders.UnionWith(runner.ReferenceFolders.Select(folder => folder.ToLower()));
+
+                    _execution[(int)runner.Index] = runner.ExecutionProcess(_mainExecutable, modules, folders, coreRunPath);
+                }
+            }
+        }
+
+        public IEnumerable<ProcessInfo[]> Compilations => _compilations;
+
+        public ProcessInfo[] Execution => _execution;
+    }
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -23,17 +23,13 @@ namespace ReadyToRun.SuperIlc
                 new Command("compile-directory", "Compile all assemblies in directory", 
                     new Option[] 
                     {
-                        ToolPath(),
                         InputDirectory(),
                         OutputDirectory(),
-                        UseCrossgen(),
-                        UseCpaot(),
+                        CrossgenDirectory(),
+                        CpaotDirectory(),
                         ReferencePath()
                     },
-                    handler: CommandHandler.Create<DirectoryInfo, DirectoryInfo, DirectoryInfo, bool, bool, DirectoryInfo[]>(CompileDirectoryCommand.CompileDirectory));
-
-            Option ToolPath() =>
-                new Option(new[] {"--tool-directory", "-t"}, "Directory containing the selected optimizing compiler", new Argument<DirectoryInfo>().ExistingOnly());
+                    handler: CommandHandler.Create<DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo[]>(CompileDirectoryCommand.CompileDirectory));
 
             // Todo: Input / Output directories should be required arguments to the command when they're made available to handlers
             // https://github.com/dotnet/command-line-api/issues/297
@@ -43,11 +39,11 @@ namespace ReadyToRun.SuperIlc
             Option OutputDirectory() =>
                 new Option(new [] {"--output-directory", "-out"}, "Folder to emit compiled assemblies", new Argument<DirectoryInfo>().LegalFilePathsOnly());
 
-            Option UseCrossgen() =>
-                new Option("--crossgen", "Compile with CoreCLR Crossgen", new Argument<bool>());
+            Option CrossgenDirectory() =>
+                new Option(new[] { "--crossgen-directory", "-crossgen" }, "Folder containing the Crossgen compiler", new Argument<DirectoryInfo>().ExistingOnly());
 
-            Option UseCpaot() =>
-                new Option("--cpaot", "Compile with CoreRT CPAOT", new Argument<bool>());
+            Option CpaotDirectory() =>
+                new Option(new[] { "--cpaot-directory", "-cpaot" }, "Folder containing the CPAOT compiler", new Argument<DirectoryInfo>().ExistingOnly());
 
             Option ReferencePath() =>
                 new Option(new[] {"--reference-path", "-r"}, "Folder containing assemblies to reference during compilation", new Argument<DirectoryInfo[]>(){Arity = ArgumentArity.ZeroOrMore}.ExistingOnly());

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -60,7 +60,7 @@ public abstract class CompilerRunner
         return processInfo;
     }
 
-    public ProcessInfo ExecutionProcess(string appPath, ICollection<string> modules, ICollection<string> folders, string coreRunPath)
+    public ProcessInfo ExecutionProcess(string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath)
     {
         string exeToRun = GetOutputFileName(appPath);
         ProcessInfo processInfo = new ProcessInfo();

--- a/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 /// </summary>
 class CpaotRunner : CompilerRunner
 {
+    public override CompilerIndex Index => CompilerIndex.CPAOT;
+
     protected override string CompilerFileName => "ilc.exe";
 
     public CpaotRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders) : base(compilerFolder, inputFolder, outputFolder, referenceFolders) {}

--- a/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -12,6 +12,8 @@ using System.Text;
 /// </summary>
 class CrossgenRunner : CompilerRunner
 {
+    public override CompilerIndex Index => CompilerIndex.Crossgen;
+
     protected override string CompilerFileName => "crossgen.exe";
 
     public CrossgenRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders) : base(compilerFolder, inputFolder, outputFolder, referenceFolders) {}

--- a/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
@@ -1,0 +1,177 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// A set of helper to manipulate paths into a canonicalized form to ensure user-provided paths
+/// match those in the ETW log.
+/// </summary>
+static class PathExtensions
+{
+    /// <summary>
+    /// Millisecond timeout for file / directory deletion.
+    /// </summary>
+    const int DeletionTimeoutMilliseconds = 10000;
+
+    /// <summary>
+    /// Back-off for repeated checks for directory deletion. According to my local experience [trylek],
+    /// when the directory is opened in the file explorer, the propagation typically takes 2 seconds.
+    /// </summary>
+    const int DirectoryDeletionBackoffMilliseconds = 500;
+
+    internal static string ToAbsolutePath(this string argValue) => Path.GetFullPath(argValue);
+
+    internal static string ToAbsoluteDirectoryPath(this string argValue) => argValue.ToAbsolutePath().StripTrailingDirectorySeparators();
+        
+    internal static string StripTrailingDirectorySeparators(this string str)
+    {
+        if (String.IsNullOrWhiteSpace(str))
+        {
+            return str;
+        }
+
+        while (str.Length > 0 && str[str.Length - 1] == Path.DirectorySeparatorChar)
+        {
+            str = str.Remove(str.Length - 1);
+        }
+
+        return str;
+    }
+
+    internal static void RecreateDirectory(this string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+            Task<bool> deleteSubtreeTask = path.DeleteSubtree();
+            deleteSubtreeTask.Wait();
+            if (deleteSubtreeTask.Result)
+            {
+                Console.WriteLine("Deleted {0} in {1} msecs", path, stopwatch.ElapsedMilliseconds);
+            }
+            else
+            {
+                throw new Exception($"Error: Could not delete output folder {path}");
+            }
+        }
+
+        Directory.CreateDirectory(path);
+    }
+
+    internal static bool IsParentOf(this DirectoryInfo outputPath, DirectoryInfo inputPath)
+    {
+        DirectoryInfo parentInfo = inputPath.Parent;
+        while (parentInfo != null)
+        {
+            if (parentInfo == outputPath)
+                return true;
+
+            parentInfo = parentInfo.Parent;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Asynchronous task for subtree deletion.
+    /// </summary>
+    /// <param name="path">Directory to delete</param>
+    /// <returns>Task returning true on success, false on failure</returns>
+    public static async Task<bool> DeleteSubtree(this string path)
+    {
+        bool succeeded = true;
+
+        try
+        {
+            if (!Directory.Exists(path))
+            {
+                // Non-existent folders are harmless w.r.t. deletion
+                Console.WriteLine("Skipping non-existent folder: '{0}'", path);
+                return succeeded;
+            }
+            Console.WriteLine("Deleting '{0}'", path);
+            var tasks = new List<Task<bool>>();
+            foreach (string subfolder in Directory.EnumerateDirectories(path))
+            {
+                tasks.Add(Task<bool>.Run(() => subfolder.DeleteSubtree()));
+            }
+            string[] files = Directory.GetFiles(path);
+            foreach (string file in files)
+            {
+                tasks.Add(Task<bool>.Run(() => file.DeleteFile()));
+            }
+
+            await Task<bool>.WhenAll(tasks);
+
+            foreach (var task in tasks)
+            {
+                if (!task.Result)
+                    succeeded = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine("Error deleting '{0}': {1}", path, ex.Message);
+            succeeded = false;
+        }
+
+        if (succeeded)
+        {
+            Stopwatch folderDeletion = new Stopwatch();
+            folderDeletion.Start();
+            while (Directory.Exists(path))
+            {
+                try
+                {
+                    Directory.Delete(path, recursive: false);
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    // Directory not found is OK (the directory might have been deleted during the back-off delay).
+                }
+                catch (Exception)
+                {
+                    Console.WriteLine("Folder deletion failure, maybe transient ({0} msecs): '{1}'", folderDeletion.ElapsedMilliseconds, path);
+                }
+
+                if (!Directory.Exists(path))
+                {
+                    break;
+                }
+
+                if (folderDeletion.ElapsedMilliseconds > DeletionTimeoutMilliseconds)
+                {
+                    Console.Error.WriteLine("Timed out trying to delete directory '{0}'", path);
+                    succeeded = false;
+                    break;
+                }
+
+                Thread.Sleep(DirectoryDeletionBackoffMilliseconds);
+            }
+        }
+
+        return succeeded;
+    }
+
+    private static bool DeleteFile(this string file)
+    {
+        try
+        {
+            File.Delete(file);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"{file}: {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -10,6 +10,10 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
+
 public class ProcessInfo
 {
     /// <summary>
@@ -24,12 +28,18 @@ public class ProcessInfo
     public int TimeoutMilliseconds = DefaultTimeout;
     public int ExpectedExitCode;
     public string InputFileName;
+    public string OutputFileName;
+    public long CompilationCostHeuristic;
+    public bool CollectJittedMethods;
+    public ICollection<string> MonitorModules;
+    public ICollection<string> MonitorFolders;
 
     public bool Finished;
     public bool Succeeded;
     public bool TimedOut;
     public int DurationMilliseconds;
     public int ExitCode;
+    public IReadOnlyDictionary<string, HashSet<string>> JittedMethods;
 }
 
 public class ProcessRunner : IDisposable
@@ -48,6 +58,10 @@ public class ProcessRunner : IDisposable
 
     private Process _process;
 
+    private TraceEventSession _traceEventSession;
+
+    private ReadyToRunJittedMethods _r2rMethodFilter;
+
     private readonly Stopwatch _stopwatch;
 
     /// <summary>
@@ -65,9 +79,7 @@ public class ProcessRunner : IDisposable
         _processIndex = processIndex;
         _processExitEvent = processExitEvent;
 
-        CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-
-        _cancellationTokenSource = cancellationTokenSource;
+        _cancellationTokenSource = new CancellationTokenSource();
 
         _stopwatch = new Stopwatch();
         _stopwatch.Start();
@@ -103,7 +115,18 @@ public class ProcessRunner : IDisposable
 
         Interlocked.Exchange(ref _state, StateRunning);
 
+        if (_processInfo.CollectJittedMethods)
+        {
+            _traceEventSession = new TraceEventSession("ReadyToRunTestSession");
+            _traceEventSession.EnableProvider(ClrTraceEventParser.ProviderGuid, TraceEventLevel.Verbose, (ulong)(ClrTraceEventParser.Keywords.Jit | ClrTraceEventParser.Keywords.Loader));
+        }
+
         _process.Start();
+
+        if (_processInfo.CollectJittedMethods)
+        {
+            _r2rMethodFilter = new ReadyToRunJittedMethods(_traceEventSession, _processInfo.MonitorModules, _processInfo.MonitorFolders, _process.Id);
+        }
 
         _process.OutputDataReceived += new DataReceivedEventHandler(StandardOutputEventHandler);
         _process.BeginOutputReadLine();
@@ -111,23 +134,27 @@ public class ProcessRunner : IDisposable
         _process.ErrorDataReceived += new DataReceivedEventHandler(StandardErrorEventHandler);
         _process.BeginErrorReadLine();
 
-        Task.Run(() =>
-        {
-            try
-            {
-                Task.Delay(_processInfo.TimeoutMilliseconds, cancellationTokenSource.Token).Wait();
-                StopProcessAtomic();
-            }
-            catch (TaskCanceledException)
-            {
-                // Ignore cancellation
-            }
-        });
+        Task.Run(TimeoutWatchdog);
     }
 
     public void Dispose()
     {
         CleanupProcess();
+        CleanupLogWriter();
+        CleanupEventTracing();
+    }
+
+    private void TimeoutWatchdog()
+    {
+        try
+        {
+            Task.Delay(_processInfo.TimeoutMilliseconds, _cancellationTokenSource.Token).Wait();
+            StopProcessAtomic();
+        }
+        catch (TaskCanceledException)
+        {
+            // Ignore cancellation
+        }
     }
 
     private void CleanupProcess()
@@ -143,11 +170,23 @@ public class ProcessRunner : IDisposable
             _process.Dispose();
             _process = null;
         }
+    }
 
+    private void CleanupLogWriter()
+    {
         if (_logWriter != null)
         {
             _logWriter.Dispose();
             _logWriter = null;
+        }
+    }
+
+    private void CleanupEventTracing()
+    {
+        if (_traceEventSession != null)
+        {
+            _traceEventSession.Dispose();
+            _traceEventSession = null;
         }
     }
 
@@ -158,62 +197,13 @@ public class ProcessRunner : IDisposable
 
     private void StopProcessAtomic()
     {
-        if (Interlocked.CompareExchange(ref _state, StateFinishing, StateRunning) != StateRunning)
+        if (Interlocked.CompareExchange(ref _state, StateFinishing, StateRunning) == StateRunning)
         {
-            return;
+            _cancellationTokenSource.Cancel();
+            _processInfo.DurationMilliseconds = (int)_stopwatch.ElapsedMilliseconds;
+            _processExitEvent?.Set();
+            _traceEventSession?.Stop();
         }
-
-        _cancellationTokenSource.Cancel();
-
-        _processInfo.DurationMilliseconds = (int)_stopwatch.ElapsedMilliseconds;
-
-        bool success;
-        if (_process.WaitForExit(0))
-        {
-            _process.WaitForExit();
-            _processInfo.ExitCode = _process.ExitCode;
-            success = (_processInfo.ExitCode == _processInfo.ExpectedExitCode);
-            _logWriter.WriteLine(">>>>");
-            if (success)
-            {
-                _logWriter.WriteLine($"Succeeded in {_processInfo.DurationMilliseconds} msecs, exit code {_processInfo.ExitCode}");
-                Console.WriteLine(
-                    $"{_processIndex}: succeeded in {_processInfo.DurationMilliseconds} msecs; " +
-                    $"exit code {_processInfo.ExitCode}: {_processInfo.ProcessPath} {_processInfo.Arguments}");
-                _processInfo.Succeeded = true;
-            }
-            else
-            {
-                _logWriter.WriteLine($"Failed in {_processInfo.DurationMilliseconds} msecs, exit code {_processInfo.ExitCode}, expected {_processInfo.ExpectedExitCode}");
-                Console.Error.WriteLine(
-                    $"{_processIndex}: failed in {_processInfo.DurationMilliseconds} msecs; " +
-                    $"exit code {_processInfo.ExitCode}, expected{_processInfo.ExpectedExitCode}: " +
-                    $"{_processInfo.ProcessPath} {_processInfo.Arguments}");
-            }
-        }
-        else
-        {
-            _process.Kill();
-            _process.WaitForExit();
-            _processInfo.ExitCode = TimeoutExitCode;
-            _processInfo.TimedOut = true;
-            success = false;
-            _logWriter.WriteLine(">>>>");
-            _logWriter.WriteLine($"Timed out in {_processInfo.DurationMilliseconds} msecs");
-            Console.Error.WriteLine(
-                $"{_processIndex}: timed out in {_processInfo.DurationMilliseconds} msecs: " +
-                $"{_processInfo.ProcessPath} {_processInfo.Arguments}");
-        }
-
-        _processInfo.Finished = true;
-
-        _logWriter.Flush();
-        _logWriter.Close();
-
-        CleanupProcess();
-
-        Interlocked.Exchange(ref _state, StateIdle);
-        _processExitEvent?.Set();
     }
 
     private void StandardOutputEventHandler(object sender, DataReceivedEventArgs eventArgs)
@@ -236,6 +226,95 @@ public class ProcessRunner : IDisposable
 
     public bool IsAvailable()
     {
-        return _state == StateIdle;
+        if (_state != StateFinishing)
+        {
+            return _state == StateIdle;
+        }
+
+        if (_process.WaitForExit(0))
+        {
+            _process.WaitForExit();
+            _processInfo.ExitCode = _process.ExitCode;
+            _processInfo.Succeeded = (_processInfo.ExitCode == _processInfo.ExpectedExitCode);
+            _logWriter.WriteLine(">>>>");
+            if (_processInfo.Succeeded)
+            {
+                _logWriter.WriteLine(
+                    $"Succeeded in {_processInfo.DurationMilliseconds} msecs, " +
+                    $"exit code {_processInfo.ExitCode} = 0x{_processInfo.ExitCode:X8}");
+                Console.WriteLine(
+                    $"{_processIndex}: succeeded in {_processInfo.DurationMilliseconds} msecs; " +
+                    $"exit code {_processInfo.ExitCode} = 0x{_processInfo.ExitCode:X8}: " +
+                    $"{_processInfo.ProcessPath} {_processInfo.Arguments}");
+                _processInfo.Succeeded = true;
+            }
+            else
+            {
+                _logWriter.WriteLine(
+                    $"Failed in {_processInfo.DurationMilliseconds} msecs, " +
+                    $"exit code {_processInfo.ExitCode} = 0x{_processInfo.ExitCode:X8}, " +
+                    $"expected {_processInfo.ExpectedExitCode} = 0x{_processInfo.ExpectedExitCode:X8}");
+                Console.Error.WriteLine(
+                    $"{_processIndex}: failed in {_processInfo.DurationMilliseconds} msecs; " +
+                    $"exit code {_processInfo.ExitCode} = 0x{_processInfo.ExitCode:X8}, " +
+                    $"expected {_processInfo.ExpectedExitCode} = 0x{_processInfo.ExpectedExitCode:X8}: " +
+                    $"{_processInfo.ProcessPath} {_processInfo.Arguments}");
+            }
+        }
+        else
+        {
+            _process.Kill();
+            _process.WaitForExit();
+            _processInfo.ExitCode = TimeoutExitCode;
+            _processInfo.TimedOut = true;
+            _processInfo.Succeeded = false;
+            _logWriter.WriteLine(">>>>");
+            _logWriter.WriteLine($"Timed out in {_processInfo.DurationMilliseconds} msecs");
+            Console.Error.WriteLine(
+                $"{_processIndex}: timed out in {_processInfo.DurationMilliseconds} msecs: " +
+                $"{_processInfo.ProcessPath} {_processInfo.Arguments}");
+        }
+
+        if (_processInfo.CollectJittedMethods)
+        {
+            // Block, processing callbacks for events we subscribed to
+            _traceEventSession.Source.Process();
+            _processInfo.JittedMethods = _r2rMethodFilter.JittedMethods;
+
+            _logWriter.WriteLine($"Jitted methods ({_processInfo.JittedMethods.Count} total):");
+            foreach (KeyValuePair<string, HashSet<string>> jittedMethodAndModules in _processInfo.JittedMethods)
+            {
+                _logWriter.Write(jittedMethodAndModules.Key);
+                _logWriter.Write(": ");
+                bool first = true;
+                foreach (string module in jittedMethodAndModules.Value)
+                {
+                    if (first)
+                    {
+                        first = false;
+                    }
+                    else
+                    {
+                        _logWriter.Write(", ");
+                    }
+                    _logWriter.Write(module);
+                }
+                _logWriter.WriteLine();
+            }
+
+            CleanupProcess();
+
+            CleanupEventTracing();
+        }
+
+        _processInfo.Finished = true;
+
+        _logWriter.Flush();
+        _logWriter.Close();
+
+        CleanupLogWriter();
+
+        _state = StateIdle;
+        return true;
     }
 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.38" />
     <PackageReference Include="System.CommandLine.Experimental" Version="0.1.0-alpha-63724-02" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
   </ItemGroup>

--- a/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRunJittedMethods.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRunJittedMethods.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
+
+/// <summary>
+/// Intercept module loads for assemblies we want to collect method Jit info for.
+/// Each Method that gets Jitted from a ready-to-run assembly is interesting to look at.
+/// For a fully r2r'd assembly, there should be no such methods, so that would be a test failure.
+/// </summary>
+class ReadyToRunJittedMethods
+{
+    private ICollection<string> _testModuleNames;
+    private ICollection<string> _testFolderNames;
+    private List<long> _testModuleIds = new List<long>();
+    private Dictionary<long, string> _testModuleIdToName = new Dictionary<long, string>();
+    private Dictionary<string, HashSet<string>> _methodsJitted = new Dictionary<string, HashSet<string>>();
+    private int _pid = -1;
+
+    public ReadyToRunJittedMethods(TraceEventSession session, ICollection<string> testModuleNames, ICollection<string> testFolderNames, int pid)
+    {
+        _testModuleNames = testModuleNames;
+        _testFolderNames = testFolderNames;
+        _pid = pid;
+
+        session.Source.Clr.LoaderModuleLoad += delegate (ModuleLoadUnloadTraceData data)
+        {
+            if (ShouldMonitorModule(data))
+            {
+                Console.WriteLine($"Tracking module {data.ModuleILFileName} with Id {data.ModuleID}");
+                _testModuleIds.Add(data.ModuleID);
+                _testModuleIdToName[data.ModuleID] = Path.GetFileNameWithoutExtension(data.ModuleILFileName);
+            }
+        };
+
+        session.Source.Clr.MethodLoadVerbose += delegate (MethodLoadUnloadVerboseTraceData data)
+        {
+            if (data.ProcessID == _pid && _testModuleIds.Contains(data.ModuleID) && data.IsJitted)
+            {
+                Console.WriteLine($"Method loaded {GetName(data)} - {data}");
+                string methodName = GetName(data);
+                string moduleName = _testModuleIdToName[data.ModuleID];
+                HashSet<string> modulesForMethodName;
+                if (!_methodsJitted.TryGetValue(methodName, out modulesForMethodName))
+                {
+                    modulesForMethodName = new HashSet<string>();
+                    _methodsJitted.Add(methodName, modulesForMethodName);
+                }
+                modulesForMethodName.Add(moduleName);
+            }
+        };
+    }
+
+    private bool ShouldMonitorModule(ModuleLoadUnloadTraceData data)
+    {
+        if (data.ProcessID != _pid)
+            return false;
+
+        if (File.Exists(data.ModuleILPath) && _testFolderNames.Contains(Path.GetDirectoryName(data.ModuleILPath).ToAbsoluteDirectoryPath().ToLower()))
+            return true;
+
+        if (_testModuleNames.Contains(data.ModuleILPath.ToLower()) || _testModuleNames.Contains(data.ModuleNativePath.ToLower()))
+            return true;
+
+        return false;
+    }
+
+    public IReadOnlyDictionary<string, HashSet<string>> JittedMethods => _methodsJitted;
+
+    /// <summary>
+    /// Returns the number of test assemblies that were loaded by the runtime
+    /// </summary>
+    public int AssembliesWithEventsCount => _testModuleIds.Count;
+
+    //
+    // Builds a method name from event data of the form Class.Method(arg1, arg2)
+    //
+    private static string GetName(MethodLoadUnloadVerboseTraceData data)
+    {
+        var signature = "";
+        var signatureWithReturnType = data.MethodSignature;
+        var openParenIndex = signatureWithReturnType.IndexOf('(');
+
+        if (0 <= openParenIndex)
+        {
+            signature = signatureWithReturnType.Substring(openParenIndex);
+        }
+
+        var className = data.MethodNamespace;
+        var firstBox = className.IndexOf('[');
+        var lastDot = className.LastIndexOf('.', firstBox >= 0 ? firstBox : className.Length - 1);
+        if (0 <= lastDot)
+        {
+            className = className.Substring(lastDot + 1);
+        }
+
+        var optionalSeparator = ".";
+        if (className.Length == 0)
+        {
+            optionalSeparator = "";
+        }
+
+        return className + optionalSeparator + data.MethodName + signature;
+    }
+}


### PR DESCRIPTION
1) Change --cpaot and --corerun from boolean flags to paths to the
actual compilers; this also implicitly removes the --tool-directory
option.

2) Introduce new compiler index for internal use to easily iterate
over CPAOT vs. Crossgen results. I have also changed the output
directory name to be based on this logical enumeration rather than
on the plain file name of the compiler exe.

3) Integrate logic for ETW tracing. I have not yet implemented
the actual per-assembly JIT breakdown but this delta goes a long way
towards that goal. The delta is getting big so I'd prefer to merge
something in and follow up in a subsequent change if possible.

Thanks

Tomas