### PR TITLE
Fix dependency reporting issues

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -166,6 +166,13 @@ namespace ILCompiler.DependencyAnalysis
         {
             DependencyList dependencies = new DependencyList();
 
+            if (_dictionaryOwner is TypeDesc type)
+            {
+                // The generic lookup will need to consult the vtable of the owning type to find the
+                // vtable slot where the generic dictionary is placed - report the dependency.
+                dependencies.Add(factory.VTable(type), "Owning type vtable");
+            }
+
             dependencies.Add(factory.GenericDictionaryLayout(_dictionaryOwner), "Layout");
 
             foreach (DependencyNodeCore<NodeFactory> dependency in _lookupSignature.NonRelocDependenciesFromUsage(factory))

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/SealedVTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/SealedVTableNode.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-
+using ILCompiler.DependencyAnalysisFramework;
 using Internal.Text;
 using Internal.TypeSystem;
 
@@ -136,6 +136,20 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             return true;
+        }
+
+        protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
+        {
+            var result = new DependencyList();
+
+            // When building the sealed vtable, we consult the vtable layout of these types
+            TypeDesc declType = _type.GetClosestDefType();
+            result.Add(factory.VTable(declType), "VTable of the type");
+
+            foreach (var interfaceType in declType.RuntimeInterfaces)
+                result.Add(factory.VTable(interfaceType), "VTable of the interface");
+
+            return result;
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)


### PR DESCRIPTION
`SealedVTableNode` is going to query the vtable of the type and its interfaces in `GetData`. Make sure to report that as a non-reloc dependency.

`ReadyToRunGenericHelperNode` is going to query the vtable in the generated helper to find the dictionary slot. Report that too.

Not reporting these leads to failures when scanner is involved (and we use pre-built vtables). We're currently getting away without this reporting, because native layout and reflection report these dependencies too.