### PR TITLE
Make globalization a removable feature

### DIFF
--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -491,6 +491,8 @@ namespace ILCompiler
                     removedFeatures |= RemovedFeature.Etw;
                 else if (feature == "FrameworkStrings")
                     removedFeatures |= RemovedFeature.FrameworkResources;
+                else if (feature == "Globalization")
+                    removedFeatures |= RemovedFeature.Globalization;
             }
 
             ILProvider ilProvider = _isReadyToRunCodeGen ? (ILProvider)new ReadyToRunILProvider() : new CoreRTILProvider();

--- a/src/ILCompiler/src/RemovingILProvider.cs
+++ b/src/ILCompiler/src/RemovingILProvider.cs
@@ -103,6 +103,34 @@ namespace ILCompiler
                 }
             }
 
+            if ((_removedFeature & RemovedFeature.Globalization) != 0)
+            {
+                if (owningType is Internal.TypeSystem.Ecma.EcmaType mdType
+                    && mdType.Module == method.Context.SystemModule)
+                {
+                    if (method.Signature.IsStatic &&
+                        mdType.Name == "GlobalizationMode" && mdType.Namespace == "System.Globalization" &&
+                        method.Name == "get_Invariant")
+                    {
+                        return RemoveAction.ConvertToTrueStub;
+                    }
+
+                    if (method.IsConstructor &&
+                        method.Signature.Length == 3 &&
+                        mdType.Name == "CalendarData" && mdType.Namespace == "System.Globalization")
+                    {
+                        return RemoveAction.ConvertToThrow;
+                    }
+
+                    if (method.Signature.Length == 1 &&
+                        method.Name == "GetCalendarInstanceRare" &&
+                        mdType.Name == "CultureInfo" && mdType.Namespace == "System.Globalization")
+                    {
+                        return RemoveAction.ConvertToThrow;
+                    }
+                }
+            }
+
             return RemoveAction.Nothing;
         }
 
@@ -110,7 +138,7 @@ namespace ILCompiler
         private bool IsEventSourceType(TypeDesc type)
         {
             if (_eventSourceType == null)
-                _eventSourceType = type.Context.SystemModule.GetType("System.Diagnostics.Tracing", "EventSource") ?? new object();
+                _eventSourceType = type.Context.SystemModule.GetType("System.Diagnostics.Tracing", "EventSource", false) ?? new object();
 
             return Object.ReferenceEquals(type, _eventSourceType);
         }
@@ -150,5 +178,6 @@ namespace ILCompiler
     {
         Etw = 0x1,
         FrameworkResources = 0x2,
+        Globalization = 0x4,
     }
 }

--- a/src/ILCompiler/src/RemovingILProvider.cs
+++ b/src/ILCompiler/src/RemovingILProvider.cs
@@ -138,7 +138,7 @@ namespace ILCompiler
         private bool IsEventSourceType(TypeDesc type)
         {
             if (_eventSourceType == null)
-                _eventSourceType = type.Context.SystemModule.GetType("System.Diagnostics.Tracing", "EventSource", false) ?? new object();
+                _eventSourceType = type.Context.SystemModule.GetType("System.Diagnostics.Tracing", "EventSource", throwIfNotFound: false) ?? new object();
 
             return Object.ReferenceEquals(type, _eventSourceType);
         }


### PR DESCRIPTION
Removes another ~100 kB from a Hello World.

Unfortunately, more removal was needed than just flipping the `get_Invariant` bit because the scanner doesn't do inlining and dead code elimination: on retail builds, we still scan the complete graph before RyuJIT does dead code elimination. This makes us find new things that are callable and not reflection blocked on the way, and force them into the optimized closure even though they're no longer reachable from optimized code.