### PR TITLE
Miscellaneous SuperIlc Improvements, pt# 3

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/Application.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/Application.cs
@@ -51,8 +51,10 @@ namespace ReadyToRun.SuperIlc
                     HashSet<string> modules = new HashSet<string>();
                     HashSet<string> folders = new HashSet<string>();
 
-                    modules.Add(_mainExecutable);
-                    modules.UnionWith(_compilationInputFiles);
+                    modules.Add(_mainExecutable.ToLower());
+                    modules.Add(runner.GetOutputFileName(_mainExecutable).ToLower());
+                    modules.UnionWith(_compilationInputFiles.Select(file => file.ToLower()));
+                    modules.UnionWith(_compilationInputFiles.Select(file => runner.GetOutputFileName(file).ToLower()));
                     folders.Add(Path.GetDirectoryName(_mainExecutable).ToLower());
                     folders.UnionWith(runner.ReferenceFolders.Select(folder => folder.ToLower()));
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
@@ -188,6 +188,16 @@ namespace ReadyToRun.SuperIlc
                 }
 
                 ParallelRunner.Run(executionsToRun);
+
+                Dictionary<string, HashSet<string>>[] jittedMethodsPerModulePerCompiler = new Dictionary<string, HashSet<string>>[(int)CompilerIndex.Count];
+                foreach (CompilerRunner runner in runners)
+                {
+                    Dictionary<string, HashSet<string>> jittedMethodsPerModule = new Dictionary<string, HashSet<string>>();
+                    jittedMethodsPerModulePerCompiler[(int)runner.Index] = jittedMethodsPerModule;
+                    application.AddModuleToJittedMethodsMapping(jittedMethodsPerModule, runner.Index);
+                }
+
+                application.WriteJitStatistics(jittedMethodsPerModulePerCompiler, runners.Select(runner => runner.Index));
             }
 
             return success ? 0 : 1;

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
@@ -57,6 +57,8 @@ namespace ReadyToRun.SuperIlc
             }
 
             List<CompilerRunner> runners = new List<CompilerRunner>();
+            runners.Add(new JitRunner(null, inputDirectory.ToString(), outputDirectory.ToString(), referencePaths));
+
             if (cpaotDirectory != null)
             {
                 runners.Add(new CpaotRunner(cpaotDirectory.ToString(), inputDirectory.ToString(), outputDirectory.ToString(), referencePaths));
@@ -105,7 +107,11 @@ namespace ReadyToRun.SuperIlc
             {
                 foreach (CompilerRunner runner in runners)
                 {
-                    compilationsToRun.Add(compilation[(int)runner.Index]);
+                    ProcessInfo compilationProcess = compilation[(int)runner.Index];
+                    if (compilationProcess != null)
+                    {
+                        compilationsToRun.Add(compilationProcess);
+                    }
                 }
             }
 
@@ -124,7 +130,7 @@ namespace ReadyToRun.SuperIlc
                 foreach (CompilerRunner runner in runners)
                 {
                     ProcessInfo runnerProcess = compilation[(int)runner.Index];
-                    if (!runnerProcess.Succeeded)
+                    if (runnerProcess != null && !runnerProcess.Succeeded)
                     {
                         File.Copy(runnerProcess.InputFileName, runnerProcess.OutputFileName);
                         if (file == null)
@@ -170,7 +176,7 @@ namespace ReadyToRun.SuperIlc
                 List<ProcessInfo> executionsToRun = new List<ProcessInfo>();
                 foreach (CompilerRunner runner in runners)
                 {
-                    bool compilationsSucceeded = application.Compilations.All(comp => comp[(int)runner.Index].Succeeded);
+                    bool compilationsSucceeded = application.Compilations.All(comp => comp[(int)runner.Index]?.Succeeded ?? true);
                     if (compilationsSucceeded)
                     {
                         ProcessInfo executionProcess = application.Execution[(int)runner.Index];

--- a/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -16,6 +16,13 @@ class CpaotRunner : CompilerRunner
 
     public CpaotRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders) : base(compilerFolder, inputFolder, outputFolder, referenceFolders) {}
 
+    public override ProcessInfo ExecutionProcess(string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath)
+    {
+        ProcessInfo processInfo = base.ExecutionProcess(appPath, modules, folders, coreRunPath);
+        processInfo.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "1";
+        return processInfo;
+    }
+
     protected override IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName)
     {
         // The file to compile

--- a/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -18,6 +18,13 @@ class CrossgenRunner : CompilerRunner
 
     public CrossgenRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders) : base(compilerFolder, inputFolder, outputFolder, referenceFolders) {}
 
+    public override ProcessInfo ExecutionProcess(string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath)
+    {
+        ProcessInfo processInfo = base.ExecutionProcess(appPath, modules, folders, coreRunPath);
+        processInfo.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "1";
+        return processInfo;
+    }
+
     protected override IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName)
     {
         // The file to compile

--- a/tests/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+/// <summary>
+/// No-op runner keeping the original IL assemblies to be directly run with full jitting.
+/// </summary>
+class JitRunner : CompilerRunner
+{
+    public override CompilerIndex Index => CompilerIndex.Jit;
+
+    protected override string CompilerFileName => "clrjit.dll";
+
+    public JitRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders) : base(compilerFolder, inputFolder, outputFolder, referenceFolders) { }
+
+    /// <summary>
+    /// JIT runner has no compilation process as it doesn't transform the source IL code in any manner.
+    /// </summary>
+    /// <returns></returns>
+    public override ProcessInfo CompilationProcess(string assemblyFileName)
+    {
+        File.Copy(assemblyFileName, GetOutputFileName(assemblyFileName));
+        return null;
+    }
+
+    public override ProcessInfo ExecutionProcess(string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath)
+    {
+        ProcessInfo processInfo = base.ExecutionProcess(appPath, modules, folders, coreRunPath);
+        processInfo.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "0";
+        return processInfo;
+    }
+
+    protected override IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName)
+    {
+        // This should never get called as the overridden CompilationProcess returns null
+        throw new NotImplementedException();
+    }
+
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
@@ -154,25 +154,13 @@ public sealed class ParallelRunner
             {
                 using (StreamWriter logWriter = new StreamWriter(processInfo.LogPath, append: true))
                 {
-                    logWriter.WriteLine($"Jitted methods ({processInfo.JittedMethods.Count} total):");
-                    foreach (KeyValuePair<string, HashSet<string>> jittedMethodAndModules in processInfo.JittedMethods)
+                    logWriter.WriteLine($"Jitted methods ({processInfo.JittedMethods.Sum(moduleMethodsKvp => moduleMethodsKvp.Value.Count)} total):");
+                    foreach (KeyValuePair<string, HashSet<string>> jittedMethodsPerModule in processInfo.JittedMethods)
                     {
-                        logWriter.Write(jittedMethodAndModules.Key);
-                        logWriter.Write(": ");
-                        bool first = true;
-                        foreach (string module in jittedMethodAndModules.Value)
+                        foreach (string method in jittedMethodsPerModule.Value)
                         {
-                            if (first)
-                            {
-                                first = false;
-                            }
-                            else
-                            {
-                                logWriter.Write(", ");
-                            }
-                            logWriter.Write(module);
+                            logWriter.WriteLine(jittedMethodsPerModule.Key + " -> " + method);
                         }
-                        logWriter.WriteLine();
                     }
                 }
             }

--- a/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
@@ -114,52 +114,68 @@ public sealed class ParallelRunner
 
         if (collectEtwTraces)
         {
-            using (TraceEventSession traceEventSession = new TraceEventSession("ReadyToRunTestSession"))
-            {
-                traceEventSession.EnableProvider(ClrTraceEventParser.ProviderGuid, TraceEventLevel.Verbose, (ulong)(ClrTraceEventParser.Keywords.Jit | ClrTraceEventParser.Keywords.Loader));
-                ReadyToRunJittedMethods jittedMethods = new ReadyToRunJittedMethods(traceEventSession, processesToRun);
-                Task.Run(() =>
-                {
-                    BuildProjects(processesToRun, jittedMethods, degreeOfParallelism);
-                    traceEventSession.Stop();
-                });
-                traceEventSession.Source.Process();
-            }
+            // In ETW collection mode, separate the processes to run into smaller batches as we need to keep
+            // the process objects alive for the entire duration of the parallel execution, otherwise PID's
+            // may get recycled by the OS and we can no longer back-translate PIDs in events to the logical
+            // process executions.
+            const int EtwCollectionBatching = 1000;
 
-            // Append jitted method info to the logs
-            foreach (ProcessInfo processInfo in processesToRun)
+            for (int startIndex = 0; startIndex < processCount; startIndex += EtwCollectionBatching)
             {
-                if (processInfo.CollectJittedMethods)
-                {
-                    using (StreamWriter logWriter = new StreamWriter(processInfo.LogPath, append: true))
-                    {
-                        logWriter.WriteLine($"Jitted methods ({processInfo.JittedMethods.Count} total):");
-                        foreach (KeyValuePair<string, HashSet<string>> jittedMethodAndModules in processInfo.JittedMethods)
-                        {
-                            logWriter.Write(jittedMethodAndModules.Key);
-                            logWriter.Write(": ");
-                            bool first = true;
-                            foreach (string module in jittedMethodAndModules.Value)
-                            {
-                                if (first)
-                                {
-                                    first = false;
-                                }
-                                else
-                                {
-                                    logWriter.Write(", ");
-                                }
-                                logWriter.Write(module);
-                            }
-                            logWriter.WriteLine();
-                        }
-                    }
-                }
+                BuildEtwProcesses(processesToRun.Skip(startIndex).Take(EtwCollectionBatching), degreeOfParallelism);
             }
         }
         else
         {
             BuildProjects(processesToRun, null, degreeOfParallelism);
+        }
+    }
+
+    private static void BuildEtwProcesses(IEnumerable<ProcessInfo> processesToRun, int degreeOfParallelism)
+    {
+        using (TraceEventSession traceEventSession = new TraceEventSession("ReadyToRunTestSession"))
+        {
+            traceEventSession.EnableProvider(ClrTraceEventParser.ProviderGuid, TraceEventLevel.Verbose, (ulong)(ClrTraceEventParser.Keywords.Jit | ClrTraceEventParser.Keywords.Loader));
+            using (ReadyToRunJittedMethods jittedMethods = new ReadyToRunJittedMethods(traceEventSession, processesToRun))
+            {
+                Task.Run(() =>
+                {
+                    BuildProjects(processesToRun, jittedMethods, degreeOfParallelism);
+                    traceEventSession.Stop();
+                });
+            }
+            traceEventSession.Source.Process();
+        }
+
+        // Append jitted method info to the logs
+        foreach (ProcessInfo processInfo in processesToRun)
+        {
+            if (processInfo.CollectJittedMethods)
+            {
+                using (StreamWriter logWriter = new StreamWriter(processInfo.LogPath, append: true))
+                {
+                    logWriter.WriteLine($"Jitted methods ({processInfo.JittedMethods.Count} total):");
+                    foreach (KeyValuePair<string, HashSet<string>> jittedMethodAndModules in processInfo.JittedMethods)
+                    {
+                        logWriter.Write(jittedMethodAndModules.Key);
+                        logWriter.Write(": ");
+                        bool first = true;
+                        foreach (string module in jittedMethodAndModules.Value)
+                        {
+                            if (first)
+                            {
+                                first = false;
+                            }
+                            else
+                            {
+                                logWriter.Write(", ");
+                            }
+                            logWriter.Write(module);
+                        }
+                        logWriter.WriteLine();
+                    }
+                }
+            }
         }
     }
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -19,13 +19,24 @@ public class ProcessInfo
     /// <summary>
     /// 10 minutes should be plenty for a CPAOT / Crossgen compilation.
     /// </summary>
-    public const int DefaultTimeout = 600 * 1000;
+    public const int DefaultIlcTimeout = 600 * 1000;
+
+    /// <summary>
+    /// Test execution timeout.
+    /// </summary>
+    public const int DefaultExeTimeout = 200 * 1000;
+
+    /// <summary>
+    /// Test execution timeout under GC stress mode.
+    /// </summary>
+    public const int DefaultExeTimeoutGCStress = 2000 * 1000;
 
     public string ProcessPath;
     public string Arguments;
+    public Dictionary<string, string> EnvironmentOverrides = new Dictionary<string, string>();
     public bool UseShellExecute;
     public string LogPath;
-    public int TimeoutMilliseconds = DefaultTimeout;
+    public int TimeoutMilliseconds;
     public int ExpectedExitCode;
     public string InputFileName;
     public string OutputFileName;
@@ -117,7 +128,7 @@ public class ProcessRunner : IDisposable
         _process.Start();
         if (_processInfo.CollectJittedMethods)
         {
-            _jittedMethods.SetProcessId(_processInfo, _process.Id);
+            _jittedMethods.AddProcessMapping(_processInfo, _process);
         }
 
         _process.OutputDataReceived += new DataReceivedEventHandler(StandardOutputEventHandler);
@@ -156,7 +167,11 @@ public class ProcessRunner : IDisposable
             _cancellationTokenSource = null;
         }
 
-        if (_process != null)
+        // In ETW collection mode, the disposal is carried out in ReadyToRunJittedMethods
+        // as we need to keep the process alive for the entire lifetime of the trace event
+        // session, otherwise PID's may get recycled and we couldn't reliably back-translate
+        // them into the logical process executions.
+        if (_process != null && !_processInfo.CollectJittedMethods)
         {
             _process.Dispose();
             _process = null;

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -118,6 +118,11 @@ public class ProcessRunner : IDisposable
             RedirectStandardError = true,
         };
 
+        foreach (KeyValuePair<string, string> environmentOverride in _processInfo.EnvironmentOverrides)
+        {
+            psi.EnvironmentVariables[environmentOverride.Key] = environmentOverride.Value;
+        }
+
         _process = new Process();
         _process.StartInfo = psi;
         _process.EnableRaisingEvents = true;

--- a/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRunJittedMethods.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRunJittedMethods.cs
@@ -72,13 +72,13 @@ public class ReadyToRunJittedMethods : IDisposable
                 {
                     processInfo.JittedMethods = new Dictionary<string, HashSet<string>>();
                 }
-                HashSet<string> modulesForMethod;
-                if (!processInfo.JittedMethods.TryGetValue(methodName, out modulesForMethod))
+                HashSet<string> methodsForModule;
+                if (!processInfo.JittedMethods.TryGetValue(moduleName, out methodsForModule))
                 {
-                    modulesForMethod = new HashSet<string>();
-                    processInfo.JittedMethods.Add(methodName, modulesForMethod);
+                    methodsForModule = new HashSet<string>();
+                    processInfo.JittedMethods.Add(moduleName, methodsForModule);
                 }
-                modulesForMethod.Add(moduleName);
+                methodsForModule.Add(methodName);
             }
         };
     }


### PR DESCRIPTION
1) Add new JitRunner representing a no-op compilation step
followed by JIT-only execution of the source IL assembly.

2) CompilerRunner - add timeout constant for execution
with / without GC stress and support for environment overrides.

3) ParallelRunner - I have come to the conclusion that
in ETW mode we need to keep the process ID alive for
the entire duration of the [potentially parallel] ETW run,
otherwise OS may end up recycling some PIDs and we become
unable to back-translate them to logical execution processes.

To compensate for this somewhat ugly requirement, I have
added logic to split the execution process set to chunks
(currently each chunk corresponds to 1000 processes);
we only apply parallelism within a particular chunk,
the chunks are run in serial and each creates a new trace
event session and the ReadyToRunJittedMethods filter.

Thanks

Tomas