### PR TITLE
Update metadata Rvas w.r.t. rva section

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/MetadataRvaFixupBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/MetadataRvaFixupBuilder.cs
@@ -23,8 +23,8 @@ namespace ILCompiler.PEWriter
         /// is the delta between the containing PE section's start Rva in the input versus the output.
         /// </summary>
         /// <param name="peReader">Input MSIL image reader</param>
-        /// <param name="sectionRvaDelta">The difference in bytes between the metadata PE section 
-        /// (ie, ".text") start Rva in the input MSIL image versus the output image</param>
+        /// <param name="relocateRva">A delegate which can transform an RVA from the input MSIL image into an RVA
+        /// in the output ready-to-run image</param>
         public static unsafe BlobBuilder Relocate(PEReader peReader, Func<int, int> relocateRva)
         {
             BlobBuilder builder = new BlobBuilder();

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/MetadataRvaFixupBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/MetadataRvaFixupBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
@@ -24,7 +25,7 @@ namespace ILCompiler.PEWriter
         /// <param name="peReader">Input MSIL image reader</param>
         /// <param name="sectionRvaDelta">The difference in bytes between the metadata PE section 
         /// (ie, ".text") start Rva in the input MSIL image versus the output image</param>
-        public static unsafe BlobBuilder Relocate(PEReader peReader, int sectionRvaDelta)
+        public static unsafe BlobBuilder Relocate(PEReader peReader, Func<int, int> relocateRva)
         {
             BlobBuilder builder = new BlobBuilder();
             BlobReader reader = new BlobReader(peReader.GetMetadata().Pointer, peReader.GetMetadata().Length);
@@ -36,7 +37,7 @@ namespace ILCompiler.PEWriter
 
             int methodDefTableOffset = metadataReader.GetTableMetadataOffset(TableIndex.MethodDef);
             builder.WriteBytes(reader.CurrentPointer, methodDefTableOffset);
-            RelocateTableRvas(builder, TableIndex.MethodDef, metadataReader, ref reader, sectionRvaDelta);
+            RelocateTableRvas(builder, TableIndex.MethodDef, metadataReader, ref reader, relocateRva);
 
             //
             // fieldRva table
@@ -44,7 +45,7 @@ namespace ILCompiler.PEWriter
 
             int fieldRvaTableOffset = metadataReader.GetTableMetadataOffset(TableIndex.FieldRva);
             builder.WriteBytes(reader.CurrentPointer, fieldRvaTableOffset - reader.Offset);
-            RelocateTableRvas(builder, TableIndex.FieldRva, metadataReader, ref reader, sectionRvaDelta);
+            RelocateTableRvas(builder, TableIndex.FieldRva, metadataReader, ref reader, relocateRva);
 
             // Copy the rest of the metadata blob
             builder.WriteBytes(reader.CurrentPointer, metadataReader.MetadataLength - reader.Offset);
@@ -54,7 +55,7 @@ namespace ILCompiler.PEWriter
             return builder;
         }
 
-        private unsafe static void RelocateTableRvas(BlobBuilder builder, TableIndex tableIndex, MetadataReader metadataReader, ref BlobReader reader, int sectionRvaDelta)
+        private unsafe static void RelocateTableRvas(BlobBuilder builder, TableIndex tableIndex, MetadataReader metadataReader, ref BlobReader reader, Func<int, int> relocateRva)
         {
             int tableMetadataOffset = metadataReader.GetTableMetadataOffset(tableIndex);
             int rowCount = metadataReader.GetTableRowCount(tableIndex);
@@ -76,7 +77,7 @@ namespace ILCompiler.PEWriter
                 }
                 else
                 {
-                    builder.WriteInt32(inputRva + sectionRvaDelta);
+                    builder.WriteInt32(relocateRva(inputRva));
                 }
 
                 // Skip the rest of the row

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/SectionBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/SectionBuilder.cs
@@ -976,6 +976,8 @@ namespace ILCompiler.PEWriter
                 corHeader,
                 r2rBuilder.CorHeaderFileOffset,
                 outputStream);
+
+            r2rBuilder.RelocateMetadataBlob(outputStream);
         }
     }
 }


### PR DESCRIPTION
Initial implementation for fixing up RVAs embedded in the copied metadata blob in R2R compilation mode contains a bug where if the RVA pointed to in the metadata lies outside the `.text` section, a spurious fixed up RVA is emitted.

* Adjust the implementation to update the metadata RVAs after all sections are laid out and the image is finalized.
* Run the metadata RVA fixups on the output stream to avoid another full copy.
* Pass in a delegate to `MetadataRvaFixupBuilder` which can transform any input MSIL image Rva to an output R2R image Rva. Previously we just passed in `.text` section Rva delta which is insufficient.

In particular this fixes a runtime issue with a previously Crossgened System.Private.CoreLib where RVA fields are inaccessible because they lie in the .data section and we emitted a large negative RVA value which points nowhere good.