### PR TITLE
Basic support for running multiple tests

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/ApplicationSet.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ApplicationSet.cs
@@ -1,0 +1,352 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace ReadyToRun.SuperIlc
+{
+    public class ApplicationSet : IDisposable
+    {
+        private IEnumerable<Application> _applications;
+
+        private IEnumerable<CompilerRunner> _compilerRunners;
+
+        private string _coreRunPath;
+
+        private string _logPath;
+
+        private StreamWriter _logWriter;
+
+        private long _compilationMilliseconds;
+
+        private long _executionMilliseconds;
+
+        private long _buildMilliseconds;
+
+        public ApplicationSet(
+            IEnumerable<Application> applications,
+            IEnumerable<CompilerRunner> compilerRunners,
+            string coreRunPath,
+            string logPath)
+        {
+            _applications = applications;
+            _compilerRunners = compilerRunners;
+            _coreRunPath = coreRunPath;
+            _logPath = logPath;
+
+            _logWriter = new StreamWriter(_logPath);
+        }
+
+        public void Dispose()
+        {
+            _logWriter?.Dispose();
+        }
+
+        private void WriteJittedMethodSummary()
+        {
+            Dictionary<string, HashSet<string>>[] allMethodsPerModulePerCompiler = new Dictionary<string, HashSet<string>>[(int)CompilerIndex.Count];
+
+            foreach (CompilerRunner runner in _compilerRunners)
+            {
+                allMethodsPerModulePerCompiler[(int)runner.Index] = new Dictionary<string, HashSet<string>>();
+            }
+
+            foreach (Application app in _applications)
+            {
+                Dictionary<string, HashSet<string>>[] appMethodsPerModulePerCompiler = new Dictionary<string, HashSet<string>>[(int)CompilerIndex.Count];
+
+                foreach (CompilerRunner runner in _compilerRunners)
+                {
+                    appMethodsPerModulePerCompiler[(int)runner.Index] = new Dictionary<string, HashSet<string>>();
+                    app.AddModuleToJittedMethodsMapping(allMethodsPerModulePerCompiler[(int)runner.Index], runner.Index);
+                    app.AddModuleToJittedMethodsMapping(appMethodsPerModulePerCompiler[(int)runner.Index], runner.Index);
+                }
+                app.WriteJitStatistics(appMethodsPerModulePerCompiler, _compilerRunners);
+            }
+
+            Application.WriteJitStatistics(_logWriter, allMethodsPerModulePerCompiler, _compilerRunners);
+        }
+
+        public bool Compile()
+        {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            List<ProcessInfo> compilationsToRun = new List<ProcessInfo>();
+
+            foreach (Application application in _applications)
+            {
+                foreach (ProcessInfo[] compilation in application.Compilations)
+                {
+                    foreach (CompilerRunner runner in _compilerRunners)
+                    {
+                        ProcessInfo compilationProcess = compilation[(int)runner.Index];
+                        if (compilationProcess != null)
+                        {
+                            compilationsToRun.Add(compilationProcess);
+                        }
+                    }
+                }
+            }
+
+            compilationsToRun.Sort((a, b) => b.CompilationCostHeuristic.CompareTo(a.CompilationCostHeuristic));
+
+            ParallelRunner.Run(compilationsToRun);
+
+            bool success = true;
+            List<KeyValuePair<string, string>> failedCompilationsPerBuilder = new List<KeyValuePair<string, string>>();
+            int successfulCompileCount = 0;
+
+            foreach (Application app in _applications)
+            {
+                foreach (ProcessInfo[] compilation in app.Compilations)
+                {
+                    string file = null;
+                    string failedBuilders = null;
+                    foreach (CompilerRunner runner in _compilerRunners)
+                    {
+                        ProcessInfo runnerProcess = compilation[(int)runner.Index];
+                        if (runnerProcess != null && !runnerProcess.Succeeded)
+                        {
+                            File.Copy(runnerProcess.InputFileName, runnerProcess.OutputFileName);
+                            if (file == null)
+                            {
+                                file = runnerProcess.InputFileName;
+                                failedBuilders = runner.CompilerName;
+                            }
+                            else
+                            {
+                                failedBuilders += "; " + runner.CompilerName;
+                            }
+                        }
+                    }
+                    if (file != null)
+                    {
+                        failedCompilationsPerBuilder.Add(new KeyValuePair<string, string>(file, failedBuilders));
+                        success = false;
+                    }
+                    else
+                    {
+                        successfulCompileCount++;
+                    }
+                }
+            }
+
+            _logWriter.WriteLine($"Compiled {successfulCompileCount} / {successfulCompileCount + failedCompilationsPerBuilder.Count} assemblies in {stopwatch.ElapsedMilliseconds} msecs.");
+
+            if (failedCompilationsPerBuilder.Count > 0)
+            {
+                int compilerRunnerCount = _compilerRunners.Count();
+                _logWriter.WriteLine($"Failed to compile {failedCompilationsPerBuilder.Count} assemblies:");
+                foreach (KeyValuePair<string, string> assemblyBuilders in failedCompilationsPerBuilder)
+                {
+                    string assemblySpec = assemblyBuilders.Key;
+                    if (compilerRunnerCount > 1)
+                    {
+                        assemblySpec += " (" + assemblyBuilders.Value + ")";
+                    }
+                    _logWriter.WriteLine(assemblySpec);
+                }
+            }
+
+            _compilationMilliseconds = stopwatch.ElapsedMilliseconds;
+
+            return success;
+        }
+
+        public bool Execute()
+        {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+            List<ProcessInfo> executionsToRun = new List<ProcessInfo>();
+
+            foreach (Application app in _applications)
+            {
+                AddAppExecution(executionsToRun, app, stopwatch);
+            }
+
+            ParallelRunner.Run(executionsToRun);
+
+            _executionMilliseconds = stopwatch.ElapsedMilliseconds;
+
+            return executionsToRun.All(processInfo => processInfo.Succeeded);
+        }
+
+        public bool Build(string coreRunPath, IEnumerable<CompilerRunner> runners, string logPath)
+        {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            bool success = Compile();
+
+            if (coreRunPath != null)
+            {
+                success = Execute() && success;
+            }
+
+            _buildMilliseconds = stopwatch.ElapsedMilliseconds;
+
+            WriteBuildStatistics();
+
+            return success;
+        }
+
+        private void AddAppExecution(List<ProcessInfo> executionsToRun, Application app, Stopwatch stopwatch)
+        {
+            foreach (CompilerRunner runner in _compilerRunners)
+            {
+                bool compilationsSucceeded = app.Compilations.All(comp => comp[(int)runner.Index]?.Succeeded ?? true);
+                if (compilationsSucceeded && app.Execution != null)
+                {
+                    ProcessInfo executionProcess = app.Execution[(int)runner.Index];
+                    if (executionProcess != null)
+                    {
+                        executionsToRun.Add(executionProcess);
+                    }
+                }
+            }
+        }
+
+        void WriteTopRankingProcesses(string metric, IEnumerable<ProcessInfo> processes)
+        {
+            const int TopAppCount = 10;
+
+            _logWriter.WriteLine();
+
+            string headerLine = $"Top {TopAppCount} top ranking {metric}";
+            _logWriter.WriteLine(headerLine);
+            _logWriter.WriteLine(new string('-', headerLine.Length));
+
+            foreach (ProcessInfo processInfo in processes.OrderByDescending(process => process.DurationMilliseconds).Take(TopAppCount))
+            {
+                _logWriter.WriteLine($"{processInfo.DurationMilliseconds,10} | {processInfo.InputFileName}");
+            }
+        }
+
+        enum Outcome
+        {
+            PASS = 0,
+            ILC_FAIL = 1,
+            EXE_FAIL = 2,
+
+            Count
+        }
+
+        private void WriteBuildStatistics()
+        {
+            _logWriter.WriteLine();
+            _logWriter.WriteLine($"Total apps:       {_applications.Count()}");
+            _logWriter.WriteLine($"Total build time: {_buildMilliseconds} msecs");
+            _logWriter.WriteLine($"Compilation time: {_compilationMilliseconds} msecs");
+            _logWriter.WriteLine($"Execution time:   {_executionMilliseconds} msecs");
+
+            // The Count'th element corresponds to totals over all compiler runners used in the run
+            int[,] outcomes = new int[(int)Outcome.Count, (int)CompilerIndex.Count + 1];
+            int total = 0;
+
+            foreach (Application app in _applications)
+            {
+                total++;
+                bool anyCompilationFailed = false;
+                bool anyExecutionFailed = false;
+                foreach (CompilerRunner runner in _compilerRunners)
+                {
+                    bool compilationFailed = app.Compilations.Any(comp => comp[(int)runner.Index] != null && !comp[(int)runner.Index].Succeeded);
+                    if (compilationFailed)
+                    {
+                        outcomes[(int)Outcome.ILC_FAIL, (int)runner.Index]++;
+                        anyCompilationFailed = true;
+                    }
+                    bool executionFailed = (!compilationFailed &&
+                        app.Execution != null &&
+                        app.Execution[(int)runner.Index] != null &&
+                        !app.Execution[(int)runner.Index].Succeeded);
+                    if (executionFailed)
+                    {
+                        outcomes[(int)Outcome.EXE_FAIL, (int)runner.Index]++;
+                        anyExecutionFailed = true;
+                    }
+                    if (!compilationFailed && !executionFailed)
+                    {
+                        outcomes[(int)Outcome.PASS, (int)runner.Index]++;
+                    }
+                }
+                if (anyCompilationFailed)
+                {
+                    outcomes[(int)Outcome.ILC_FAIL, (int)CompilerIndex.Count]++;
+                }
+                else if (anyExecutionFailed)
+                {
+                    outcomes[(int)Outcome.EXE_FAIL, (int)CompilerIndex.Count]++;
+                }
+                else
+                {
+                    outcomes[(int)Outcome.PASS, (int)CompilerIndex.Count]++;
+                }
+            }
+
+            _logWriter.WriteLine();
+            _logWriter.Write($"{total,5} TOTAL |");
+            foreach (CompilerRunner runner in _compilerRunners)
+            {
+                _logWriter.Write($"{runner.CompilerName,8} |");
+            }
+            _logWriter.WriteLine(" Overall");
+            int lineSize = 10 * _compilerRunners.Count() + 13 + 8;
+            string separator = new string('-', lineSize);
+            _logWriter.WriteLine(separator);
+            for (int outcomeIndex = 0; outcomeIndex < (int)Outcome.Count; outcomeIndex++)
+            {
+                _logWriter.Write($"{((Outcome)outcomeIndex).ToString(),11} |");
+                foreach (CompilerRunner runner in _compilerRunners)
+                {
+                    _logWriter.Write($"{outcomes[outcomeIndex, (int)runner.Index],8} |");
+                }
+                _logWriter.WriteLine($"{outcomes[outcomeIndex, (int)CompilerIndex.Count],8}");
+            }
+
+            WriteJittedMethodSummary();
+
+            WriteTopRankingProcesses("compilations by duration", EnumerateCompilations());
+            WriteTopRankingProcesses("executions by duration", EnumerateExecutions());
+        }
+
+        private IEnumerable<ProcessInfo> EnumerateCompilations()
+        {
+            foreach (Application app in _applications)
+            {
+                foreach (ProcessInfo[] compilation in app.Compilations)
+                {
+                    foreach (CompilerRunner runner in _compilerRunners)
+                    {
+                        ProcessInfo compilationProcess = compilation[(int)runner.Index];
+                        if (compilationProcess != null)
+                        {
+                            yield return compilationProcess;
+                        }
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<ProcessInfo> EnumerateExecutions()
+        {
+            foreach (Application app in _applications)
+            {
+                foreach (CompilerRunner runner in _compilerRunners)
+                {
+                    ProcessInfo executionProcess = app.Execution[(int)runner.Index];
+                    if (executionProcess != null)
+                    {
+                        yield return executionProcess;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/ApplicationSet.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ApplicationSet.cs
@@ -58,6 +58,11 @@ namespace ReadyToRun.SuperIlc
 
             foreach (Application app in _applications)
             {
+                if (app.MainExecutable == null || app.Execution == null)
+                {
+                    continue;
+                }
+
                 Dictionary<string, HashSet<string>>[] appMethodsPerModulePerCompiler = new Dictionary<string, HashSet<string>>[(int)CompilerIndex.Count];
 
                 foreach (CompilerRunner runner in _compilerRunners)
@@ -94,6 +99,8 @@ namespace ReadyToRun.SuperIlc
                 }
             }
 
+            Console.WriteLine();
+            Console.WriteLine($"Building {_applications.Count()} apps ({compilationsToRun.Count} compilations total)");
             compilationsToRun.Sort((a, b) => b.CompilationCostHeuristic.CompareTo(a.CompilationCostHeuristic));
 
             ParallelRunner.Run(compilationsToRun);
@@ -338,12 +345,15 @@ namespace ReadyToRun.SuperIlc
         {
             foreach (Application app in _applications)
             {
-                foreach (CompilerRunner runner in _compilerRunners)
+                if (app.Execution != null)
                 {
-                    ProcessInfo executionProcess = app.Execution[(int)runner.Index];
-                    if (executionProcess != null)
+                    foreach (CompilerRunner runner in _compilerRunners)
                     {
-                        yield return executionProcess;
+                        ProcessInfo executionProcess = app.Execution[(int)runner.Index];
+                        if (executionProcess != null)
+                        {
+                            yield return executionProcess;
+                        }
                     }
                 }
             }

--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -29,11 +29,11 @@ namespace ReadyToRun.SuperIlc
                         CrossgenDirectory(),
                         CpaotDirectory(),
                         NoJit(),
-                        //NoExe(),
+                        NoExe(),
                         NoEtw(),
                         ReferencePath()
                     },
-                    handler: CommandHandler.Create<DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo, bool, /*bool,*/ bool, DirectoryInfo[]>(CompileDirectoryCommand.CompileDirectory));
+                    handler: CommandHandler.Create<BuildOptions>(CompileDirectoryCommand.CompileDirectory));
 
             Command CompileSubtree() =>
                 new Command("compile-subtree", "Build each directory in a given subtree containing any managed assemblies as a separate app",
@@ -44,19 +44,19 @@ namespace ReadyToRun.SuperIlc
                         CrossgenDirectory(),
                         CpaotDirectory(),
                         NoJit(),
-                        //NoExe(),
+                        NoExe(),
                         NoEtw(),
                         ReferencePath()
                     },
-                    handler: CommandHandler.Create<DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo, bool, /*bool,*/ bool, DirectoryInfo[]>(CompileSubtreeCommand.CompileSubtree));
+                    handler: CommandHandler.Create<BuildOptions>(CompileSubtreeCommand.CompileSubtree));
 
             // Todo: Input / Output directories should be required arguments to the command when they're made available to handlers
             // https://github.com/dotnet/command-line-api/issues/297
             Option InputDirectory() =>
-                new Option(new [] {"--input-directory", "-in"}, "Folder containing assemblies to optimize", new Argument<DirectoryInfo>().ExistingOnly());
+                new Option(new[] { "--input-directory", "-in" }, "Folder containing assemblies to optimize", new Argument<DirectoryInfo>().ExistingOnly());
 
             Option OutputDirectory() =>
-                new Option(new [] {"--output-directory", "-out"}, "Folder to emit compiled assemblies", new Argument<DirectoryInfo>().LegalFilePathsOnly());
+                new Option(new[] { "--output-directory", "-out" }, "Folder to emit compiled assemblies", new Argument<DirectoryInfo>().LegalFilePathsOnly());
 
             Option CrossgenDirectory() =>
                 new Option(new[] { "--crossgen-directory", "-crossgen" }, "Folder containing the Crossgen compiler", new Argument<DirectoryInfo>().ExistingOnly());
@@ -65,7 +65,7 @@ namespace ReadyToRun.SuperIlc
                 new Option(new[] { "--cpaot-directory", "-cpaot" }, "Folder containing the CPAOT compiler", new Argument<DirectoryInfo>().ExistingOnly());
 
             Option ReferencePath() =>
-                new Option(new[] {"--reference-path", "-r"}, "Folder containing assemblies to reference during compilation", new Argument<DirectoryInfo[]>(){Arity = ArgumentArity.ZeroOrMore}.ExistingOnly());
+                new Option(new[] { "--reference-path", "-r" }, "Folder containing assemblies to reference during compilation", new Argument<DirectoryInfo[]>() { Arity = ArgumentArity.ZeroOrMore }.ExistingOnly());
 
             Option NoJit() =>
                 new Option(new[] { "--nojit" }, "Don't run tests in JITted mode", new Argument<bool>());

--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -31,6 +31,7 @@ namespace ReadyToRun.SuperIlc
                         NoJit(),
                         NoExe(),
                         NoEtw(),
+                        NoCleanup(),
                         ReferencePath()
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileDirectoryCommand.CompileDirectory));
@@ -46,6 +47,7 @@ namespace ReadyToRun.SuperIlc
                         NoJit(),
                         NoExe(),
                         NoEtw(),
+                        NoCleanup(),
                         ReferencePath()
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileSubtreeCommand.CompileSubtree));
@@ -75,6 +77,9 @@ namespace ReadyToRun.SuperIlc
 
             Option NoExe() =>
                 new Option(new[] { "--noexe" }, "Compilation-only mode (don't execute the built apps)", new Argument<bool>());
+
+            Option NoCleanup() =>
+                new Option(new[] { "--nocleanup" }, "Don't clean up compilation artifacts after test runs", new Argument<bool>());
         }
     }
 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -15,21 +15,38 @@ namespace ReadyToRun.SuperIlc
         public static CommandLineBuilder Build()
         {
             var parser = new CommandLineBuilder()
-                .AddCommand(CompileFolder());
-            
+                .AddCommand(CompileFolder())
+                .AddCommand(CompileSubtree());
+
             return parser;
 
             Command CompileFolder() =>
-                new Command("compile-directory", "Compile all assemblies in directory", 
-                    new Option[] 
+                new Command("compile-directory", "Compile all assemblies in directory",
+                    new Option[]
                     {
                         InputDirectory(),
                         OutputDirectory(),
                         CrossgenDirectory(),
                         CpaotDirectory(),
+                        NoJit(),
+                        NoEtw(),
                         ReferencePath()
                     },
-                    handler: CommandHandler.Create<DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo[]>(CompileDirectoryCommand.CompileDirectory));
+                    handler: CommandHandler.Create<DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo, bool, bool, DirectoryInfo[]>(CompileDirectoryCommand.CompileDirectory));
+
+            Command CompileSubtree() =>
+                new Command("compile-subtree", "Build each directory in a given subtree containing any managed assemblies as a separate app",
+                    new Option[]
+                    {
+                        InputDirectory(),
+                        OutputDirectory(),
+                        CrossgenDirectory(),
+                        CpaotDirectory(),
+                        NoJit(),
+                        NoEtw(),
+                        ReferencePath()
+                    },
+                    handler: CommandHandler.Create<DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo, bool, bool, DirectoryInfo[]>(CompileSubtreeCommand.CompileSubtree));
 
             // Todo: Input / Output directories should be required arguments to the command when they're made available to handlers
             // https://github.com/dotnet/command-line-api/issues/297
@@ -47,6 +64,12 @@ namespace ReadyToRun.SuperIlc
 
             Option ReferencePath() =>
                 new Option(new[] {"--reference-path", "-r"}, "Folder containing assemblies to reference during compilation", new Argument<DirectoryInfo[]>(){Arity = ArgumentArity.ZeroOrMore}.ExistingOnly());
+
+            Option NoJit() =>
+                new Option(new[] { "--nojit" }, "Don't run tests in JITted mode", new Argument<bool>());
+
+            Option NoEtw() =>
+                new Option(new[] { "--noetw" }, "Don't capture jitted methods using ETW", new Argument<bool>());
         }
     }
 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -29,10 +29,11 @@ namespace ReadyToRun.SuperIlc
                         CrossgenDirectory(),
                         CpaotDirectory(),
                         NoJit(),
+                        //NoExe(),
                         NoEtw(),
                         ReferencePath()
                     },
-                    handler: CommandHandler.Create<DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo, bool, bool, DirectoryInfo[]>(CompileDirectoryCommand.CompileDirectory));
+                    handler: CommandHandler.Create<DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo, bool, /*bool,*/ bool, DirectoryInfo[]>(CompileDirectoryCommand.CompileDirectory));
 
             Command CompileSubtree() =>
                 new Command("compile-subtree", "Build each directory in a given subtree containing any managed assemblies as a separate app",
@@ -43,10 +44,11 @@ namespace ReadyToRun.SuperIlc
                         CrossgenDirectory(),
                         CpaotDirectory(),
                         NoJit(),
+                        //NoExe(),
                         NoEtw(),
                         ReferencePath()
                     },
-                    handler: CommandHandler.Create<DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo, bool, bool, DirectoryInfo[]>(CompileSubtreeCommand.CompileSubtree));
+                    handler: CommandHandler.Create<DirectoryInfo, DirectoryInfo, DirectoryInfo, DirectoryInfo, bool, /*bool,*/ bool, DirectoryInfo[]>(CompileSubtreeCommand.CompileSubtree));
 
             // Todo: Input / Output directories should be required arguments to the command when they're made available to handlers
             // https://github.com/dotnet/command-line-api/issues/297
@@ -70,6 +72,9 @@ namespace ReadyToRun.SuperIlc
 
             Option NoEtw() =>
                 new Option(new[] { "--noetw" }, "Don't capture jitted methods using ETW", new Argument<bool>());
+
+            Option NoExe() =>
+                new Option(new[] { "--noexe" }, "Compilation-only mode (don't execute the built apps)", new Argument<bool>());
         }
     }
 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
@@ -17,14 +17,13 @@ namespace ReadyToRun.SuperIlc
             DirectoryInfo outputDirectory,
             DirectoryInfo crossgenDirectory,
             DirectoryInfo cpaotDirectory,
+            bool noJit,
+            bool noEtw,
             DirectoryInfo[] referencePath)
         {
-            Stopwatch stopwatch = new Stopwatch();
-            stopwatch.Start();
-
             if (inputDirectory == null)
             {
-                Console.WriteLine("--input-directory is a required argument.");
+                Console.Error.WriteLine("--input-directory is a required argument.");
                 return 1;
             }
 
@@ -35,172 +34,27 @@ namespace ReadyToRun.SuperIlc
 
             if (outputDirectory.IsParentOf(inputDirectory))
             {
-                Console.WriteLine("Error: Input and output folders must be distinct, and the output directory (which gets deleted) better not be a parent of the input directory.");
+                Console.Error.WriteLine("Error: Input and output folders must be distinct, and the output directory (which gets deleted) better not be a parent of the input directory.");
                 return 1;
             }
 
             List<string> referencePaths = referencePath?.Select(x => x.ToString())?.ToList();
-            string coreRunPath = null;
-            foreach (string path in referencePaths)
+            string coreRunPath = SuperIlcHelpers.FindCoreRun(referencePaths);
+
+            IEnumerable<CompilerRunner> runners = SuperIlcHelpers.CompilerRunners(
+                inputDirectory.ToString(), outputDirectory.ToString(), cpaotDirectory.ToString(), crossgenDirectory.ToString(), noJit, referencePaths);
+
+            Application application = Application.FromDirectory(inputDirectory.FullName, runners, outputDirectory.FullName, noEtw, coreRunPath);
+            if (application == null)
             {
-                string candidatePath = Path.Combine(path, "CoreRun.exe");
-                if (File.Exists(candidatePath))
-                {
-                    coreRunPath = candidatePath;
-                    break;
-                }
+                Console.Error.WriteLine($"No managed app found in {inputDirectory.FullName}");
             }
+            string applicationSetLogPath = Path.Combine(inputDirectory.ToString(), "application-set.log");
 
-            if (coreRunPath == null)
+            using (ApplicationSet applicationSet = new ApplicationSet(new Application[] { application }, runners, coreRunPath, applicationSetLogPath))
             {
-                Console.Error.WriteLine("CoreRun.exe not found in reference folders, execution won't run");
+                return applicationSet.Build(coreRunPath, runners, applicationSetLogPath) ? 0 : 1;
             }
-
-            List<CompilerRunner> runners = new List<CompilerRunner>();
-            runners.Add(new JitRunner(null, inputDirectory.ToString(), outputDirectory.ToString(), referencePaths));
-
-            if (cpaotDirectory != null)
-            {
-                runners.Add(new CpaotRunner(cpaotDirectory.ToString(), inputDirectory.ToString(), outputDirectory.ToString(), referencePaths));
-            }
-            if (crossgenDirectory != null)
-            {
-                runners.Add(new CrossgenRunner(crossgenDirectory.ToString(), inputDirectory.ToString(), outputDirectory.ToString(), referencePaths));
-            }
-
-            List<string> compilationInputFiles = new List<string>();
-            List<string> passThroughFiles = new List<string>();
-            string mainExecutable = null;
-
-            // Copy unmanaged files (runtime, native dependencies, resources, etc)
-            foreach (string file in Directory.EnumerateFiles(inputDirectory.FullName))
-            {
-                bool isManagedAssembly = ComputeManagedAssemblies.IsManaged(file);
-                if (isManagedAssembly)
-                {
-                    compilationInputFiles.Add(file);
-                }
-                else
-                {
-                    passThroughFiles.Add(file);
-                }
-                if (Path.GetExtension(file).Equals(".exe", StringComparison.OrdinalIgnoreCase))
-                {
-                    mainExecutable = file;
-                }
-            }
-
-            foreach (CompilerRunner runner in runners)
-            {
-                string runnerOutputPath = runner.GetOutputPath();
-                runnerOutputPath.RecreateDirectory();
-                foreach (string file in passThroughFiles)
-                {
-                    File.Copy(file, Path.Combine(runnerOutputPath, Path.GetFileName(file)));
-                }
-            }
-
-            List<ProcessInfo> compilationsToRun = new List<ProcessInfo>();
-
-            Application application = new Application(compilationInputFiles, mainExecutable, runners, coreRunPath);
-            foreach (ProcessInfo[] compilation in application.Compilations)
-            {
-                foreach (CompilerRunner runner in runners)
-                {
-                    ProcessInfo compilationProcess = compilation[(int)runner.Index];
-                    if (compilationProcess != null)
-                    {
-                        compilationsToRun.Add(compilationProcess);
-                    }
-                }
-            }
-
-            compilationsToRun.Sort((a, b) => b.CompilationCostHeuristic.CompareTo(a.CompilationCostHeuristic));
-
-            ParallelRunner.Run(compilationsToRun);
-
-            bool success = true;
-            List<KeyValuePair<string, string>> failedCompilationsPerBuilder = new List<KeyValuePair<string, string>>();
-            int successfulCompileCount = 0;
-
-            foreach (ProcessInfo[] compilation in application.Compilations)
-            {
-                string file = null;
-                string failedBuilders = null;
-                foreach (CompilerRunner runner in runners)
-                {
-                    ProcessInfo runnerProcess = compilation[(int)runner.Index];
-                    if (runnerProcess != null && !runnerProcess.Succeeded)
-                    {
-                        File.Copy(runnerProcess.InputFileName, runnerProcess.OutputFileName);
-                        if (file == null)
-                        {
-                            file = runnerProcess.InputFileName;
-                            failedBuilders = runner.CompilerName;
-                        }
-                        else
-                        {
-                            failedBuilders += "; " + runner.CompilerName;
-                        }
-                    }
-                }
-                if (file != null)
-                {
-                    failedCompilationsPerBuilder.Add(new KeyValuePair<string, string>(file, failedBuilders));
-                    success = false;
-                }
-                else
-                {
-                    successfulCompileCount++;
-                }
-            }
-
-            Console.WriteLine($"Compiled {successfulCompileCount} / {successfulCompileCount + failedCompilationsPerBuilder.Count} assemblies in {stopwatch.ElapsedMilliseconds} msecs.");
-
-            if (failedCompilationsPerBuilder.Count > 0)
-            {
-                Console.WriteLine($"Failed to compile {failedCompilationsPerBuilder.Count} assemblies:");
-                foreach (KeyValuePair<string, string> assemblyBuilders in failedCompilationsPerBuilder)
-                {
-                    string assemblySpec = assemblyBuilders.Key;
-                    if (runners.Count > 1)
-                    {
-                        assemblySpec += " (" + assemblyBuilders.Value + ")";
-                    }
-                    Console.WriteLine(assemblySpec);
-                }
-            }
-
-            if (coreRunPath != null)
-            {
-                List<ProcessInfo> executionsToRun = new List<ProcessInfo>();
-                foreach (CompilerRunner runner in runners)
-                {
-                    bool compilationsSucceeded = application.Compilations.All(comp => comp[(int)runner.Index]?.Succeeded ?? true);
-                    if (compilationsSucceeded)
-                    {
-                        ProcessInfo executionProcess = application.Execution[(int)runner.Index];
-                        if (executionProcess != null)
-                        {
-                            executionsToRun.Add(executionProcess);
-                        }
-                    }
-                }
-
-                ParallelRunner.Run(executionsToRun);
-
-                Dictionary<string, HashSet<string>>[] jittedMethodsPerModulePerCompiler = new Dictionary<string, HashSet<string>>[(int)CompilerIndex.Count];
-                foreach (CompilerRunner runner in runners)
-                {
-                    Dictionary<string, HashSet<string>> jittedMethodsPerModule = new Dictionary<string, HashSet<string>>();
-                    jittedMethodsPerModulePerCompiler[(int)runner.Index] = jittedMethodsPerModule;
-                    application.AddModuleToJittedMethodsMapping(jittedMethodsPerModule, runner.Index);
-                }
-
-                application.WriteJitStatistics(jittedMethodsPerModulePerCompiler, runners.Select(runner => runner.Index));
-            }
-
-            return success ? 0 : 1;
         }
     }    
 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
@@ -18,9 +18,12 @@ namespace ReadyToRun.SuperIlc
             DirectoryInfo crossgenDirectory,
             DirectoryInfo cpaotDirectory,
             bool noJit,
+            //bool noExe,
             bool noEtw,
             DirectoryInfo[] referencePath)
         {
+            const bool noExe = false;
+
             if (inputDirectory == null)
             {
                 Console.Error.WriteLine("--input-directory is a required argument.");
@@ -44,12 +47,16 @@ namespace ReadyToRun.SuperIlc
             IEnumerable<CompilerRunner> runners = SuperIlcHelpers.CompilerRunners(
                 inputDirectory.ToString(), outputDirectory.ToString(), cpaotDirectory.ToString(), crossgenDirectory.ToString(), noJit, referencePaths);
 
-            Application application = Application.FromDirectory(inputDirectory.FullName, runners, outputDirectory.FullName, noEtw, coreRunPath);
+            PathExtensions.DeleteOutputFolders(inputDirectory.FullName, recursive: false);
+
+            Application application = Application.FromDirectory(inputDirectory.FullName, runners, outputDirectory.FullName, noExe, noEtw, coreRunPath);
             if (application == null)
             {
                 Console.Error.WriteLine($"No managed app found in {inputDirectory.FullName}");
             }
-            string applicationSetLogPath = Path.Combine(inputDirectory.ToString(), "application-set.log");
+
+            string timeStamp = DateTime.Now.ToString("MMDD-hhmm");
+            string applicationSetLogPath = Path.Combine(inputDirectory.ToString(), "directory-" + timeStamp + ".log");
 
             using (ApplicationSet applicationSet = new ApplicationSet(new Application[] { application }, runners, coreRunPath, applicationSetLogPath))
             {

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
@@ -34,10 +34,9 @@ namespace ReadyToRun.SuperIlc
             List<string> referencePaths = options.ReferencePath?.Select(x => x.ToString())?.ToList();
             string coreRunPath = SuperIlcHelpers.FindCoreRun(referencePaths);
 
-            IEnumerable<CompilerRunner> runners = SuperIlcHelpers.CompilerRunners(
-                options.InputDirectory.ToString(), options.OutputDirectory.ToString(), options.CpaotDirectory.ToString(), options.CrossgenDirectory.ToString(), options.NoJit, referencePaths);
+            IEnumerable<CompilerRunner> runners = options.CompilerRunners();
 
-            PathExtensions.DeleteOutputFolders(options.InputDirectory.FullName, recursive: false);
+            PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, recursive: false);
 
             Application application = Application.FromDirectory(options.InputDirectory.FullName, runners, options.OutputDirectory.FullName, options.NoExe, options.NoEtw, coreRunPath);
             if (application == null)
@@ -50,7 +49,14 @@ namespace ReadyToRun.SuperIlc
 
             using (ApplicationSet applicationSet = new ApplicationSet(new Application[] { application }, runners, coreRunPath, applicationSetLogPath))
             {
-                return applicationSet.Build(coreRunPath, runners, applicationSetLogPath) ? 0 : 1;
+                bool success = applicationSet.Build(coreRunPath, runners, applicationSetLogPath);
+
+                if (!options.NoCleanup)
+                {
+                    PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, recursive: false);
+                }
+
+                return success ? 0 : 1;
             }
         }
     }    

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
@@ -54,6 +54,7 @@ namespace ReadyToRun.SuperIlc
 
             List<Application> applications = new List<Application>();
             int relativePathOffset = directories[0].Length + 1;
+            int count = 0;
             foreach (string directory in directories)
             {
                 string outputDirectoryPerApp = outputDirectory.FullName;
@@ -65,6 +66,10 @@ namespace ReadyToRun.SuperIlc
                 if (application != null)
                 {
                     applications.Add(application);
+                }
+                if (++count % 100 == 0)
+                {
+                    Console.WriteLine($@"Found {applications.Count} apps in {count} folders");
                 }
             }
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace ReadyToRun.SuperIlc
+{
+    class CompileSubtreeCommand
+    {
+        public static int CompileSubtree(
+            DirectoryInfo inputDirectory,
+            DirectoryInfo outputDirectory,
+            DirectoryInfo crossgenDirectory,
+            DirectoryInfo cpaotDirectory,
+            bool noJit,
+            bool noEtw,
+            DirectoryInfo[] referencePath)
+        {
+            if (inputDirectory == null)
+            {
+                Console.WriteLine("--input-directory is a required argument.");
+                return 1;
+            }
+
+            if (outputDirectory == null)
+            {
+                outputDirectory = inputDirectory;
+            }
+
+            if (outputDirectory.IsParentOf(inputDirectory))
+            {
+                Console.WriteLine("Error: Input and output folders must be distinct, and the output directory (which gets deleted) better not be a parent of the input directory.");
+                return 1;
+            }
+
+            List<string> referencePaths = referencePath?.Select(x => x.ToString())?.ToList();
+            string coreRunPath = SuperIlcHelpers.FindCoreRun(referencePaths);
+
+            IEnumerable<CompilerRunner> runners = SuperIlcHelpers.CompilerRunners(
+                inputDirectory.ToString(), outputDirectory.ToString(), cpaotDirectory?.ToString(), crossgenDirectory?.ToString(), noJit, referencePaths);
+
+            string[] directories = new string[] { inputDirectory.FullName }
+                .Concat(
+                    inputDirectory
+                        .EnumerateDirectories("*", SearchOption.AllDirectories)
+                        .Select(dirInfo => dirInfo.FullName)
+                        .Where(path => !Path.GetExtension(path).Equals(".out", StringComparison.OrdinalIgnoreCase)))
+                .ToArray();
+
+            List<Application> applications = new List<Application>();
+            int relativePathOffset = directories[0].Length + 1;
+            foreach (string directory in directories)
+            {
+                string outputDirectoryPerApp = outputDirectory.FullName;
+                if (directory.Length > relativePathOffset)
+                {
+                    outputDirectoryPerApp = Path.Combine(outputDirectoryPerApp, directory.Substring(relativePathOffset));
+                }
+                Application application = Application.FromDirectory(directory.ToString(), runners, outputDirectoryPerApp, noEtw, coreRunPath);
+                if (application != null)
+                {
+                    applications.Add(application);
+                }
+            }
+
+            string applicationSetLogPath = Path.Combine(inputDirectory.ToString(), "application-set.log");
+
+            using (ApplicationSet applicationSet = new ApplicationSet(applications, runners, coreRunPath, applicationSetLogPath))
+            {
+                return applicationSet.Build(coreRunPath, runners, applicationSetLogPath) ? 0 : 1;
+            }
+        }
+    }
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -19,19 +19,15 @@ public enum CompilerIndex
 public abstract class CompilerRunner
 {
     protected string _compilerPath;
-    protected string _inputPath;
-    protected string _outputPath;
-    protected IReadOnlyList<string> _referenceFolders;
+    protected IEnumerable<string> _referenceFolders;
 
-    public CompilerRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders)
+    public CompilerRunner(string compilerFolder, IEnumerable<string> referenceFolders)
     {
         _compilerPath = compilerFolder;
-        _inputPath = inputFolder;
-        _outputPath = outputFolder;
-        _referenceFolders = referenceFolders ?? new List<string>();
+        _referenceFolders = referenceFolders;
     }
 
-    public IReadOnlyList<string> ReferenceFolders => _referenceFolders;
+    public IEnumerable<string> ReferenceFolders => _referenceFolders;
 
     public abstract CompilerIndex Index { get;  }
 
@@ -40,12 +36,12 @@ public abstract class CompilerRunner
     protected abstract string CompilerFileName {get;}
     protected abstract IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName);
 
-    public virtual ProcessInfo CompilationProcess(string assemblyFileName)
+    public virtual ProcessInfo CompilationProcess(string outputRoot, string assemblyFileName)
     {
-        CreateOutputFolder();
+        CreateOutputFolder(outputRoot);
 
-        string outputFileName = GetOutputFileName(assemblyFileName);
-        string responseFile = GetResponseFileName(assemblyFileName);
+        string outputFileName = GetOutputFileName(outputRoot, assemblyFileName);
+        string responseFile = GetResponseFileName(outputRoot, assemblyFileName);
         var commandLineArgs = BuildCommandLineArguments(assemblyFileName, outputFileName);
         CreateResponseFile(responseFile, commandLineArgs);
 
@@ -62,12 +58,13 @@ public abstract class CompilerRunner
         return processInfo;
     }
 
-    public virtual ProcessInfo ExecutionProcess(string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath)
+    public virtual ProcessInfo ExecutionProcess(string outputRoot, string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath, bool noEtw)
     {
-        string exeToRun = GetOutputFileName(appPath);
+        string exeToRun = GetOutputFileName(outputRoot, appPath);
         ProcessInfo processInfo = new ProcessInfo();
         processInfo.ProcessPath = coreRunPath;
         processInfo.Arguments = exeToRun;
+        processInfo.InputFileName = exeToRun;
 
         if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("__GCSTRESSLEVEL")))
         {
@@ -84,16 +81,19 @@ public abstract class CompilerRunner
         processInfo.UseShellExecute = false;
         processInfo.LogPath = Path.ChangeExtension(exeToRun, ".exe.log");
         processInfo.ExpectedExitCode = 100;
-        processInfo.CollectJittedMethods = true;
-        processInfo.MonitorModules = modules;
-        processInfo.MonitorFolders = folders;
+        processInfo.CollectJittedMethods = !noEtw;
+        if (!noEtw)
+        {
+            processInfo.MonitorModules = modules;
+            processInfo.MonitorFolders = folders;
+        }
 
         return processInfo;
     }
 
-    public void CreateOutputFolder()
+    public void CreateOutputFolder(string outputRoot)
     {
-        string outputPath = GetOutputPath();
+        string outputPath = GetOutputPath(outputRoot);
         if (!Directory.Exists(outputPath))
         {
             Directory.CreateDirectory(outputPath);
@@ -111,12 +111,12 @@ public abstract class CompilerRunner
         }
     }
 
-    public string GetOutputPath() => Path.Combine(_outputPath, CompilerName);
+    public string GetOutputPath(string outputRoot) => Path.Combine(outputRoot, CompilerName + ".out");
 
     // <input>\a.dll -> <output>\a.dll
-    public string GetOutputFileName(string fileName) =>
-        Path.Combine(GetOutputPath(), $"{Path.GetFileName(fileName)}"); 
+    public string GetOutputFileName(string outputRoot, string fileName) =>
+        Path.Combine(GetOutputPath(outputRoot), $"{Path.GetFileName(fileName)}"); 
 
-    public string GetResponseFileName(string assemblyFileName) =>
-        Path.Combine(GetOutputPath(), Path.GetFileNameWithoutExtension(assemblyFileName) + ".rsp");
+    public string GetResponseFileName(string outputRoot, string assemblyFileName) =>
+        Path.Combine(GetOutputPath(outputRoot), Path.GetFileNameWithoutExtension(assemblyFileName) + ".rsp");
 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 /// <summary>
 /// Compiles assemblies using the Cross-Platform AOT compiler
@@ -14,11 +15,12 @@ class CpaotRunner : CompilerRunner
 
     protected override string CompilerFileName => "ilc.exe";
 
-    public CpaotRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders) : base(compilerFolder, inputFolder, outputFolder, referenceFolders) {}
+    public CpaotRunner(string compilerFolder, IEnumerable<string> referenceFolders) 
+        : base(compilerFolder, referenceFolders) {}
 
-    public override ProcessInfo ExecutionProcess(string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath)
+    public override ProcessInfo ExecutionProcess(string outputRoot, string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath, bool noEtw)
     {
-        ProcessInfo processInfo = base.ExecutionProcess(appPath, modules, folders, coreRunPath);
+        ProcessInfo processInfo = base.ExecutionProcess(outputRoot, appPath, modules, folders, coreRunPath, noEtw);
         processInfo.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "1";
         return processInfo;
     }
@@ -40,7 +42,7 @@ class CpaotRunner : CompilerRunner
         yield return "--targetarch=x64";
         yield return "--stacktracedata";
 
-        foreach (var reference in ComputeManagedAssemblies.GetManagedAssembliesInFolder(_inputPath))
+        foreach (var reference in ComputeManagedAssemblies.GetManagedAssembliesInFolder(Path.GetDirectoryName(assemblyFileName)))
         {
             yield return $"-r:{reference}";
         }

--- a/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 /// <summary>
@@ -16,11 +17,12 @@ class CrossgenRunner : CompilerRunner
 
     protected override string CompilerFileName => "crossgen.exe";
 
-    public CrossgenRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders) : base(compilerFolder, inputFolder, outputFolder, referenceFolders) {}
+    public CrossgenRunner(string compilerFolder, IEnumerable<string> referenceFolders) 
+        : base(compilerFolder, referenceFolders) {}
 
-    public override ProcessInfo ExecutionProcess(string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath)
+    public override ProcessInfo ExecutionProcess(string outputRoot, string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath, bool noEtw)
     {
-        ProcessInfo processInfo = base.ExecutionProcess(appPath, modules, folders, coreRunPath);
+        ProcessInfo processInfo = base.ExecutionProcess(outputRoot, appPath, modules, folders, coreRunPath, noEtw);
         processInfo.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "1";
         return processInfo;
     }
@@ -38,7 +40,7 @@ class CrossgenRunner : CompilerRunner
         yield return "/platform_assemblies_paths";
         
         StringBuilder sb = new StringBuilder();
-        sb.Append(_inputPath + (_referenceFolders.Count > 0 ? ";" : ""));
+        sb.Append(Path.GetDirectoryName(assemblyFileName) + (_referenceFolders.Any() ? ";" : ""));
         sb.AppendJoin(';', _referenceFolders);
         yield return sb.ToString();
     }

--- a/tests/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
@@ -15,21 +15,21 @@ class JitRunner : CompilerRunner
 
     protected override string CompilerFileName => "clrjit.dll";
 
-    public JitRunner(string compilerFolder, string inputFolder, string outputFolder, IReadOnlyList<string> referenceFolders) : base(compilerFolder, inputFolder, outputFolder, referenceFolders) { }
+    public JitRunner(IEnumerable<string> referenceFolders) : base(null, referenceFolders) { }
 
     /// <summary>
     /// JIT runner has no compilation process as it doesn't transform the source IL code in any manner.
     /// </summary>
     /// <returns></returns>
-    public override ProcessInfo CompilationProcess(string assemblyFileName)
+    public override ProcessInfo CompilationProcess(string outputRoot, string assemblyFileName)
     {
-        File.Copy(assemblyFileName, GetOutputFileName(assemblyFileName));
+        File.Copy(assemblyFileName, GetOutputFileName(outputRoot, assemblyFileName), overwrite: true);
         return null;
     }
 
-    public override ProcessInfo ExecutionProcess(string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath)
+    public override ProcessInfo ExecutionProcess(string outputRoot, string appPath, IEnumerable<string> modules, IEnumerable<string> folders, string coreRunPath, bool noEtw)
     {
-        ProcessInfo processInfo = base.ExecutionProcess(appPath, modules, folders, coreRunPath);
+        ProcessInfo processInfo = base.ExecutionProcess(outputRoot, appPath, modules, folders, coreRunPath, noEtw);
         processInfo.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "0";
         return processInfo;
     }

--- a/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
@@ -80,6 +80,19 @@ static class PathExtensions
         return false;
     }
 
+    public static string FindFile(this string fileName, IEnumerable<string> paths)
+    {
+        foreach (string path in paths)
+        {
+            string fileOnPath = Path.Combine(path, fileName);
+            if (File.Exists(fileOnPath))
+            {
+                return fileOnPath;
+            }
+        }
+        return null;
+    }
+
     /// <summary>
     /// Asynchronous task for subtree deletion.
     /// </summary>

--- a/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -94,57 +95,75 @@ static class PathExtensions
     }
 
     /// <summary>
-    /// Asynchronous task for subtree deletion.
+    /// Parallel deletion of multiple disjunct subtrees.
     /// </summary>
-    /// <param name="path">Directory to delete</param>
+    /// <param name="path">List of directories to delete</param>
     /// <returns>Task returning true on success, false on failure</returns>
-    public static async Task<bool> DeleteSubtree(this string path)
+    public static bool DeleteSubtrees(this string[] paths)
+    {
+        return DeleteSubtreesAsync(paths).Result;
+    }
+
+    private static async Task<bool> DeleteSubtreesAsync(this string[] paths)
     {
         bool succeeded = true;
 
-        try
+        var tasks = new List<Task<bool>>();
+        foreach (string path in paths)
         {
-            if (!Directory.Exists(path))
+            try
             {
-                // Non-existent folders are harmless w.r.t. deletion
-                Console.WriteLine("Skipping non-existent folder: '{0}'", path);
-                return succeeded;
+                if (!Directory.Exists(path))
+                {
+                    // Non-existent folders are harmless w.r.t. deletion
+                    Console.WriteLine("Skipping non-existent folder: '{0}'", path);
+                }
+                else
+                {
+                    Console.WriteLine("Deleting '{0}'", path);
+                    tasks.Add(path.DeleteSubtree());
+                }
             }
-            Console.WriteLine("Deleting '{0}'", path);
-            var tasks = new List<Task<bool>>();
-            foreach (string subfolder in Directory.EnumerateDirectories(path))
+            catch (Exception ex)
             {
-                tasks.Add(Task<bool>.Run(() => subfolder.DeleteSubtree()));
-            }
-            string[] files = Directory.GetFiles(path);
-            foreach (string file in files)
-            {
-                tasks.Add(Task<bool>.Run(() => file.DeleteFile()));
-            }
-
-            await Task<bool>.WhenAll(tasks);
-
-            foreach (var task in tasks)
-            {
-                if (!task.Result)
-                    succeeded = false;
+                Console.Error.WriteLine("Error deleting '{0}': {1}", path, ex.Message);
+                succeeded = false;
             }
         }
-        catch (Exception ex)
+
+        await Task<bool>.WhenAll(tasks);
+
+        foreach (var task in tasks)
         {
-            Console.Error.WriteLine("Error deleting '{0}': {1}", path, ex.Message);
-            succeeded = false;
+            if (!task.Result)
+            {
+                succeeded = false;
+                break;
+            }
         }
+        return succeeded;
+    }
+
+    private static async Task<bool> DeleteSubtree(this string folder)
+    {
+        Task<bool>[] subtasks = new []
+        {
+            DeleteSubtreesAsync(Directory.GetDirectories(folder)),
+            DeleteFiles(Directory.GetFiles(folder))
+        };
+
+        await Task<bool>.WhenAll(subtasks);
+        bool succeeded = subtasks.All(subtask => subtask.Result);
 
         if (succeeded)
         {
             Stopwatch folderDeletion = new Stopwatch();
             folderDeletion.Start();
-            while (Directory.Exists(path))
+            while (Directory.Exists(folder))
             {
                 try
                 {
-                    Directory.Delete(path, recursive: false);
+                    Directory.Delete(folder, recursive: false);
                 }
                 catch (DirectoryNotFoundException)
                 {
@@ -152,17 +171,17 @@ static class PathExtensions
                 }
                 catch (Exception)
                 {
-                    Console.WriteLine("Folder deletion failure, maybe transient ({0} msecs): '{1}'", folderDeletion.ElapsedMilliseconds, path);
+                    Console.WriteLine("Folder deletion failure, maybe transient ({0} msecs): '{1}'", folderDeletion.ElapsedMilliseconds, folder);
                 }
 
-                if (!Directory.Exists(path))
+                if (!Directory.Exists(folder))
                 {
                     break;
                 }
 
                 if (folderDeletion.ElapsedMilliseconds > DeletionTimeoutMilliseconds)
                 {
-                    Console.Error.WriteLine("Timed out trying to delete directory '{0}'", path);
+                    Console.Error.WriteLine("Timed out trying to delete directory '{0}'", folder);
                     succeeded = false;
                     break;
                 }
@@ -172,6 +191,18 @@ static class PathExtensions
         }
 
         return succeeded;
+    }
+
+    private static async Task<bool> DeleteFiles(string[] files)
+    {
+        Task<bool>[] tasks = new Task<bool>[files.Length];
+        for (int i = 0; i < files.Length; i++)
+        {
+            int temp = i;
+            tasks[i] = Task<bool>.Run(() => files[temp].DeleteFile());
+        }
+        await Task<bool>.WhenAll(tasks);
+        return tasks.All(task => task.Result);
     }
 
     private static bool DeleteFile(this string file)
@@ -184,6 +215,32 @@ static class PathExtensions
         catch (Exception ex)
         {
             Console.Error.WriteLine($"{file}: {ex.Message}");
+            return false;
+        }
+    }
+
+    public static string[] LocateOutputFolders(string folder, bool recursive)
+    {
+        return Directory.GetDirectories(folder, "*.out", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+    }
+
+    public static bool DeleteOutputFolders(string folder, bool recursive)
+    {
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.Start();
+
+        Console.WriteLine("Locating output {0} {1}", (recursive ? "subtree" : "folder"), folder);
+        string[] outputFolders = LocateOutputFolders(folder, recursive);
+        Console.WriteLine("Deleting {0} output folders", outputFolders.Length);
+
+        if (DeleteSubtrees(outputFolders))
+        {
+            Console.WriteLine("Successfully deleted {0} output folders in {1} msecs", outputFolders.Length, stopwatch.ElapsedMilliseconds);
+            return true;
+        }
+        else
+        {
+            Console.Error.WriteLine("Failed deleting {0} output folders in {1} msecs", outputFolders.Length, stopwatch.ElapsedMilliseconds);
             return false;
         }
     }

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -217,7 +217,6 @@ public class ProcessRunner : IDisposable
         if (!string.IsNullOrEmpty(eventArgs.Data))
         {
             _logWriter.WriteLine(eventArgs.Data);
-            Console.Out.WriteLine(_processIndex.ToString() + ": " + eventArgs.Data);
         }
     }
 
@@ -226,7 +225,6 @@ public class ProcessRunner : IDisposable
         if (!string.IsNullOrEmpty(eventArgs.Data))
         {
             _logWriter.WriteLine(eventArgs.Data);
-            Console.Error.WriteLine(_processIndex.ToString() + ": " + eventArgs.Data);
         }
     }
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -155,8 +155,12 @@ public class ProcessRunner : IDisposable
     {
         try
         {
-            Task.Delay(_processInfo.TimeoutMilliseconds, _cancellationTokenSource.Token).Wait();
-            StopProcessAtomic();
+            CancellationTokenSource source = _cancellationTokenSource;
+            if (source != null)
+            {
+                Task.Delay(_processInfo.TimeoutMilliseconds, source.Token).Wait();
+                StopProcessAtomic();
+            }
         }
         catch (TaskCanceledException)
         {

--- a/tests/src/tools/ReadyToRun.SuperIlc/Program.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/Program.cs
@@ -13,14 +13,7 @@ namespace ReadyToRun.SuperIlc
     {
         static async Task<int> Main(string[] args)
         {
-            var parser = CommandLineOptions.Build()
-                .UseHelp()
-                .UseParseDirective()
-                .UseSuggestDirective()
-                .UseParseErrorReporting()
-                .UseExceptionHandler()
-                .UseTypoCorrections()
-                .Build();
+            var parser = CommandLineOptions.Build().UseDefaults().Build();
 
             return await parser.InvokeAsync(args);
         }

--- a/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRun.SuperIlc.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.38" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.1.0-alpha-63724-02" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19174.3" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
   </ItemGroup>
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRunJittedMethods.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRunJittedMethods.cs
@@ -30,14 +30,14 @@ public class ReadyToRunJittedMethods : IDisposable
     private HashSet<string> _testFolderNames;
     private List<long> _testModuleIds = new List<long>();
     private Dictionary<long, string> _testModuleIdToName = new Dictionary<long, string>();
-    private Dictionary<string, HashSet<string>> _methodsJitted = new Dictionary<string, HashSet<string>>();
+    private Dictionary<string, HashSet<string>> _methodsJitted = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
     public ReadyToRunJittedMethods(TraceEventSession session, IEnumerable<ProcessInfo> processes)
     {
         _etwProcesses = new List<Process>();
         _pidToProcess = new Dictionary<int, ProcessInfo>();
-        _testModuleNames = new HashSet<string>();
-        _testFolderNames = new HashSet<string>();
+        _testModuleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        _testFolderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (ProcessInfo process in processes)
         {
@@ -70,7 +70,7 @@ public class ReadyToRunJittedMethods : IDisposable
                 string moduleName = _testModuleIdToName[data.ModuleID];
                 if (processInfo.JittedMethods == null)
                 {
-                    processInfo.JittedMethods = new Dictionary<string, HashSet<string>>();
+                    processInfo.JittedMethods = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
                 }
                 HashSet<string> methodsForModule;
                 if (!processInfo.JittedMethods.TryGetValue(moduleName, out methodsForModule))
@@ -102,10 +102,10 @@ public class ReadyToRunJittedMethods : IDisposable
         if (!_pidToProcess.ContainsKey(data.ProcessID))
             return false;
 
-        if (File.Exists(data.ModuleILPath) && _testFolderNames.Contains(Path.GetDirectoryName(data.ModuleILPath).ToAbsoluteDirectoryPath().ToLower()))
+        if (File.Exists(data.ModuleILPath) && _testFolderNames.Contains(Path.GetDirectoryName(data.ModuleILPath).ToAbsoluteDirectoryPath()))
             return true;
 
-        if (_testModuleNames.Contains(data.ModuleILPath.ToLower()) || _testModuleNames.Contains(data.ModuleNativePath.ToLower()))
+        if (_testModuleNames.Contains(data.ModuleILPath) || _testModuleNames.Contains(data.ModuleNativePath))
             return true;
 
         return false;

--- a/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
@@ -1,9 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 
 namespace ReadyToRun.SuperIlc
 {
+    public class BuildOptions
+    {
+        public DirectoryInfo InputDirectory { get; set; }
+        public DirectoryInfo OutputDirectory { get; set; }
+        public DirectoryInfo CrossgenDirectory { get; set; }
+        public DirectoryInfo CpaotDirectory { get; set; }
+        public bool NoJit { get; set; }
+        public bool NoExe { get; set; }
+        public bool NoEtw { get; set; }
+        public DirectoryInfo[] ReferencePath { get; set; }
+    }
+
     public static class SuperIlcHelpers
     {
         public static IEnumerable<CompilerRunner> CompilerRunners(

--- a/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace ReadyToRun.SuperIlc
@@ -14,39 +15,35 @@ namespace ReadyToRun.SuperIlc
         public bool NoJit { get; set; }
         public bool NoExe { get; set; }
         public bool NoEtw { get; set; }
+        public bool NoCleanup { get; set; }
         public DirectoryInfo[] ReferencePath { get; set; }
-    }
 
-    public static class SuperIlcHelpers
-    {
-        public static IEnumerable<CompilerRunner> CompilerRunners(
-            string inputDirectory, 
-            string outputDirectory, 
-            string cpaotDirectory, 
-            string crossgenDirectory, 
-            bool noJit,
-            IEnumerable<string> referencePaths)
+        public IEnumerable<CompilerRunner> CompilerRunners()
         {
             List<CompilerRunner> runners = new List<CompilerRunner>();
+            List<string> referencePaths = ReferencePath?.Select(x => x.ToString())?.ToList();
 
-            if (cpaotDirectory != null)
+            if (CpaotDirectory != null)
             {
-                runners.Add(new CpaotRunner(cpaotDirectory, referencePaths));
+                runners.Add(new CpaotRunner(CpaotDirectory.FullName, referencePaths));
             }
 
-            if (crossgenDirectory != null)
+            if (CrossgenDirectory != null)
             {
-                runners.Add(new CrossgenRunner(crossgenDirectory, referencePaths));
+                runners.Add(new CrossgenRunner(CrossgenDirectory.FullName, referencePaths));
             }
 
-            if (!noJit)
+            if (!NoJit)
             {
                 runners.Add(new JitRunner(referencePaths));
             }
 
             return runners;
         }
+    }
 
+    public static class SuperIlcHelpers
+    {
         public static string FindCoreRun(IEnumerable<string> referencePaths)
         {
             string coreRunPath = "CoreRun.exe".FindFile(referencePaths);

--- a/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ReadyToRun.SuperIlc
+{
+    public static class SuperIlcHelpers
+    {
+        public static IEnumerable<CompilerRunner> CompilerRunners(
+            string inputDirectory, 
+            string outputDirectory, 
+            string cpaotDirectory, 
+            string crossgenDirectory, 
+            bool noJit,
+            IEnumerable<string> referencePaths)
+        {
+            List<CompilerRunner> runners = new List<CompilerRunner>();
+
+            if (cpaotDirectory != null)
+            {
+                runners.Add(new CpaotRunner(cpaotDirectory, referencePaths));
+            }
+
+            if (crossgenDirectory != null)
+            {
+                runners.Add(new CrossgenRunner(crossgenDirectory, referencePaths));
+            }
+
+            if (!noJit)
+            {
+                runners.Add(new JitRunner(referencePaths));
+            }
+
+            return runners;
+        }
+
+        public static string FindCoreRun(IEnumerable<string> referencePaths)
+        {
+            string coreRunPath = "CoreRun.exe".FindFile(referencePaths);
+            if (coreRunPath == null)
+            {
+                Console.Error.WriteLine("CoreRun.exe not found in reference folders, execution won't run");
+            }
+            return coreRunPath;
+        }
+    }
+}


### PR DESCRIPTION
This change introduces a new helper class, ApplicationSet,
representing an arbitrary number of apps. This change let me
add support for building and summarizing a larger number of apps.

I had to decouple the compiler runners from the input / output
path pair as these vary for the individual apps within the
set (right now the logic is that basically one folder = one app).

I have added a new switch compile-subtree and two new options
--nojit and --noetw with hopefully self-explanatory purpose.
I haven't yet integrated the bucketing logic as I need to switch
over to actually measuring the statistics and working on the
presentation.

Thanks

Tomas