### PR TITLE
Add option to remove CurlHandler

### DIFF
--- a/samples/prerequisites.md
+++ b/samples/prerequisites.md
@@ -12,7 +12,7 @@ The following pre-requisites need to be installed for building .NET Core project
 * Install clang and developer packages for libraries that .NET Core depends on.
 
 ```sh
-sudo apt-get install clang-3.9 libcurl4-openssl-dev zlib1g-dev libkrb5-dev
+sudo apt-get install clang-3.9 zlib1g-dev libkrb5-dev
 ```
 
 # macOS (10.12+)

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -60,12 +60,16 @@ See the LICENSE file in the project root for more information.
     </ItemGroup>
 
     <ItemGroup>
+      <!-- Workaround for https://github.com/dotnet/corert/issues/7000 -->
+      <IlcArg Include="--removefeature:CurlHandler" />
+    </ItemGroup>
+
+    <ItemGroup>
       <NativeLibrary Include="$(IlcPath)/sdk/libSystem.Private.CoreLib.Native$(NativeLibraryExtension)" />
       <NativeLibrary Condition="$(NativeCodeGen) == ''" Include="$(IlcPath)/sdk/libSystem.Private.TypeLoader.Native$(NativeLibraryExtension)" />
       <NativeLibrary Include="$(IlcPath)/framework/System.Native$(NativeLibraryExtension)" />
       <NativeLibrary Include="$(IlcPath)/framework/System.Globalization.Native$(NativeLibraryExtension)" />
       <NativeLibrary Include="$(IlcPath)/framework/System.IO.Compression.Native$(NativeLibraryExtension)" />
-      <NativeLibrary Include="$(IlcPath)/framework/System.Net.Http.Native$(NativeLibraryExtension)" />
       <NativeLibrary Include="$(IlcPath)/framework/System.Net.Security.Native$(NativeLibraryExtension)" />
       <NativeLibrary Include="$(IlcPath)/framework/System.Security.Cryptography.Native.Apple$(NativeLibraryExtension)" Condition="'$(TargetOS)' == 'OSX'"/>
       <NativeLibrary Include="$(IlcPath)/framework/System.Security.Cryptography.Native.OpenSsl$(NativeLibraryExtension)" Condition="'$(TargetOS)' != 'OSX'"/>
@@ -86,7 +90,6 @@ See the LICENSE file in the project root for more information.
       <LinkerArg Include="-lstdc++" />
       <LinkerArg Include="-ldl" />
       <LinkerArg Include="-lm" />
-      <LinkerArg Include="-lcurl" />
       <LinkerArg Include="-lz" />
       <LinkerArg Include="-lgssapi_krb5" Condition="'$(TargetOS)' != 'OSX'" />
       <LinkerArg Include="-lrt" Condition="'$(TargetOS)' != 'OSX'" />

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -495,6 +495,8 @@ namespace ILCompiler
                     removedFeatures |= RemovedFeature.Globalization;
                 else if (feature == "Comparers")
                     removedFeatures |= RemovedFeature.Comparers;
+                else if (feature == "CurlHandler")
+                    removedFeatures |= RemovedFeature.CurlHandler;
             }
 
             ILProvider ilProvider = _isReadyToRunCodeGen ? (ILProvider)new ReadyToRunILProvider() : new CoreRTILProvider();

--- a/src/ILCompiler/src/RemovingILProvider.cs
+++ b/src/ILCompiler/src/RemovingILProvider.cs
@@ -168,7 +168,7 @@ namespace ILCompiler
 
             if ((_removedFeature & RemovedFeature.CurlHandler) != 0)
             {
-                if (owningType.GetTypeDefinition() is Internal.TypeSystem.Ecma.EcmaType mdType
+                if (owningType is Internal.TypeSystem.Ecma.EcmaType mdType
                     && mdType.Module.Assembly.GetName().Name == "System.Net.Http"
                     && mdType.Name == "CurlHandler"
                     && mdType.Namespace == "System.Net.Http")

--- a/src/ILCompiler/src/RemovingILProvider.cs
+++ b/src/ILCompiler/src/RemovingILProvider.cs
@@ -166,6 +166,17 @@ namespace ILCompiler
                 }
             }
 
+            if ((_removedFeature & RemovedFeature.CurlHandler) != 0)
+            {
+                if (owningType.GetTypeDefinition() is Internal.TypeSystem.Ecma.EcmaType mdType
+                    && mdType.Module.Assembly.GetName().Name == "System.Net.Http"
+                    && mdType.Name == "CurlHandler"
+                    && mdType.Namespace == "System.Net.Http")
+                {
+                    return RemoveAction.ConvertToThrow;
+                }
+            }
+
             return RemoveAction.Nothing;
         }
 
@@ -217,5 +228,6 @@ namespace ILCompiler
         FrameworkResources = 0x2,
         Globalization = 0x4,
         Comparers = 0x8,
+        CurlHandler = 0x10,
     }
 }


### PR DESCRIPTION
Workaround for https://github.com/dotnet/corert/issues/7000. The CurlHandle is on its path to extinction. Until that happens, add an option to strip it manually.