### PR TITLE
Add option to enable method body folding

### DIFF
--- a/Documentation/using-corert/optimizing-corert.md
+++ b/Documentation/using-corert/optimizing-corert.md
@@ -13,3 +13,4 @@ By default, the compiler tries to maximize compatibility with existing .NET code
 ## Options related to code generation
 * `<IlcOptimizationPreference>Speed</IlcOptimizationPreference>`: when generating optimized code, favor code execution speed.
 * `<IlcOptimizationPreference>Size</IlcOptimizationPreference>`: when generating optimized code, favor smaller code size.
+* `<IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>`: folds method bodies with identical bytes (method body deduplication). With this option, stack traces might sometimes look nonsensical (unexpected methods might show up in the stack trace because the expected method had the same bytes as the unexpected method). Note: the current implementation of deduplication doesn't attempt to make the folding unobservable to managed code: delegates pointing to two logically different methods that ended up being folded together will compare equal.

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -206,6 +206,7 @@ See the LICENSE file in the project root for more information.
       <IlcArg Condition="$(IlcGenerateStackTraceData) == 'true'" Include="--stacktracedata" />
       <IlcArg Condition="$(RootAllApplicationAssemblies) == 'true'" Include="--rootallapplicationassemblies" />
       <IlcArg Condition="$(IlcScanReflection) == 'true'" Include="--scanreflection" />
+      <IlcArg Condition="$(IlcFoldIdenticalMethodBodies) == 'true'" Include="--methodbodyfolding" />
       <IlcArg Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) == 'Size'" Include="--Os" />
       <IlcArg Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) == 'Speed'" Include="--Ot" />
     </ItemGroup>

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
@@ -30,6 +30,7 @@ namespace ILCompiler
         protected DebugInformationProvider _debugInformationProvider = new DebugInformationProvider();
         protected DevirtualizationManager _devirtualizationManager = new DevirtualizationManager();
         protected PInvokeILEmitterConfiguration _pinvokePolicy = new DirectPInvokePolicy();
+        protected bool _methodBodyFolding;
 
         public CompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup compilationGroup, NameMangler nameMangler)
         {
@@ -102,6 +103,12 @@ namespace ILCompiler
         public CompilationBuilder UsePInvokePolicy(PInvokeILEmitterConfiguration policy)
         {
             _pinvokePolicy = policy;
+            return this;
+        }
+
+        public CompilationBuilder UseMethodBodyFolding(bool enable)
+        {
+            _methodBodyFolding = enable;
             return this;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
@@ -51,7 +51,9 @@ namespace ILCompiler.DependencyAnalysis
         public static readonly ObjectNodeSection TLSSection = new ObjectNodeSection("TLS", SectionType.Writeable);
         public static readonly ObjectNodeSection ManagedCodeStartSection = new ObjectNodeSection(".managedcode$A", SectionType.Executable);
         public static readonly ObjectNodeSection ManagedCodeWindowsContentSection = new ObjectNodeSection(".managedcode$I", SectionType.Executable);
+        public static readonly ObjectNodeSection FoldableManagedCodeWindowsContentSection = new ObjectNodeSection(".managedcode$I", SectionType.Executable);
         public static readonly ObjectNodeSection ManagedCodeUnixContentSection = new ObjectNodeSection("__managedcode", SectionType.Executable);
+        public static readonly ObjectNodeSection FoldableManagedCodeUnixContentSection = new ObjectNodeSection("__managedcode", SectionType.Executable);
         public static readonly ObjectNodeSection ManagedCodeEndSection = new ObjectNodeSection(".managedcode$Z", SectionType.Executable);
     }
 }

--- a/src/ILCompiler.RyuJit/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -20,6 +20,7 @@ namespace ILCompiler.DependencyAnalysis
         private DebugLocInfo[] _debugLocInfos;
         private DebugVarInfo[] _debugVarInfos;
         private DebugEHClauseInfo[] _debugEHClauseInfos;
+        private bool _isFoldable;
 
         public MethodCodeNode(MethodDesc method)
         {
@@ -28,10 +29,11 @@ namespace ILCompiler.DependencyAnalysis
             _method = method;
         }
 
-        public void SetCode(ObjectData data)
+        public void SetCode(ObjectData data, bool isFoldable)
         {
             Debug.Assert(_methodCode == null);
             _methodCode = data;
+            _isFoldable = isFoldable;
         }
 
         public MethodDesc Method =>  _method;
@@ -42,7 +44,9 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return _method.Context.Target.IsWindows ? ObjectNodeSection.ManagedCodeWindowsContentSection : ObjectNodeSection.ManagedCodeUnixContentSection;
+                return _method.Context.Target.IsWindows ?
+                    (_isFoldable ? ObjectNodeSection.FoldableManagedCodeWindowsContentSection : ObjectNodeSection.ManagedCodeWindowsContentSection) :
+                    (_isFoldable ? ObjectNodeSection.FoldableManagedCodeUnixContentSection : ObjectNodeSection.ManagedCodeUnixContentSection);
             }
         }
         

--- a/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilation.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilation.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 
 using ILCompiler.DependencyAnalysis;
@@ -18,6 +19,7 @@ namespace ILCompiler
     {
         private CorInfoImpl _corInfo;
         private JitConfigProvider _jitConfigProvider;
+        internal readonly RyuJitCompilationOptions _compilationOptions;
 
         internal RyuJitCompilation(
             DependencyAnalyzerBase<NodeFactory> dependencyGraph,
@@ -28,10 +30,12 @@ namespace ILCompiler
             PInvokeILEmitterConfiguration pinvokePolicy,
             Logger logger,
             DevirtualizationManager devirtualizationManager,
-            JitConfigProvider configProvider)
+            JitConfigProvider configProvider,
+            RyuJitCompilationOptions options)
             : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, devirtualizationManager, pinvokePolicy, logger)
         {
             _jitConfigProvider = configProvider;
+            _compilationOptions = options;
         }
 
         protected override void CompileInternal(string outputFile, ObjectDumper dumper)
@@ -89,5 +93,11 @@ namespace ILCompiler
                 }
             }
         }
+    }
+
+    [Flags]
+    public enum RyuJitCompilationOptions
+    {
+        MethodBodyFolding = 0x1,
     }
 }

--- a/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilationBuilder.cs
@@ -99,12 +99,16 @@ namespace ILCompiler
                 jitFlagBuilder.Add(CorJitFlag.CORJIT_FLAG_FEATURE_SIMD);
             }
 
+            RyuJitCompilationOptions options = 0;
+            if (_methodBodyFolding)
+                options |= RyuJitCompilationOptions.MethodBodyFolding;
+
             var interopStubManager = new CompilerGeneratedInteropStubManager(_compilationGroup, _context, new InteropStateManager(_context.GeneratedAssembly));
             var factory = new RyuJitNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
 
             var jitConfig = new JitConfigProvider(jitFlagBuilder.ToArray(), _ryujitOptions);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
-            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _pinvokePolicy, _logger, _devirtualizationManager, jitConfig);
+            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _pinvokePolicy, _logger, _devirtualizationManager, jitConfig, options);
         }
     }
 }

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -15,6 +15,7 @@ using ILCompiler.DependencyAnalysis;
 
 #if SUPPORT_JIT
 using MethodCodeNode = Internal.Runtime.JitSupport.JitMethodCodeNode;
+using RyuJitCompilation = ILCompiler.Compilation;
 #endif
 
 namespace Internal.JitInterface

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -31,7 +31,7 @@ namespace Internal.JitInterface
 
         private uint OffsetOfDelegateFirstTarget => (uint)(4 * PointerSize); // Delegate::m_functionPointer
 
-        private Compilation _compilation;
+        private RyuJitCompilation _compilation;
         private MethodCodeNode _methodCodeNode;
         private DebugLocInfo[] _debugLocInfos;
         private DebugVarInfo[] _debugVarInfos;
@@ -40,7 +40,7 @@ namespace Internal.JitInterface
         private Dictionary<uint, string> _parameterIndexToNameMap;
         private TypeDesc[] _variableToTypeDesc;
 
-        public CorInfoImpl(Compilation compilation, JitConfigProvider jitConfig)
+        public CorInfoImpl(RyuJitCompilation compilation, JitConfigProvider jitConfig)
             : this(jitConfig)
         {
             _compilation = compilation;

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -55,6 +55,7 @@ namespace ILCompiler
         private bool _noMetadataBlocking;
         private bool _completeTypesMetadata;
         private bool _scanReflection;
+        private bool _methodBodyFolding;
 
         private string _singleMethodTypeName;
         private string _singleMethodName;
@@ -181,6 +182,7 @@ namespace ILCompiler
                 syntax.DefineOption("noscan", ref _noScanner, "Do not use IL scanner to generate optimized code");
                 syntax.DefineOption("ildump", ref _ilDump, "Dump IL assembly listing for compiler-generated IL");
                 syntax.DefineOption("stacktracedata", ref _emitStackTraceData, "Emit data to support generating stack trace strings at runtime");
+                syntax.DefineOption("methodbodyfolding", ref _methodBodyFolding, "Fold identical method bodies");
                 syntax.DefineOptionList("initassembly", ref _initAssemblies, "Assembly(ies) with a library initializer");
                 syntax.DefineOptionList("appcontextswitch", ref _appContextSwitches, "System.AppContext switches to set");
                 syntax.DefineOptionList("runtimeopt", ref _runtimeOptions, "Runtime options to set");
@@ -590,6 +592,7 @@ namespace ILCompiler
 
             builder
                 .UseBackendOptions(_codegenOptions)
+                .UseMethodBodyFolding(_methodBodyFolding)
                 .UseMetadataManager(metadataManager)
                 .UseLogger(logger)
                 .UseDependencyTracking(trackingLevel)

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -260,7 +260,11 @@ namespace Internal.JitInterface
                 }
             }
 
-            _methodCodeNode.SetCode(objectData);
+            _methodCodeNode.SetCode(objectData
+#if !SUPPORT_JIT && !READYTORUN
+                , isFoldable: (_compilation._compilationOptions & RyuJitCompilationOptions.MethodBodyFolding) != 0
+#endif
+                );
 
             _methodCodeNode.InitializeFrameInfos(_frameInfos);
             _methodCodeNode.InitializeDebugEHClauseInfos(debugEHClauseInfos);


### PR DESCRIPTION
This adds an option to specify the user would like to fold identical method bodies together. When enabled, we generate method bodies into separate COMDAT sections and when linker has `/OPT:ICF` passed to it (we already pass that), it's going to fold sections with identical content together.

This results in size savings - e.g. we save 170 kB on a Hello world because there's lots of methods with identical bodies in the image.

I've also enabled folding of the `FoldableReadOnlyDataSection`. This was added for Project N but wasn't taken advantage of in the open source compiler. With this, we can fold identical interface dispatch maps and a couple other things. The size savings from that are not substatial, but we can do it without being under the optional switch, so that's nice.