### PR TITLE
SuperIlc - minor improvements and bugfixes

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
@@ -31,7 +31,7 @@ namespace ReadyToRun.SuperIlc
                 return 1;
             }
 
-            List<string> referencePaths = options.ReferencePath?.Select(x => x.ToString())?.ToList();
+            IEnumerable<string> referencePaths = options.ReferencePaths();
             string coreRunPath = SuperIlcHelpers.FindCoreRun(referencePaths);
 
             IEnumerable<CompilerRunner> runners = options.CompilerRunners();
@@ -44,7 +44,7 @@ namespace ReadyToRun.SuperIlc
                 Console.Error.WriteLine($"No managed app found in {options.InputDirectory.FullName}");
             }
 
-            string timeStamp = DateTime.Now.ToString("MMDD-hhmm");
+            string timeStamp = DateTime.Now.ToString("MMdd-hhmm");
             string applicationSetLogPath = Path.Combine(options.InputDirectory.ToString(), "directory-" + timeStamp + ".log");
 
             using (ApplicationSet applicationSet = new ApplicationSet(new Application[] { application }, runners, coreRunPath, applicationSetLogPath))

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
@@ -32,7 +32,7 @@ namespace ReadyToRun.SuperIlc
                 return 1;
             }
 
-            List<string> referencePaths = options.ReferencePath?.Select(x => x.ToString())?.ToList();
+            IEnumerable<string> referencePaths = options.ReferencePaths();
             string coreRunPath = SuperIlcHelpers.FindCoreRun(referencePaths);
 
             IEnumerable<CompilerRunner> runners = options.CompilerRunners();

--- a/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
@@ -18,6 +18,11 @@ namespace ReadyToRun.SuperIlc
         public bool NoCleanup { get; set; }
         public DirectoryInfo[] ReferencePath { get; set; }
 
+        public IEnumerable<string> ReferencePaths()
+        {
+            return ReferencePath?.Select(x => x.ToString()) ?? Enumerable.Empty<string>();
+        }
+
         public IEnumerable<CompilerRunner> CompilerRunners()
         {
             List<CompilerRunner> runners = new List<CompilerRunner>();


### PR DESCRIPTION
These are a couple of items I spotted in my local SuperIlc testing:

1) FindCoreRun was crashing with nullref when no ReferencePaths were
specified. I used this opportunity to unify the idiom of converting
the command line argument to an IEnumerable<string>.

2) The execution step was missing logging of failures similar to
what we have for compilations. I have adapted compilation logging
for this purpose.

3) I hit and fixed a typo in the DateTime formatting string for the
CompileDirectory command.

4) I came to the conclusion that it's more precise to have the
"outcome" table represent individual compilations and executions
rather than the complete "apps" (folders) so I modified the code
as appropriate.

5) I fixed a bug where I had incorrectly placed a try / catch block
and that caused error count calculation to be slightly off.

Thanks

Tomas