### PR TITLE
wasm: remove unneeded fpext when doing ops on 2 floats

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -199,7 +199,7 @@ namespace Internal.IL
             else if (kind == StackValueKind.Int64)
                 return ValueAsInt64(builder, signExtend);
             else if (kind == StackValueKind.Float)
-                return ValueAsType(LLVM.DoubleType(), builder);
+                return ValueAsType(Type.IsWellKnownType(WellKnownType.Single) ? LLVM.FloatType() : LLVM.DoubleType(), builder);
             else if (kind == StackValueKind.NativeInt || kind == StackValueKind.ByRef || kind == StackValueKind.ObjRef)
                 return ValueAsInt32(builder, false);
             else

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2553,6 +2553,14 @@ namespace Internal.IL
                     }
                     else
                     {
+                        if (op1.Type.IsWellKnownType(WellKnownType.Double) && op2.Type.IsWellKnownType(WellKnownType.Single))
+                        {
+                            left = LLVM.BuildFPExt(_builder, left, LLVM.DoubleType(), "fpextop2");
+                        }
+                        else if (op2.Type.IsWellKnownType(WellKnownType.Double) && op1.Type.IsWellKnownType(WellKnownType.Single))
+                        {
+                            right = LLVM.BuildFPExt(_builder, right, LLVM.DoubleType(), "fpextop1");
+                        }
                         switch (opcode)
                         {
                             case ILOpcode.beq:
@@ -2690,6 +2698,14 @@ namespace Internal.IL
             LLVMValueRef right = op1.ValueForStackKind(kind, _builder, false);
             if (kind == StackValueKind.Float)
             {
+                if(op1.Type.IsWellKnownType(WellKnownType.Double) && op2.Type.IsWellKnownType(WellKnownType.Single))
+                {
+                    left = LLVM.BuildFPExt(_builder, left, LLVM.DoubleType(), "fpextop2");
+                }
+                else if (op2.Type.IsWellKnownType(WellKnownType.Double) && op1.Type.IsWellKnownType(WellKnownType.Single))
+                {
+                    right = LLVM.BuildFPExt(_builder, right, LLVM.DoubleType(), "fpextop1");
+                }
                 switch (opcode)
                 {
                     case ILOpcode.add:
@@ -2908,6 +2924,14 @@ namespace Internal.IL
             }
             else
             {
+                if (op1.Type.IsWellKnownType(WellKnownType.Double) && op2.Type.IsWellKnownType(WellKnownType.Single))
+                {
+                    typeSaneOp2 = LLVM.BuildFPExt(_builder, typeSaneOp2, LLVM.DoubleType(), "fpextop2");
+                }
+                else if (op2.Type.IsWellKnownType(WellKnownType.Double) && op1.Type.IsWellKnownType(WellKnownType.Single))
+                {
+                    typeSaneOp1 = LLVM.BuildFPExt(_builder, typeSaneOp1, LLVM.DoubleType(), "fpextop1");
+                }
                 switch (opcode)
                 {
                     case ILOpcode.ceq:


### PR DESCRIPTION
previously when floats where popped off the stack they were always widened to doubles.  This change removes that and only widens floats when the operation has a double on the other side.