### PR TITLE
Fix build with VS2019

### DIFF
--- a/buildscripts/build-managed.cmd
+++ b/buildscripts/build-managed.cmd
@@ -36,7 +36,7 @@ call  "%__ProjectDir%\init-tools.cmd"
 echo Using CLI tools version:
 dir /b "%__DotNetCliPath%\sdk"
 
-"%__DotNetCliPath%\dotnet.exe" msbuild "%__ProjectDir%\build.proj" /nologo /t:Restore /flp:v=normal;LogFile=build-restore.log /p:NuPkgRid=%__NugetRuntimeId% /maxcpucount /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
+"%__DotNetCliPath%\dotnet.exe" msbuild "%__ProjectDir%\build.proj" /nologo /t:Restore /flp:v=normal;LogFile="%__BuildLog%" /p:NuPkgRid=%__NugetRuntimeId% /maxcpucount /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
 IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
 
 rem Buildtools tooling is not capable of publishing netcoreapp currently. Use helper projects to publish skeleton of

--- a/buildscripts/build-tests.cmd
+++ b/buildscripts/build-tests.cmd
@@ -29,8 +29,8 @@ exit /b %ERRORLEVEL%
 
 if defined __SkipTests exit /b 0
 
-echo "%__DotNetCliPath%\dotnet.exe" msbuild "%__ProjectDir%\tests\dirs.proj" /nologo /t:Restore /flp:v=normal;LogFile=build-tests-restore.log /p:NuPkgRid=%__NugetRuntimeId% /maxcpucount /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
-"%__DotNetCliPath%\dotnet.exe" msbuild "%__ProjectDir%\tests\dirs.proj" /nologo /t:Restore /flp:v=normal;LogFile=build-tests-restore.log /p:NuPkgRid=%__NugetRuntimeId% /maxcpucount /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
+echo "%__DotNetCliPath%\dotnet.exe" msbuild "%__ProjectDir%\tests\dirs.proj" /nologo /t:Restore /flp:v=normal;LogFile="%__TestBuildLog%" /p:NuPkgRid=%__NugetRuntimeId% /maxcpucount /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
+"%__DotNetCliPath%\dotnet.exe" msbuild "%__ProjectDir%\tests\dirs.proj" /nologo /t:Restore /flp:v=normal;LogFile="%__TestBuildLog%" /p:NuPkgRid=%__NugetRuntimeId% /maxcpucount /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
 IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
 
 call "!VS%__VSProductVersion%COMNTOOLS!\VsDevCmd.bat"


### PR DESCRIPTION
The environment setup scripts that come with VS2019 change current directory. It breaks places in the build that depend on current directory.