### PR TITLE
Publish to Azure blob feed

### DIFF
--- a/buildpipeline/DotNet-CoreRT-Publish.json
+++ b/buildpipeline/DotNet-CoreRT-Publish.json
@@ -343,14 +343,6 @@
       "value": "$(BuildTag)-$(Build.BuildNumber)",
       "allowOverride": true
     },
-    "MyGetFeedUrl": {
-      "value": "https://dotnet.myget.org/F/dotnet-core/api/v2/package",
-      "allowOverride": true
-    },
-    "MyGetApiKey": {
-      "value": null,
-      "isSecret": true
-    },
     "VstsPat": {
       "value": null,
       "isSecret": true
@@ -401,7 +393,7 @@
       "value": null,
       "isSecret": true
     },
-    "MyGetFeedUrl": {
+    "AzureFeedUrl": {
       "value": "https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json",
       "allowOverride": true
     },

--- a/buildpipeline/DotNet-CoreRT-Publish.json
+++ b/buildpipeline/DotNet-CoreRT-Publish.json
@@ -396,7 +396,15 @@
     "UseLegacyBuildScripts": {
       "value": "false",
       "allowOverride": true
-    }
+    },
+    "AzureFeedAccountKey": {
+      "value": null,
+      "isSecret": true
+    },
+    "MyGetFeedUrl": {
+      "value": "https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json",
+      "allowOverride": true
+    },
   },
   "retentionRules": [
     {

--- a/buildpipeline/DotNet-CoreRT-Publish.json
+++ b/buildpipeline/DotNet-CoreRT-Publish.json
@@ -138,10 +138,10 @@
       }
     },
     {
-      "enabled": false,
+      "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "packages -> dotnet.myget.org",
+      "displayName": "packages -> Azure blob feed",
       "timeoutInMinutes": 0,
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
@@ -151,8 +151,8 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "$(MyGetApiKey)",
-        "inlineScript": "param($ApiKey)\nif ($env:Configuration -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\$env:Configuration\\$env:AzureContainerPackageGlob $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
+        "arguments": "",
+        "inlineScript": "if ($env:Configuration -ne \"Release\") { exit }\n msbuild publish.msbuild /t:PublishToAzureBlobFeed /p:AccountKey=$(AzureFeedAccountKey) /p:ExpectedFeedUrl=$(AzureFeedUrl) /p:PublishPattern=$env:Pipeline_SourcesDirectory\\packages\\AzureTransfer\\$env:Configuration\\$env:AzureContainerPackageGlob",
         "workingFolder": "",
         "failOnStandardError": "true"
       }
@@ -161,7 +161,7 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "symbol packages -> dotnet.myget.org",
+      "displayName": "symbol packages -> Azure blob feed",
       "timeoutInMinutes": 0,
       "task": {
         "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
@@ -171,8 +171,7 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "$(MyGetApiKey)",
-        "inlineScript": "param($ApiKey)\nif ($env:Configuration -ne \"Release\") { exit }\n& $env:CustomNuGetPath push $env:Build_StagingDirectory\\IndexedSymbolPackages\\*.nupkg $ApiKey -Source $env:MyGetFeedUrl -Timeout 3600",
+        "inlineScript": "if ($env:Configuration -ne \"Release\") { exit }\n msbuild publish.msbuild /t:t:PublishSymbolsToAzureBlobFeed /p:AccountKey=$(AzureFeedAccountKey) /p:ExpectedFeedUrl=$(AzureFeedUrl) /p:PublishPattern=$env:Build_StagingDirectory\\IndexedSymbolPackages\\*.nupkg",
         "workingFolder": "",
         "failOnStandardError": "true"
       }

--- a/dependencies.props
+++ b/dependencies.props
@@ -10,5 +10,7 @@
     <XUnitPackageVersion>2.4.1-pre.build.4059</XUnitPackageVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>2.4.0-beta.18420.4</MicrosoftDotNetXUnitExtensionsVersion>
     <SystemReflectionMetadataVersion>1.4.3</SystemReflectionMetadataVersion>
+    <FeedTasksPackage>Microsoft.DotNet.Build.Tasks.Feed</FeedTasksPackage>
+    <FeedTasksPackageVersion>2.1.0-rc1-03905-01</FeedTasksPackageVersion>
   </PropertyGroup>
 </Project>

--- a/init-tools.msbuild
+++ b/init-tools.msbuild
@@ -5,7 +5,11 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)Tools/$(BuildToolsPackageVersion)</BaseIntermediateOutputPath>
   </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)dependencies.props" />
+
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.BuildTools" Version="$(BuildToolsPackageVersion)" />
+    <PackageReference Include="$(FeedTasksPackage)" Version="$(FeedTasksPackageVersion)" /> 
   </ItemGroup>
 </Project>

--- a/publish.msbuild
+++ b/publish.msbuild
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$(PackagesDir)/$(FeedTasksPackage)/$(FeedTasksPackageVersion)/build/$(FeedTasksPackage).targets" />
+
+  <PropertyGroup>
+     <PublishPattern Condition="'$(PublishPattern)' == ''">$(PackageOutputRoot)**\*.nupkg</PublishPattern>
+     <SymbolsPackagesPattern>$(PackageOutputRoot)**\*.symbols.nupkg</SymbolsPackagesPattern>
+  </PropertyGroup>
+
+  <ItemGroup>
+     <_PackagesToPublish Include="$(PublishPattern)" Exclude="$(SymbolsPackagesPattern)" />
+     <_SymbolsPackagesToPublish Include="$(SymbolsPackagesPattern)" Condition="'$(PublishSymbols)' == 'true'" />
+  </ItemGroup>      
+
+  <Target Name="PublishToAzureBlobFeed">
+    <Error Condition="'@(_PackagesToPublish)'==''" Text="ItemsToPush for packages is empty." />
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(AccountKey)"
+                    ItemsToPush="@(_PackagesToPublish)"
+                    Overwrite="$(PublishOverwrite)" />
+  </Target>
+
+  <Target Name="PublishSymbolsToAzureBlobFeed">
+    <Error Condition="'@(_SymbolsPackagesToPublish)'==''" Text="ItemsToPush for packages is empty." />
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(AccountKey)"
+                    ItemsToPush="@(_SymbolsPackagesToPublish)"
+                    Overwrite="$(PublishOverwrite)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
MyGet keeps running out of storage quota (see https://github.com/dotnet/core-eng/issues/5070). Switch to Azure blob feed so CoreRT nightly builds are publicly available.