### PR TITLE
Remove reflection from Enum.ToString

### DIFF
--- a/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -114,6 +114,15 @@ namespace Internal.Runtime
                 }
             }
 
+            flags |= ComputeElementTypeFlags(type);
+
+            return flags;
+        }
+
+        public static UInt16 ComputeElementTypeFlags(TypeDesc type)
+        {
+            UInt16 flags = 0;
+
             CorElementType corElementType = CorElementType.ELEMENT_TYPE_END;
 
             // The top 5 bits of flags are used to convey enum underlying type, primitive type, or mark the type as being System.Array

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -60,6 +60,9 @@ namespace ILCompiler.DependencyAnalysis
             if (HasOptionalFields)
                 flags |= (short)EETypeFlags.OptionalFieldsFlag;
 
+            if (_type.IsEnum)
+                flags |= (short)EETypeBuilderHelpers.ComputeElementTypeFlags(_type);
+
             dataBuilder.EmitShort((short)_type.Instantiation.Length);
             dataBuilder.EmitShort(flags);
             dataBuilder.EmitInt(0);         // Base size is always 0

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -437,6 +437,38 @@ namespace Internal.Runtime.Augments
             return e.GetValue();
         }
 
+        public static Type GetEnumUnderlyingType(RuntimeTypeHandle enumTypeHandle)
+        {
+            Debug.Assert(enumTypeHandle.ToEETypePtr().IsEnum);
+
+            RuntimeImports.RhCorElementType corElementType = enumTypeHandle.ToEETypePtr().CorElementType;
+            switch (corElementType)
+            {
+                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_BOOLEAN:
+                    return CommonRuntimeTypes.Boolean;
+                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_CHAR:
+                    return CommonRuntimeTypes.Char;
+                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I1:
+                    return CommonRuntimeTypes.SByte;
+                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U1:
+                    return CommonRuntimeTypes.Byte;
+                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I2:
+                    return CommonRuntimeTypes.Int16;
+                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U2:
+                    return CommonRuntimeTypes.UInt16;
+                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I4:
+                    return CommonRuntimeTypes.Int32;
+                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U4:
+                    return CommonRuntimeTypes.UInt32;
+                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I8:
+                    return CommonRuntimeTypes.Int64;
+                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U8:
+                    return CommonRuntimeTypes.UInt64;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
         public static RuntimeTypeHandle GetRelatedParameterTypeHandle(RuntimeTypeHandle parameterTypeHandle)
         {
             EETypePtr elementType = parameterTypeHandle.ToEETypePtr().ArrayElementType;

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -194,8 +194,11 @@ namespace System
                 // A: When it's nested inside a generic type.
                 if (!(IsDefType))
                     return false;
-                EETypePtr baseType = this.BaseType;
-                return baseType == EETypePtr.EETypePtrOf<Enum>();
+
+                // Generic type definitions that return true for IsPrimitive are type definitions of generic enums.
+                // Otherwise check the base type.
+                return (IsGenericTypeDefinition && IsPrimitive) ||
+                    this.BaseType == EETypePtr.EETypePtrOf<Enum>();
             }
         }
 

--- a/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
+++ b/src/System.Private.Reflection.Core/src/Internal/Reflection/Core/Execution/ExecutionEnvironment.cs
@@ -11,6 +11,7 @@ using System.Reflection.Runtime.TypeInfos;
 using Internal.Metadata.NativeFormat;
 
 using OpenMethodInvoker = System.Reflection.Runtime.MethodInfos.OpenMethodInvoker;
+using EnumInfo = Internal.Runtime.Augments.EnumInfo;
 
 namespace Internal.Reflection.Core.Execution
 {
@@ -92,6 +93,7 @@ namespace Internal.Reflection.Core.Execution
         //==============================================================================================
         public abstract bool IsCOMObject(Type type);
         public abstract FieldAccessor CreateLiteralFieldAccessor(object value, RuntimeTypeHandle fieldTypeHandle);
+        public abstract EnumInfo GetEnumInfo(RuntimeTypeHandle typeHandle);
 
         //==============================================================================================
         // Non-public methods

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/EcmaFormat/DefaultValueProcessing.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/EcmaFormat/DefaultValueProcessing.cs
@@ -59,79 +59,10 @@ namespace System.Reflection.Runtime.General.EcmaFormat
 
         private static object ConstantValueAsObject(ConstantHandle constantHandle, MetadataReader metadataReader, Type declaredType, bool raw)
         {
-            object defaultValue = ConstantValueAsRawObject(constantHandle, metadataReader);
+            object defaultValue = constantHandle.ParseConstantValue(metadataReader);
             if ((!raw) && declaredType.IsEnum && defaultValue != null)
                 defaultValue = Enum.ToObject(declaredType, defaultValue);
             return defaultValue;
         }
-
-
-        private static object ConstantValueAsRawObject(ConstantHandle constantHandle, MetadataReader metadataReader)
-        {
-            if (constantHandle.IsNil)
-                throw new BadImageFormatException();
-
-            Constant constantValue = metadataReader.GetConstant(constantHandle);
-
-            if (constantValue.Value.IsNil)
-                throw new BadImageFormatException();
-
-            BlobReader reader = metadataReader.GetBlobReader(constantValue.Value);
-
-            switch (constantValue.TypeCode)
-            {
-                case ConstantTypeCode.Boolean:
-                    return reader.ReadBoolean();
-
-                case ConstantTypeCode.Char:
-                    return reader.ReadChar();
-
-                case ConstantTypeCode.SByte:
-                    return reader.ReadSByte();
-
-                case ConstantTypeCode.Int16:
-                    return reader.ReadInt16();
-
-                case ConstantTypeCode.Int32:
-                    return reader.ReadInt32();
-
-                case ConstantTypeCode.Int64:
-                    return reader.ReadInt64();
-
-                case ConstantTypeCode.Byte:
-                    return reader.ReadByte();
-
-                case ConstantTypeCode.UInt16:
-                    return reader.ReadUInt16();
-
-                case ConstantTypeCode.UInt32:
-                    return reader.ReadUInt32();
-
-                case ConstantTypeCode.UInt64:
-                    return reader.ReadUInt64();
-
-                case ConstantTypeCode.Single:
-                    return reader.ReadSingle();
-
-                case ConstantTypeCode.Double:
-                    return reader.ReadDouble();
-
-                case ConstantTypeCode.String:
-                    return reader.ReadUTF16(reader.Length);
-
-                case ConstantTypeCode.NullReference:
-                    // Partition II section 22.9:
-                    // The encoding of Type for the nullref value is ELEMENT_TYPE_CLASS with a Value of a 4-byte zero.
-                    // Unlike uses of ELEMENT_TYPE_CLASS in signatures, this one is not followed by a type token.
-                    if (reader.ReadUInt32() == 0)
-                    {
-                        return null;
-                    }
-
-                    break;
-            }
-
-            throw new BadImageFormatException();
-        } 
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.Ecma.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.Ecma.cs
@@ -23,7 +23,7 @@ namespace System.Reflection.Runtime.General
     //
     // Collect various metadata reading tasks for better chunking...
     //
-    internal static class EcmaMetadataReaderExtensions
+    public static class EcmaMetadataReaderExtensions
     {
         //
         // Used to split methods between DeclaredMethods and DeclaredConstructors.
@@ -117,6 +117,118 @@ namespace System.Reflection.Runtime.General
             }
 
             throw new BadImageFormatException();
-        }        
+        }
+
+        public static object ParseConstantValue(this ConstantHandle constantHandle, MetadataReader metadataReader)
+        {
+            if (constantHandle.IsNil)
+                throw new BadImageFormatException();
+
+            Constant constantValue = metadataReader.GetConstant(constantHandle);
+
+            if (constantValue.Value.IsNil)
+                throw new BadImageFormatException();
+
+            BlobReader reader = metadataReader.GetBlobReader(constantValue.Value);
+
+            switch (constantValue.TypeCode)
+            {
+                case ConstantTypeCode.Boolean:
+                    return reader.ReadBoolean();
+
+                case ConstantTypeCode.Char:
+                    return reader.ReadChar();
+
+                case ConstantTypeCode.SByte:
+                    return reader.ReadSByte();
+
+                case ConstantTypeCode.Int16:
+                    return reader.ReadInt16();
+
+                case ConstantTypeCode.Int32:
+                    return reader.ReadInt32();
+
+                case ConstantTypeCode.Int64:
+                    return reader.ReadInt64();
+
+                case ConstantTypeCode.Byte:
+                    return reader.ReadByte();
+
+                case ConstantTypeCode.UInt16:
+                    return reader.ReadUInt16();
+
+                case ConstantTypeCode.UInt32:
+                    return reader.ReadUInt32();
+
+                case ConstantTypeCode.UInt64:
+                    return reader.ReadUInt64();
+
+                case ConstantTypeCode.Single:
+                    return reader.ReadSingle();
+
+                case ConstantTypeCode.Double:
+                    return reader.ReadDouble();
+
+                case ConstantTypeCode.String:
+                    return reader.ReadUTF16(reader.Length);
+
+                case ConstantTypeCode.NullReference:
+                    // Partition II section 22.9:
+                    // The encoding of Type for the nullref value is ELEMENT_TYPE_CLASS with a Value of a 4-byte zero.
+                    // Unlike uses of ELEMENT_TYPE_CLASS in signatures, this one is not followed by a type token.
+                    if (reader.ReadUInt32() == 0)
+                    {
+                        return null;
+                    }
+
+                    break;
+            }
+
+            throw new BadImageFormatException();
+        }
+
+        public static bool IsCustomAttributeOfType(this CustomAttributeHandle handle, MetadataReader reader, string ns, string name)
+        {
+            CustomAttribute attribute = reader.GetCustomAttribute(handle);
+            EcmaMetadataHelpers.GetAttributeTypeDefRefOrSpecHandle(reader, attribute.Constructor, out EntityHandle typeDefOrRef);
+
+            if (typeDefOrRef.Kind == HandleKind.TypeReference)
+            {
+                TypeReference typeRef = reader.GetTypeReference((TypeReferenceHandle)typeDefOrRef);
+                HandleKind handleType = typeRef.ResolutionScope.Kind;
+
+                if (handleType == HandleKind.TypeReference || handleType == HandleKind.TypeDefinition)
+                {
+                    // Nested type
+                    return false;
+                }
+
+                return reader.StringComparer.Equals(typeRef.Name, name)
+                    && reader.StringComparer.Equals(typeRef.Namespace, name);
+            }
+            else if (typeDefOrRef.Kind == HandleKind.TypeDefinition)
+            {
+                TypeDefinition typeDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeDefOrRef);
+
+                if (EcmaMetadataHelpers.IsNested(typeDef.Attributes))
+                {
+                    // Nested type
+                    return false;
+                }
+
+                return reader.StringComparer.Equals(typeDef.Name, name)
+                    && reader.StringComparer.Equals(typeDef.Namespace, name);
+            }
+            else if (typeDefOrRef.Kind == HandleKind.TypeSpecification)
+            {
+                // Generic attribute
+                return false;
+            }
+            else
+            {
+                // unsupported metadata
+                throw new BadImageFormatException();
+            }
+        }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -23,7 +23,7 @@ namespace System.Reflection.Runtime.General
     //
     // Collect various metadata reading tasks for better chunking...
     //
-    internal static class NativeFormatMetadataReaderExtensions
+    public static class NativeFormatMetadataReaderExtensions
     {
         public static bool StringOrNullEquals(this ConstantStringValueHandle handle, String valueOrNull, MetadataReader reader)
         {
@@ -138,7 +138,7 @@ namespace System.Reflection.Runtime.General
         // Return any custom modifiers modifying the passed-in type and whose required/optional bit matches the passed in boolean.
         // Because this is intended to service the GetCustomModifiers() apis, this helper will always return a freshly allocated array
         // safe for returning to api callers.
-        public static Type[] GetCustomModifiers(this Handle handle, MetadataReader reader, TypeContext typeContext, bool optional)
+        internal static Type[] GetCustomModifiers(this Handle handle, MetadataReader reader, TypeContext typeContext, bool optional)
         {
             HandleType handleType = handle.HandleType;
             Debug.Assert(handleType == HandleType.TypeDefinition || handleType == HandleType.TypeReference || handleType == HandleType.TypeSpecification || handleType == HandleType.ModifiedType);

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -328,8 +328,7 @@ namespace System.Reflection.Runtime.General
 
         public static Object ParseConstantNumericValue(this Handle handle, MetadataReader reader)
         {
-            HandleType handleType = handle.HandleType;
-            switch (handleType)
+            switch (handle.HandleType)
             {
                 case HandleType.ConstantBooleanValue:
                     return handle.ToConstantBooleanValueHandle(reader).GetConstantBooleanValue(reader).Value;

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -326,49 +326,61 @@ namespace System.Reflection.Runtime.General
             return value;
         }
 
+        public static Object ParseConstantNumericValue(this Handle handle, MetadataReader reader)
+        {
+            HandleType handleType = handle.HandleType;
+            switch (handleType)
+            {
+                case HandleType.ConstantBooleanValue:
+                    return handle.ToConstantBooleanValueHandle(reader).GetConstantBooleanValue(reader).Value;
+                case HandleType.ConstantCharValue:
+                    return handle.ToConstantCharValueHandle(reader).GetConstantCharValue(reader).Value;
+                case HandleType.ConstantByteValue:
+                    return handle.ToConstantByteValueHandle(reader).GetConstantByteValue(reader).Value;
+                case HandleType.ConstantSByteValue:
+                    return handle.ToConstantSByteValueHandle(reader).GetConstantSByteValue(reader).Value;
+                case HandleType.ConstantInt16Value:
+                    return handle.ToConstantInt16ValueHandle(reader).GetConstantInt16Value(reader).Value;
+                case HandleType.ConstantUInt16Value:
+                    return handle.ToConstantUInt16ValueHandle(reader).GetConstantUInt16Value(reader).Value;
+                case HandleType.ConstantInt32Value:
+                    return handle.ToConstantInt32ValueHandle(reader).GetConstantInt32Value(reader).Value;
+                case HandleType.ConstantUInt32Value:
+                    return handle.ToConstantUInt32ValueHandle(reader).GetConstantUInt32Value(reader).Value;
+                case HandleType.ConstantInt64Value:
+                    return handle.ToConstantInt64ValueHandle(reader).GetConstantInt64Value(reader).Value;
+                case HandleType.ConstantUInt64Value:
+                    return handle.ToConstantUInt64ValueHandle(reader).GetConstantUInt64Value(reader).Value;
+                case HandleType.ConstantSingleValue:
+                    return handle.ToConstantSingleValueHandle(reader).GetConstantSingleValue(reader).Value;
+                case HandleType.ConstantDoubleValue:
+                    return handle.ToConstantDoubleValueHandle(reader).GetConstantDoubleValue(reader).Value;
+                default:
+                    throw new BadImageFormatException();
+            }
+        }
+
         public static Exception TryParseConstantValue(this Handle handle, MetadataReader reader, out Object value)
         {
             HandleType handleType = handle.HandleType;
             switch (handleType)
             {
                 case HandleType.ConstantBooleanValue:
-                    value = handle.ToConstantBooleanValueHandle(reader).GetConstantBooleanValue(reader).Value;
+                case HandleType.ConstantCharValue:
+                case HandleType.ConstantByteValue:
+                case HandleType.ConstantSByteValue:
+                case HandleType.ConstantInt16Value:
+                case HandleType.ConstantUInt16Value:
+                case HandleType.ConstantInt32Value:
+                case HandleType.ConstantUInt32Value:
+                case HandleType.ConstantInt64Value:
+                case HandleType.ConstantUInt64Value:
+                case HandleType.ConstantSingleValue:
+                case HandleType.ConstantDoubleValue:
+                    value = handle.ParseConstantNumericValue(reader);
                     return null;
                 case HandleType.ConstantStringValue:
                     value = handle.ToConstantStringValueHandle(reader).GetConstantStringValue(reader).Value;
-                    return null;
-                case HandleType.ConstantCharValue:
-                    value = handle.ToConstantCharValueHandle(reader).GetConstantCharValue(reader).Value;
-                    return null;
-                case HandleType.ConstantByteValue:
-                    value = handle.ToConstantByteValueHandle(reader).GetConstantByteValue(reader).Value;
-                    return null;
-                case HandleType.ConstantSByteValue:
-                    value = handle.ToConstantSByteValueHandle(reader).GetConstantSByteValue(reader).Value;
-                    return null;
-                case HandleType.ConstantInt16Value:
-                    value = handle.ToConstantInt16ValueHandle(reader).GetConstantInt16Value(reader).Value;
-                    return null;
-                case HandleType.ConstantUInt16Value:
-                    value = handle.ToConstantUInt16ValueHandle(reader).GetConstantUInt16Value(reader).Value;
-                    return null;
-                case HandleType.ConstantInt32Value:
-                    value = handle.ToConstantInt32ValueHandle(reader).GetConstantInt32Value(reader).Value;
-                    return null;
-                case HandleType.ConstantUInt32Value:
-                    value = handle.ToConstantUInt32ValueHandle(reader).GetConstantUInt32Value(reader).Value;
-                    return null;
-                case HandleType.ConstantInt64Value:
-                    value = handle.ToConstantInt64ValueHandle(reader).GetConstantInt64Value(reader).Value;
-                    return null;
-                case HandleType.ConstantUInt64Value:
-                    value = handle.ToConstantUInt64ValueHandle(reader).GetConstantUInt64Value(reader).Value;
-                    return null;
-                case HandleType.ConstantSingleValue:
-                    value = handle.ToConstantSingleValueHandle(reader).GetConstantSingleValue(reader).Value;
-                    return null;
-                case HandleType.ConstantDoubleValue:
-                    value = handle.ToConstantDoubleValueHandle(reader).GetConstantDoubleValue(reader).Value;
                     return null;
                 case HandleType.TypeDefinition:
                 case HandleType.TypeReference:

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.TypeComponentsCache.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.TypeComponentsCache.cs
@@ -9,6 +9,8 @@ using System.Collections.Concurrent;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.BindingFlagSupport;
 
+using Internal.Reflection.Core.Execution;
+
 using Unsafe = Internal.Runtime.CompilerServices.Unsafe;
 
 using EnumInfo = Internal.Runtime.Augments.EnumInfo;
@@ -74,7 +76,7 @@ namespace System.Reflection.Runtime.TypeInfos
                 return Unsafe.As<QueriedMemberList<M>>(result);
             }
 
-            public EnumInfo EnumInfo => _lazyEnumInfo ?? (_lazyEnumInfo = new EnumInfo(_type));
+            public EnumInfo EnumInfo => _lazyEnumInfo ?? (_lazyEnumInfo = ReflectionCoreExecution.ExecutionDomain.ExecutionEnvironment.GetEnumInfo(_type.TypeHandle));
 
             private static object[] CreatePerNameQueryCaches(RuntimeTypeInfo type, bool ignoreCase)
             {

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/EcmaFormatEnumInfo.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/EcmaFormatEnumInfo.cs
@@ -29,7 +29,7 @@ namespace Internal.Reflection.Execution
                 FieldDefinition field = reader.GetFieldDefinition(fieldHandle);
                 if (0 != (field.Attributes & FieldAttributes.Static))
                 {
-                    if (i >= staticFieldCount|| (field.Attributes & FieldAttributes.HasDefault) != FieldAttributes.HasDefault)
+                    if (i >= staticFieldCount || (field.Attributes & FieldAttributes.HasDefault) != FieldAttributes.HasDefault)
                         throw new BadImageFormatException();
 
                     names[i] = reader.GetString(field.Name);

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/EcmaFormatEnumInfo.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/EcmaFormatEnumInfo.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Runtime.General;
+
+using Internal.Runtime.Augments;
+
+namespace Internal.Reflection.Execution
+{
+    static class EcmaFormatEnumInfo
+    {
+        public static EnumInfo Create(RuntimeTypeHandle typeHandle, MetadataReader reader, TypeDefinitionHandle typeDefHandle)
+        {
+            TypeDefinition typeDef = reader.GetTypeDefinition(typeDefHandle);
+
+            // Per the spec, Enums are required to have one instance field. The rest are statics.
+            int staticFieldCount = typeDef.GetFields().Count - 1;
+
+            string[] names = new string[staticFieldCount];
+            object[] values = new object[staticFieldCount];
+
+            int i = 0;
+            foreach (FieldDefinitionHandle fieldHandle in typeDef.GetFields())
+            {
+                FieldDefinition field = reader.GetFieldDefinition(fieldHandle);
+                if (0 != (field.Attributes & FieldAttributes.Static))
+                {
+                    if (i >= staticFieldCount|| (field.Attributes & FieldAttributes.HasDefault) != FieldAttributes.HasDefault)
+                        throw new BadImageFormatException();
+
+                    names[i] = reader.GetString(field.Name);
+                    values[i] = field.GetDefaultValue().ParseConstantValue(reader);
+                    i++;
+                }
+            }
+
+            bool isFlags = false;
+            foreach (CustomAttributeHandle cah in typeDef.GetCustomAttributes())
+            {
+                if (cah.IsCustomAttributeOfType(reader, "System", "FlagsAttribute"))
+                    isFlags = true;
+            }
+
+            return new EnumInfo(RuntimeAugments.GetEnumUnderlyingType(typeHandle), values, names, isFlags);
+        }
+    }
+}

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Reflection.Runtime.General;
+
+using Internal.Runtime.Augments;
+using Internal.Metadata.NativeFormat;
+
+namespace Internal.Reflection.Execution
+{
+    static class NativeFormatEnumInfo
+    {
+        public static EnumInfo Create(RuntimeTypeHandle typeHandle, MetadataReader reader, TypeDefinitionHandle typeDefHandle)
+        {
+            TypeDefinition typeDef = reader.GetTypeDefinition(typeDefHandle);
+
+            // Per the spec, Enums are required to have one instance field. The rest are statics.
+            int staticFieldCount = typeDef.Fields.Count - 1;
+
+            string[] names = new string[staticFieldCount];
+            object[] values = new object[staticFieldCount];
+
+            int i = 0;
+            foreach (FieldHandle fieldHandle in typeDef.Fields)
+            {
+                Field field = fieldHandle.GetField(reader);
+                if (0 != (field.Flags & FieldAttributes.Static))
+                {
+                    if (i >= staticFieldCount)
+                        throw new BadImageFormatException();
+
+                    names[i] = field.Name.GetString(reader);
+                    values[i] = field.DefaultValue.ParseConstantNumericValue(reader);
+                    i++;
+                }
+            }
+
+            bool isFlags = false;
+            foreach (CustomAttributeHandle cah in typeDef.CustomAttributes)
+            {
+                if (cah.IsCustomAttributeOfType(reader, "System", "FlagsAttribute"))
+                    isFlags = true;
+            }
+
+            return new EnumInfo(RuntimeAugments.GetEnumUnderlyingType(typeHandle), values, names, isFlags);
+        }
+    }
+}

--- a/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
+++ b/src/System.Private.Reflection.Execution/src/System.Private.Reflection.Execution.csproj
@@ -41,6 +41,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(EcmaMetadataSupport)' == 'true'">
     <Compile Include="Internal\Reflection\Execution\PayForPlayExperience\DiagnosticMappingTables.Ecma.cs" />
+    <Compile Include="Internal\Reflection\Execution\EcmaFormatEnumInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(NativeFormatCommonPath)\NativeFormat.cs" />
@@ -50,6 +51,7 @@
     <Compile Include="$(NativeFormatCommonPath)\NativeFormatReader.String.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Internal\Reflection\Execution\NativeFormatEnumInfo.cs" />
     <Compile Include="Internal\Reflection\Execution\TypeLoader\ConstraintValidator.cs" />
     <Compile Include="Internal\Reflection\Execution\TypeLoader\ConstraintValidatorSupport.cs" />
     <Compile Include="Internal\Reflection\Execution\TypeLoader\TypeCast.cs" />


### PR DESCRIPTION
Contributes to #5013.

Having reflection field access and custom attribute parsing support in a code path reachable from `Enum.ToString` means that any "hello world"-style app needs to have pretty much the full reflection stack embedded in it. The reflection stack is huge. This also makes access to uncached `EnumInfo` marginally faster.

This pretty much restores #3801, where we replaced the specialized code paths with the common reflection path to fix a bug around blocked types. I fix that bug by simply returning an empty `EnumInfo`.

I had to make generic type definition EETypes carry their CorElementType to make this work property on generic type definitions of enums (for the corner case of enum type nested under a generic type). I'll see how difficult is it to add this to the binder on the Project N side when this ports over. If it's too complex, I'll simply restore the logic that accesses the first instance field type on generic definitions using reflection (under `#if PROJECTN`).