### PR TITLE
Add ProjectN fallback for generic enums

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -439,6 +439,23 @@ namespace Internal.Runtime.Augments
 
         public static Type GetEnumUnderlyingType(RuntimeTypeHandle enumTypeHandle)
         {
+#if PROJECTN
+            // RHBind doesn't emit CorElementType on generic type definitions, so this only works for
+            // open generics outside ProjectN. When we fix this, also remove the N-specific exclusion in EETypePtr.IsEnum.
+            if (enumTypeHandle.ToEETypePtr().IsGenericTypeDefinition)
+            {
+                Type enumType = Type.GetTypeFromHandle(enumTypeHandle);
+                FieldInfo[] candidates = enumType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                if (candidates.Length == 0)
+                    throw RuntimeAugments.Callbacks.CreateMissingMetadataException(enumType); // Most likely cause.
+
+                if (candidates.Length > 1)
+                    throw new BadImageFormatException();
+
+                return candidates[0].FieldType;
+            }
+#endif
+
             Debug.Assert(enumTypeHandle.ToEETypePtr().IsEnum);
 
             RuntimeImports.RhCorElementType corElementType = enumTypeHandle.ToEETypePtr().CorElementType;

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -197,7 +197,13 @@ namespace System
 
                 // Generic type definitions that return true for IsPrimitive are type definitions of generic enums.
                 // Otherwise check the base type.
-                return (IsGenericTypeDefinition && IsPrimitive) ||
+                return
+                    // RHBind doesn't emit CorElementType on generic type definitions, so this only works for
+                    // open generics outside ProjectN. When we fix this, also remove the N-specific fallback for getting
+                    // the underlying type of open enums in RuntimeAugments.
+#if !PROJECTN
+                    (IsGenericTypeDefinition && IsPrimitive) ||
+#endif
                     this.BaseType == EETypePtr.EETypePtrOf<Enum>();
             }
         }


### PR DESCRIPTION
Turns out it would be unnecessarily complicated to pipe this through to
rhbind (need to do this in NUTC, update the CTL format, and pipe it
through the binder).