### PR TITLE
Update CoreCLR test script for VS2019

### DIFF
--- a/tests/CoreCLR/runtest/runtest.cmd
+++ b/tests/CoreCLR/runtest/runtest.cmd
@@ -104,6 +104,11 @@ if %__VSToolsRoot:~-1%==\ set "__VSToolsRoot=%__VSToolsRoot:~0,-1%"
 
 set _msbuildexe="%VSINSTALLDIR%\MSBuild\15.0\Bin\MSBuild.exe"
 
+if not exist !_msbuildexe! (
+    REM VS2019 changed the path MSBuild.exe lives under
+    set _msbuildexe="%VSINSTALLDIR%\MSBuild\Current\Bin\MSBuild.exe"
+)
+
 if not exist !_msbuildexe! (echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/corert/blob/master/Documentation/prerequisites-for-building.md for build instructions. && exit /b 1)
 
 :: Set the environment for the  build- VS cmd prompt

--- a/tests/CoreCLR/runtest/runtest.cmd
+++ b/tests/CoreCLR/runtest/runtest.cmd
@@ -10,9 +10,11 @@ set __BuildOS=Windows_NT
 if defined VS160COMNTOOLS (
     set __VSVersion=vs2019
     set __VSProductVersion=160
+    set _msbuildexe="%VSINSTALLDIR%\MSBuild\Current\Bin\MSBuild.exe"
 ) else (
     set __VSVersion=vs2017
     set __VSProductVersion=150
+    set _msbuildexe="%VSINSTALLDIR%\MSBuild\15.0\Bin\MSBuild.exe"
 )
 
 :: Define a prefix for most output progress messages that come from this script. That makes
@@ -101,13 +103,6 @@ if not defined VS%__VSProductVersion%COMNTOOLS goto NoVS
 
 set __VSToolsRoot=!VS%__VSProductVersion%COMNTOOLS!
 if %__VSToolsRoot:~-1%==\ set "__VSToolsRoot=%__VSToolsRoot:~0,-1%"
-
-set _msbuildexe="%VSINSTALLDIR%\MSBuild\15.0\Bin\MSBuild.exe"
-
-if not exist !_msbuildexe! (
-    REM VS2019 changed the path MSBuild.exe lives under
-    set _msbuildexe="%VSINSTALLDIR%\MSBuild\Current\Bin\MSBuild.exe"
-)
 
 if not exist !_msbuildexe! (echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/corert/blob/master/Documentation/prerequisites-for-building.md for build instructions. && exit /b 1)
 


### PR DESCRIPTION
After installing VS2019 the CoreCLR test scripts can no longer find MSBuild.exe because it was moved within the VS install folder. Fix to try both options before giving up.