### PR TITLE
Minor SuperIlc fixes / improvements found while using the tool

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
@@ -70,10 +70,10 @@ namespace ReadyToRun.SuperIlc
                 }
                 if (++count % 100 == 0)
                 {
-                    Console.WriteLine($@"Found {folders.Count} apps in {count} / {directories.Length} folders");
+                    Console.WriteLine($@"Found {folders.Count} folders to build ({count} / {directories.Length} folders scanned)");
                 }
             }
-            Console.WriteLine($@"Found {folders.Count} folders with managed assemblies in {directories.Length} folders");
+            Console.WriteLine($@"Found {folders.Count} folders to build ({directories.Length} folders scanned)");
 
             string timeStamp = DateTime.Now.ToString("MMdd-hhmm");
             string folderSetLogPath = Path.Combine(options.OutputDirectory.ToString(), "subtree-" + timeStamp + ".log");

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -263,7 +263,7 @@ public class ProcessRunner : IDisposable
                 string failureMessage = $"{_processIndex}: failed in {_processInfo.DurationMilliseconds} msecs, exit code {_processInfo.ExitCode}";
                 if (_processInfo.ExitCode < 0)
                 {
-                    failureMessage += " = 0x{_processInfo.ExitCode:X8}";
+                    failureMessage += $" = 0x{_processInfo.ExitCode:X8}";
                 }
                 failureMessage += $", expected {_processInfo.ExpectedExitCode}";
                 _logWriter.WriteLine(failureMessage);


### PR DESCRIPTION
One non-trivial revelation I made is that my previous introduction
of Outcome was inconsistent w.r.t. the summary table as there is
generally a different number of compilations and executions.
I have fixed this by splitting the summary table in two for
compilations and executions.

Thanks

Tomas