### PR TITLE
Add analysis of EventSource metadata

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/BlockedInternalsBlockingPolicy.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/BlockedInternalsBlockingPolicy.cs
@@ -110,6 +110,10 @@ namespace ILCompiler
                 if (type.Name == "SR")
                     return false;
 
+                // Event sources are not blocked
+                if (type.HasCustomAttribute("System.Diagnostics.Tracing", "EventSourceAttribute"))
+                    return false;
+
                 // We block everything else if the module is blocked
                 if (blockingMode == ModuleBlockingMode.FullyBlocked)
                     return true;

--- a/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
@@ -219,6 +219,29 @@ namespace ILCompiler
                     }
                 }
             }
+
+            // Event sources need their special nested types
+            if (type is MetadataType mdType && mdType.HasCustomAttribute("System.Diagnostics.Tracing", "EventSourceAttribute"))
+            {
+                AddEventSourceSpecialTypeDependencies(ref dependencies, factory, mdType.GetNestedType("Keywords"));
+                AddEventSourceSpecialTypeDependencies(ref dependencies, factory, mdType.GetNestedType("Tasks"));
+                AddEventSourceSpecialTypeDependencies(ref dependencies, factory, mdType.GetNestedType("Opcodes"));
+
+                void AddEventSourceSpecialTypeDependencies(ref DependencyList dependencies, NodeFactory factory, MetadataType type)
+                {
+                    if (type != null)
+                    {
+                        const string reason = "Event source";
+                        dependencies = dependencies ?? new DependencyList();
+                        dependencies.Add(factory.TypeMetadata(type), reason);
+                        foreach (FieldDesc field in type.GetFields())
+                        {
+                            if (field.IsLiteral)
+                                dependencies.Add(factory.FieldMetadata(field), reason);
+                        }
+                    }
+                }
+            }
         }
 
         protected override void GetRuntimeMappingDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)


### PR DESCRIPTION
Event sources should not be blocked, so we need to poke a hole through blocking. On Project N, there's a separate IL2IL transform that deals with framework-provided event sources to sidestep this - I don't think we want to replicate that.

Then we need to add special rule to make the compiler keep metadata for the magical nested types.