### PR TITLE
Enhance analysis of reflection dependencies

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodMetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/MethodMetadataNode.cs
@@ -38,6 +38,14 @@ namespace ILCompiler.DependencyAnalysis
 
             CustomAttributeBasedDependencyAlgorithm.AddDependenciesDueToCustomAttributes(ref dependencies, factory, ((EcmaMethod)_method));
 
+            MethodSignature sig = _method.Signature;
+            const string reason = "Method signature metadata";
+            TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, sig.ReturnType, reason);
+            foreach (TypeDesc paramType in sig)
+            {
+                TypeMetadataNode.GetMetadataDependencies(ref dependencies, factory, paramType, reason);
+            }
+
             return dependencies;
         }
         protected override string GetName(NodeFactory factory)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -54,6 +54,13 @@ namespace ILCompiler.DependencyAnalysis
                     dependencies.Add(factory.MethodMetadata(invokeMethod), "Delegate invoke method metadata");
             }
 
+            if (_type.IsEnum)
+            {
+                // A lot of the enum reflection actually happens on top of the respective EEType (e.g. getting the underlying type),
+                // so for enums also include their EEType.
+                dependencies.Add(factory.MaximallyConstructableType(_type), "Reflectable enum");
+            }
+
             // If the user asked for complete metadata to be generated for all types that are getting metadata, ensure that.
             if ((mdManager._generationOptions & UsageBasedMetadataGenerationOptions.CompleteTypesOnly) != 0)
             {
@@ -91,6 +98,10 @@ namespace ILCompiler.DependencyAnalysis
                     break;
                 case TypeFlags.FunctionPointer:
                     throw new NotImplementedException();
+
+                case TypeFlags.SignatureMethodVariable:
+                case TypeFlags.SignatureTypeVariable:
+                    break;
 
                 default:
                     Debug.Assert(type.IsDefType);

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -36,6 +36,7 @@ internal class ReflectionTest
 #endif
 #endif
         TestILScanner.Run();
+        TestUnreferencedEnum.Run();
 
         TestAttributeInheritance.Run();
         TestStringConstructor.Run();
@@ -1095,6 +1096,33 @@ internal class ReflectionTest
 
                 mi.Invoke(null, Array.Empty<object>());
             }
+        }
+    }
+
+    class TestUnreferencedEnum
+    {
+        public enum UnreferencedEnum { One }
+
+#if OPTIMIZED_MODE_WITHOUT_SCANNER
+        [MethodImpl(MethodImplOptions.NoInlining)]
+#endif
+        public static void ReferenceEnum(UnreferencedEnum r)
+        {
+        }
+
+        public static void Run()
+        {
+            Console.WriteLine(nameof(TestUnreferencedEnum));
+
+            if (String.Empty.Length > 0)
+            {
+                ReferenceEnum(default);
+            }
+
+            MethodInfo mi = typeof(TestUnreferencedEnum).GetMethod(nameof(ReferenceEnum));
+            Type enumType = mi.GetParameters()[0].ParameterType;
+            if (Enum.GetUnderlyingType(enumType) != typeof(int))
+                throw new Exception();
         }
     }
 


### PR DESCRIPTION
EventSource reflects on method signatures that might refer to types we never heard about (they were never referenced from code in a way that would bring in the dependency). Bring the dependencies explicitly.