### PR TITLE
Smaller SuperIlc fixes for bugs I hit in local testing

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -103,7 +103,7 @@ namespace ReadyToRun.SuperIlc
             _logWriter.WriteLine($"Building {_buildFolders.Count()} folders ({compilationsToRun.Count} compilations total)");
             compilationsToRun.Sort((a, b) => b.CompilationCostHeuristic.CompareTo(a.CompilationCostHeuristic));
 
-            ParallelRunner.Run(startIndex: 0, compilationsToRun, _logWriter);
+            ParallelRunner.Run(compilationsToRun, _logWriter);
             
             bool success = true;
             List<KeyValuePair<string, string>> failedCompilationsPerBuilder = new List<KeyValuePair<string, string>>();
@@ -184,7 +184,7 @@ namespace ReadyToRun.SuperIlc
                 AddBuildFolderExecutions(executionsToRun, folder, stopwatch);
             }
 
-            ParallelRunner.Run(startIndex: 0, executionsToRun, _logWriter);
+            ParallelRunner.Run(executionsToRun, _logWriter, degreeOfParallelism: _options.Sequential ? 1 : Environment.ProcessorCount);
 
             List<KeyValuePair<string, string>> failedExecutionsPerBuilder = new List<KeyValuePair<string, string>>();
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -28,7 +28,7 @@ namespace ReadyToRun.SuperIlc
                         OutputDirectory(),
                         CoreRootDirectory(),
                         CpaotDirectory(),
-                        UseCrossgen(),
+                        Crossgen(),
                         NoJit(),
                         NoExe(),
                         NoEtw(),
@@ -45,7 +45,7 @@ namespace ReadyToRun.SuperIlc
                         OutputDirectory(),
                         CoreRootDirectory(),
                         CpaotDirectory(),
-                        UseCrossgen(),
+                        Crossgen(),
                         NoJit(),
                         NoExe(),
                         NoEtw(),
@@ -71,7 +71,7 @@ namespace ReadyToRun.SuperIlc
             Option ReferencePath() =>
                 new Option(new[] { "--reference-path", "-r" }, "Folder containing assemblies to reference during compilation", new Argument<DirectoryInfo[]>() { Arity = ArgumentArity.ZeroOrMore }.ExistingOnly());
 
-            Option UseCrossgen() =>
+            Option Crossgen() =>
                 new Option(new[] { "--crossgen" }, "Compile the apps using Crossgen in the CORE_ROOT folder", new Argument<bool>());
 
             Option NoJit() =>

--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -33,6 +33,7 @@ namespace ReadyToRun.SuperIlc
                         NoExe(),
                         NoEtw(),
                         NoCleanup(),
+                        Sequential(),
                         ReferencePath()
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileDirectoryCommand.CompileDirectory));
@@ -50,6 +51,7 @@ namespace ReadyToRun.SuperIlc
                         NoExe(),
                         NoEtw(),
                         NoCleanup(),
+                        Sequential(),
                         ReferencePath()
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileSubtreeCommand.CompileSubtree));
@@ -85,6 +87,9 @@ namespace ReadyToRun.SuperIlc
 
             Option NoCleanup() =>
                 new Option(new[] { "--nocleanup" }, "Don't clean up compilation artifacts after test runs", new Argument<bool>());
+
+            Option Sequential() =>
+                new Option(new[] { "--sequential" }, "Run tests sequentially", new Argument<bool>());
         }
     }
 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
@@ -244,6 +244,7 @@ namespace ReadyToRun.SuperIlc
                         line.StartsWith("EXEC : warning") ||
                         line.StartsWith("To repro,") ||
                         line.StartsWith("Emitting R2R PE file") ||
+                        line.StartsWith("Warning: ") ||
                         line == "Assertion Failed")
                     {
                         continue;

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -66,6 +66,8 @@ public class ProcessRunner : IDisposable
 
     private readonly int _processIndex;
 
+    private readonly int _processCount;
+
     private Process _process;
 
     private ReadyToRunJittedMethods _jittedMethods;
@@ -81,10 +83,11 @@ public class ProcessRunner : IDisposable
 
     private CancellationTokenSource _cancellationTokenSource;
 
-    public ProcessRunner(ProcessInfo processInfo, int processIndex, ReadyToRunJittedMethods jittedMethods, AutoResetEvent processExitEvent)
+    public ProcessRunner(ProcessInfo processInfo, int processIndex, int processCount, ReadyToRunJittedMethods jittedMethods, AutoResetEvent processExitEvent)
     {
         _processInfo = processInfo;
         _processIndex = processIndex;
+        _processCount = processCount;
         _jittedMethods = jittedMethods;
         _processExitEvent = processExitEvent;
 
@@ -227,7 +230,7 @@ public class ProcessRunner : IDisposable
         }
     }
 
-    public bool IsAvailable()
+    public bool IsAvailable(ref int progressIndex)
     {
         if (_state != StateFinishing)
         {
@@ -244,15 +247,18 @@ public class ProcessRunner : IDisposable
             processSpec = _processInfo.ProcessPath;
         }
 
+        string linePrefix = $"{_processIndex} / {_processCount} ({(++progressIndex * 100 / _processCount)}%): ";
+
         if (_process.WaitForExit(0))
         {
             _process.WaitForExit();
             _processInfo.ExitCode = _process.ExitCode;
             _processInfo.Succeeded = (_processInfo.ExitCode == _processInfo.ExpectedExitCode);
             _logWriter.WriteLine(">>>>");
+
             if (_processInfo.Succeeded)
             {
-                string successMessage = $"{_processIndex}: succeeded in {_processInfo.DurationMilliseconds} msecs";
+                string successMessage = linePrefix + $"succeeded in {_processInfo.DurationMilliseconds} msecs";
 
                 _logWriter.WriteLine(successMessage);
                 Console.WriteLine(successMessage + $": {processSpec}");
@@ -260,7 +266,7 @@ public class ProcessRunner : IDisposable
             }
             else
             {
-                string failureMessage = $"{_processIndex}: failed in {_processInfo.DurationMilliseconds} msecs, exit code {_processInfo.ExitCode}";
+                string failureMessage = linePrefix + $"failed in {_processInfo.DurationMilliseconds} msecs, exit code {_processInfo.ExitCode}";
                 if (_processInfo.ExitCode < 0)
                 {
                     failureMessage += $" = 0x{_processInfo.ExitCode:X8}";
@@ -278,7 +284,7 @@ public class ProcessRunner : IDisposable
             _processInfo.TimedOut = true;
             _processInfo.Succeeded = false;
             _logWriter.WriteLine(">>>>");
-            string timeoutMessage = $"{_processIndex}: timed out in {_processInfo.DurationMilliseconds} msecs";
+            string timeoutMessage = linePrefix + $"timed out in {_processInfo.DurationMilliseconds} msecs";
             _logWriter.WriteLine(timeoutMessage);
             Console.Error.WriteLine(timeoutMessage + $": {processSpec}");
         }

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -17,9 +17,9 @@ using Microsoft.Diagnostics.Tracing.Session;
 public class ProcessInfo
 {
     /// <summary>
-    /// 10 minutes should be plenty for a CPAOT / Crossgen compilation.
+    /// 2 minutes should be plenty for a CPAOT / Crossgen compilation.
     /// </summary>
-    public const int DefaultIlcTimeout = 600 * 1000;
+    public const int DefaultIlcTimeout = 2 * 60 * 1000;
 
     /// <summary>
     /// Test execution timeout.

--- a/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
@@ -17,6 +17,7 @@ namespace ReadyToRun.SuperIlc
         public bool NoExe { get; set; }
         public bool NoEtw { get; set; }
         public bool NoCleanup { get; set; }
+        public bool Sequential { get; set; }
         public DirectoryInfo[] ReferencePath { get; set; }
 
         public IEnumerable<string> ReferencePaths()

--- a/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
@@ -12,7 +12,7 @@ namespace ReadyToRun.SuperIlc
         public DirectoryInfo OutputDirectory { get; set; }
         public DirectoryInfo CoreRootDirectory { get; set; }
         public DirectoryInfo CpaotDirectory { get; set; }
-        public bool UseCrossgen { get; set; }
+        public bool Crossgen { get; set; }
         public bool NoJit { get; set; }
         public bool NoExe { get; set; }
         public bool NoEtw { get; set; }
@@ -44,7 +44,7 @@ namespace ReadyToRun.SuperIlc
                 runners.Add(new CpaotRunner(CpaotDirectory.FullName, referencePaths));
             }
 
-            if (UseCrossgen)
+            if (Crossgen)
             {
                 if (CoreRootDirectory == null)
                 {


### PR DESCRIPTION
1) One of the interesting features of the new command-line interface
is the fact that it tries to match the option names to identifiers
of fields and method parameters. Due to this the option --crossgen
didn't get bound because the counterpart field was called UseCrossgen.
I have renamed the field to just Crossgen.

2) Don't schedule executions for apps that failed to compile as
the executions are certain to fail due to the absence of the compiled
artifacts.

Thanks

Tomas