### PR TITLE
Fixes for some of the remaining Pri#1 CPAOT compilation buckets

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -275,7 +275,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             public DummyTypeInfo GetTypeFromSpecification(MetadataReader reader, ModuleTokenResolver genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
             {
-                throw new NotImplementedException();
+                TypeSpecification typeSpec = reader.GetTypeSpecification(handle);
+                typeSpec.DecodeSignature(this, genericContext);
+                return DummyTypeInfo.Instance;
             }
         }
     }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -218,6 +218,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     EmitPointerTypeSignature((PointerType)typeDesc, context);
                     return;
 
+                case TypeFlags.ByRef:
+                    EmitByRefTypeSignature((ByRefType)typeDesc, context);
+                    break;
+
                 case TypeFlags.Void:
                     EmitElementType(CorElementType.ELEMENT_TYPE_VOID);
                     return;
@@ -334,6 +338,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             EmitTypeSignature(type.ParameterType, context);
         }
 
+        private void EmitByRefTypeSignature(ByRefType type, SignatureContext context)
+        {
+            EmitElementType(CorElementType.ELEMENT_TYPE_BYREF);
+            EmitTypeSignature(type.ParameterType, context);
+        }
+
         private void EmitSzArrayTypeSignature(ArrayType type, SignatureContext context)
         {
             Debug.Assert(type.IsSzArray);
@@ -377,7 +387,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 flags |= (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_Constrained;
             }
 
-            if (method.HasInstantiation || method.OwningType.HasInstantiation)
+            if ((method.HasInstantiation || method.OwningType.HasInstantiation) && !method.IsGenericMethodDefinition)
             {
                 EmitMethodSpecificationSignature(method, methodToken, flags, enforceDefEncoding, context);
             }


### PR DESCRIPTION
1) Handling for ByRef in the signature emitter;

2) Expanding instantiated type signatures;

3) Not trying to emit instantiations when asked to emit the
uninstantiated generic methods in signatures.

Thanks

Tomas