### PR TITLE
Updating the roslyn toolset to 3.1.0-beta3-19213-02

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -271,9 +271,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RoslynVersion>3.0.0-beta4-final</RoslynVersion>
-    <RoslynPackageName>Microsoft.Net.Compilers</RoslynPackageName>
-    <RoslynPackageName Condition="'$(RunningOnCore)' == 'true'">Microsoft.NETCore.Compilers</RoslynPackageName>
+    <RoslynVersion>3.1.0-beta3-19213-02</RoslynVersion>
+    <RoslynPackageName>Microsoft.Net.Compilers.Toolset</RoslynPackageName>
     <RoslynPackageDir>$(PackagesDir)/$(RoslynPackageName.ToLower())/$(RoslynVersion)/</RoslynPackageDir>
     <RoslynPropsFile>$(RoslynPackageDir)build/$(RoslynPackageName).props</RoslynPropsFile>
   </PropertyGroup>

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -11,7 +11,7 @@ set /P BUILDTOOLS_VERSION=< "%~dp0BuildToolsVersion.txt"
 set BUILD_TOOLS_PATH=%PACKAGES_DIR%\Microsoft.DotNet.BuildTools\%BUILDTOOLS_VERSION%\lib
 set INIT_TOOLS_RESTORE_PROJECT=%~dp0init-tools.msbuild
 set BUILD_TOOLS_SEMAPHORE_DIR=%TOOLRUNTIME_DIR%\%BUILDTOOLS_VERSION%
-set BUILD_TOOLS_SEMAPHORE=%BUILD_TOOLS_SEMAPHORE_DIR%\init-tools.completed_2
+set BUILD_TOOLS_SEMAPHORE=%BUILD_TOOLS_SEMAPHORE_DIR%\init-tools.completed_3
 
 :: if force option is specified then clean the tool runtime and build tools package directory to force it to get recreated
 if [%1]==[force] (
@@ -83,9 +83,9 @@ if not [%INIT_TOOLS_ERRORLEVEL%]==[0] (
 
 :: Restore a custom RoslynToolset since we can't trivially update the BuildTools dependency in CoreRT
 echo Configurating RoslynToolset...
-set ROSLYNCOMPILERS_VERSION=3.0.0-beta4-final
+set ROSLYNCOMPILERS_VERSION=3.1.0-beta3-19213-02
 set DEFAULT_RESTORE_ARGS=--no-cache --packages "%PACKAGES_DIR%"
-set INIT_TOOLS_RESTORE_ARGS=%DEFAULT_RESTORE_ARGS% --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json %INIT_TOOLS_RESTORE_ARGS%
+set INIT_TOOLS_RESTORE_ARGS=%DEFAULT_RESTORE_ARGS% --source https://dotnet.myget.org/F/roslyn/api/v3/index.json --source https://api.nuget.org/v3/index.json %INIT_TOOLS_RESTORE_ARGS%
 set MSBUILD_PROJECT_CONTENT= ^
  ^^^<Project Sdk=^"Microsoft.NET.Sdk^"^^^> ^
   ^^^<PropertyGroup^^^> ^
@@ -93,8 +93,7 @@ set MSBUILD_PROJECT_CONTENT= ^
     ^^^<DisableImplicitFrameworkReferences^^^>true^^^</DisableImplicitFrameworkReferences^^^> ^
   ^^^</PropertyGroup^^^> ^
   ^^^<ItemGroup^^^> ^
-    ^^^<PackageReference Include=^"Microsoft.Net.Compilers^" Version=^"%ROSLYNCOMPILERS_VERSION%^" /^^^> ^
-    ^^^<PackageReference Include=^"Microsoft.NETCore.Compilers^" Version=^"%ROSLYNCOMPILERS_VERSION%^" /^^^> ^
+    ^^^<PackageReference Include=^"Microsoft.Net.Compilers.Toolset^" Version=^"%ROSLYNCOMPILERS_VERSION%^" /^^^> ^
   ^^^</ItemGroup^^^> ^
  ^^^</Project^^^>
 set PORTABLETARGETS_PROJECT=%TOOLRUNTIME_DIR%\generated\project.csproj
@@ -107,9 +106,6 @@ if not [%RESTORE_PORTABLETARGETS_ERROR_LEVEL%]==[0] (
   echo ERROR: An error ocurred when running: '"%DOTNET_CMD%" restore "%PORTABLETARGETS_PROJECT%"'. Please check above for more details.
   exit /b %RESTORE_PORTABLETARGETS_ERROR_LEVEL%
 )
-
-:: Copy Roslyn Compilers Over to ToolRuntime
-Robocopy "%PACKAGES_DIR%\Microsoft.Net.Compilers\%ROSLYNCOMPILERS_VERSION%\." "%TOOLRUNTIME_DIR%\net46\roslyn\." /E
 
 :: Create semaphore file
 echo Done initializing tools.

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -18,7 +18,7 @@ __DOTNET_TOOLS_VERSION=$(cat $__scriptpath/DotnetCLIVersion.txt)
 __BUILD_TOOLS_PATH=$__PACKAGES_DIR/microsoft.dotnet.buildtools/$__BUILD_TOOLS_PACKAGE_VERSION/lib
 __INIT_TOOLS_RESTORE_PROJECT=$__scriptpath/init-tools.msbuild
 __INIT_TOOLS_DONE_MARKER_DIR=$__TOOLRUNTIME_DIR/$__BUILD_TOOLS_PACKAGE_VERSION
-__INIT_TOOLS_DONE_MARKER=$__INIT_TOOLS_DONE_MARKER_DIR/done_2
+__INIT_TOOLS_DONE_MARKER=$__INIT_TOOLS_DONE_MARKER_DIR/done_3
 
 if [ -z "$__DOTNET_PKG" ]; then
     OSName=$(uname -s)
@@ -142,9 +142,9 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
 
         # Restore a custom RoslynToolset since we can't trivially update the BuildTools dependency in CoreRT
         echo "Configuring RoslynToolset..."
-        __ROSLYNCOMPILER_VERSION=3.0.0-beta4-final
+        __ROSLYNCOMPILER_VERSION=3.1.0-beta3-19213-02
         __DEFAULT_RESTORE_ARGS="--no-cache --packages \"${__PACKAGES_DIR}\""
-        __INIT_TOOLS_RESTORE_ARGS="${__DEFAULT_RESTORE_ARGS} --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
+        __INIT_TOOLS_RESTORE_ARGS="${__DEFAULT_RESTORE_ARGS} --source https://dotnet.myget.org/F/roslyn/api/v3/index.json --source https://api.nuget.org/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
         __PORTABLETARGETS_PROJECT_CONTENT="
         <Project>
           <PropertyGroup>
@@ -156,7 +156,7 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
           <Import Project=\"Sdk.props\" Sdk=\"Microsoft.NET.Sdk\" />
           <ItemGroup>
             <PackageReference Include=\"MicroBuild.Core\" Version=\"$__MICROBUILD_VERSION\" />
-            <PackageReference Include=\"Microsoft.NETCore.Compilers\" Version=\"$__ROSLYNCOMPILER_VERSION\" />
+            <PackageReference Include=\"Microsoft.Net.Compilers.Toolset\" Version=\"$__ROSLYNCOMPILER_VERSION\" />
           </ItemGroup>
           <Import Project=\"Sdk.targets\" Sdk=\"Microsoft.NET.Sdk\" />
         </Project>"

--- a/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadataAssembly.csproj
+++ b/src/ILCompiler.MetadataTransform/tests/SampleMetadataAssembly/SampleMetadataAssembly.csproj
@@ -5,6 +5,8 @@
     <AssemblyName>SampleMetadataAssembly</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SkipTestRun>true</SkipTestRun>
+    <!-- Workaround for https://github.com/dotnet/roslyn/issues/35056 -->
+    <LangVersion>7.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
CC. @jkotas 

This brings in the latest nullability changes and the new `readonly members` feature, which will be needed for changes like https://github.com/dotnet/coreclr/pull/23827

The compiler version matches that in arcade and buildtools right now.