### PR TITLE
Increase official build Linux job timeout

### DIFF
--- a/buildpipeline/DotNet-CoreRT-Linux.json
+++ b/buildpipeline/DotNet-CoreRT-Linux.json
@@ -803,7 +803,7 @@
   ],
   "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
   "jobAuthorizationScope": "projectCollection",
-  "jobTimeoutInMinutes": 60,
+  "jobTimeoutInMinutes": 120,
   "repository": {
     "properties": {
       "labelSources": "0",


### PR DESCRIPTION
We need more time when building the object writer package. 120 is probably overboard (we timed out while copying artifacts around), but it matches the Windows job timeout.