### PR TITLE
Add missing null check to ThreadInt64PersistentCounter

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
@@ -58,7 +58,10 @@ namespace System.Threading
                         count = _overflowCount;
                         foreach (ThreadLocalNode node in _threadLocalNode.ValuesAsEnumerable)
                         {
-                            count += node.Count;
+                            if (node != null)
+                            {
+                                count += node.Count;
+                            }
                         }
                         return count;
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corert/issues/7348
- Getting the `Value` property of a `ThreadLocal` as in `ThreadInt64PersistentCounter.Increment()` would link a node into the `ThreadLocal`'s linked list, and before the `Value` property is set by `Increment()`, another thread may get a null node while scanning the linked nodes. There could be other races too.
- Added check for null node when scanning the values of all threads