### PR TITLE
Port GC changes from coreclr - 4

### DIFF
--- a/src/Native/Runtime/HandleTableHelpers.cpp
+++ b/src/Native/Runtime/HandleTableHelpers.cpp
@@ -13,12 +13,12 @@
 #include "gcenv.h"
 #include "objecthandle.h"
 #include "RestrictedCallouts.h"
-#include "gcheaputilities.h"
+#include "gchandletableutilities.h"
 
 
 COOP_PINVOKE_HELPER(OBJECTHANDLE, RhpHandleAlloc, (Object *pObject, int type))
 {
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], pObject, type);
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], pObject, type);
 }
 
 COOP_PINVOKE_HELPER(OBJECTHANDLE, RhpHandleAllocDependent, (Object *pPrimary, Object *pSecondary))

--- a/src/Native/Runtime/HandleTableHelpers.cpp
+++ b/src/Native/Runtime/HandleTableHelpers.cpp
@@ -23,7 +23,7 @@ COOP_PINVOKE_HELPER(OBJECTHANDLE, RhpHandleAlloc, (Object *pObject, int type))
 
 COOP_PINVOKE_HELPER(OBJECTHANDLE, RhpHandleAllocDependent, (Object *pPrimary, Object *pSecondary))
 {
-    return CreateDependentHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], pPrimary, pSecondary);
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateDependentHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], pPrimary, pSecondary);
 }
 
 COOP_PINVOKE_HELPER(void, RhHandleFree, (OBJECTHANDLE handle))

--- a/src/Native/Runtime/HandleTableHelpers.cpp
+++ b/src/Native/Runtime/HandleTableHelpers.cpp
@@ -18,7 +18,7 @@
 
 COOP_PINVOKE_HELPER(OBJECTHANDLE, RhpHandleAlloc, (Object *pObject, int type))
 {
-    return CreateTypedHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], pObject, type);
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], pObject, type);
 }
 
 COOP_PINVOKE_HELPER(OBJECTHANDLE, RhpHandleAllocDependent, (Object *pPrimary, Object *pSecondary))

--- a/src/Native/Runtime/gchandletableutilities.h
+++ b/src/Native/Runtime/gchandletableutilities.h
@@ -7,6 +7,10 @@
 
 #include "gcinterface.h"
 
+#ifdef FEATURE_COMINTEROP
+#include <weakreference.h>
+#endif
+
 extern "C" IGCHandleTable* g_pGCHandleTable;
 
 class GCHandleTableUtilities
@@ -37,6 +41,13 @@ inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
 
 #ifndef DACCESS_COMPILE
 
+// Handle creation convenience functions
+
+inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+}
+
 inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
@@ -50,11 +61,6 @@ inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
 inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
-}
-
-inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
 }
 
 inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
@@ -81,6 +87,55 @@ inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
 }
+
+// Global handle creation convenience functions
+
+inline OBJECTHANDLE CreateGlobalHandle(OBJECTREF object)
+{
+    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateGlobalWeakHandle(OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateGlobalShortWeakHandle(OBJECTREF object)
+{
+    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+}
+
+inline OBJECTHANDLE CreateGlobalLongWeakHandle(OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+}
+
+inline OBJECTHANDLE CreateGlobalStrongHandle(OBJECTREF object)
+{
+    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_STRONG);
+}
+
+inline OBJECTHANDLE CreateGlobalPinningHandle(OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_PINNED);
+}
+
+inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateGlobalHandleOfType(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+}
+
+// Special handle creation convenience functions
+
+#ifdef FEATURE_COMINTEROP
+inline OBJECTHANDLE CreateWinRTWeakHandle(HHANDLETABLE table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table, OBJECTREFToObject(object), HNDTYPE_WEAK_WINRT, (void*)pWinRTWeakReference);
+}
+#endif // FEATURE_COMINTEROP
 
 #endif // !DACCESS_COMPILE
 

--- a/src/Native/Runtime/gchandletableutilities.h
+++ b/src/Native/Runtime/gchandletableutilities.h
@@ -133,9 +133,21 @@ inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
 #ifdef FEATURE_COMINTEROP
 inline OBJECTHANDLE CreateWinRTWeakHandle(HHANDLETABLE table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table, OBJECTREFToObject(object), HNDTYPE_WEAK_WINRT, (void*)pWinRTWeakReference);
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
+                                                                                 OBJECTREFToObject(object),
+                                                                                 HNDTYPE_WEAK_WINRT,
+                                                                                 (void*)pWinRTWeakReference);
 }
 #endif // FEATURE_COMINTEROP
+
+// Creates a variable-strength handle
+inline OBJECTHANDLE CreateVariableHandle(HHANDLETABLE table, OBJECTREF object, uint32_t type)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
+                                                                                 OBJECTREFToObject(object),
+                                                                                 HNDTYPE_VARIABLE,
+                                                                                 (void*)((uintptr_t)type));
+}
 
 #endif // !DACCESS_COMPILE
 

--- a/src/Native/Runtime/gchandletableutilities.h
+++ b/src/Native/Runtime/gchandletableutilities.h
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef _GCHANDLETABLEUTILITIES_H_
+#define _GCHANDLETABLEUTILITIES_H_
+
+#include "gcinterface.h"
+
+extern "C" IGCHandleTable* g_pGCHandleTable;
+
+class GCHandleTableUtilities
+{
+public:
+    // Retrieves the GC handle table.
+    static IGCHandleTable* GetGCHandleTable() 
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        assert(g_pGCHandleTable != nullptr);
+        return g_pGCHandleTable;
+    }
+
+private:
+    // This class should never be instantiated.
+    GCHandleTableUtilities() = delete;
+};
+
+// Given a handle, returns an OBJECTREF for the object it refers to.
+inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
+{
+    _ASSERTE(handle);
+
+    // Wrap the raw OBJECTREF and return it
+    return UNCHECKED_OBJECTREF_TO_OBJECTREF(*PTR_UNCHECKED_OBJECTREF(handle));
+}
+
+#ifndef DACCESS_COMPILE
+
+inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+}
+
+inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+}
+
+inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_STRONG);
+}
+
+inline OBJECTHANDLE CreatePinningHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_PINNED);
+}
+
+inline OBJECTHANDLE CreateSizedRefHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
+}
+
+inline OBJECTHANDLE CreateAsyncPinningHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
+}
+
+inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+}
+
+#endif // !DACCESS_COMPILE
+
+#endif // _GCHANDLETABLEUTILITIES_H_
+

--- a/src/Native/Runtime/gcheaputilities.cpp
+++ b/src/Native/Runtime/gcheaputilities.cpp
@@ -5,6 +5,7 @@
 #include "common.h"
 #include "gcenv.h"
 #include "gcheaputilities.h"
+#include "gchandletableutilities.h"
 
 // This is the global GC heap, maintained by the VM.
 GPTR_IMPL(IGCHeap, g_pGCHeap);

--- a/src/Native/Runtime/gcheaputilities.h
+++ b/src/Native/Runtime/gcheaputilities.h
@@ -22,8 +22,6 @@ GVAL_DECL(GCHeapType, g_heap_type);
 }
 #endif // !DACCESS_COMPILE
 
-extern "C" IGCHandleTable* g_pGCHandleTable;
-
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
 extern "C" uint32_t* g_card_bundle_table;
 #endif // FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
@@ -59,15 +57,6 @@ public:
         return g_pGCHeap;
     }
 
-    // Retrieves the GC handle table.
-    static IGCHandleTable* GetGCHandleTable() 
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        assert(g_pGCHandleTable != nullptr);
-        return g_pGCHandleTable;
-    }
-
     // Returns true if the heap has been initialized, false otherwise.
     inline static bool IsGCHeapInitialized()
     {
@@ -99,65 +88,5 @@ private:
     // This class should never be instantiated.
     GCHeapUtilities() = delete;
 };
-
-// Handle-related utilities.
-
-// Given a handle, returns an OBJECTREF for the object it refers to.
-inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
-{
-    _ASSERTE(handle);
-
-    // Wrap the raw OBJECTREF and return it
-    return UNCHECKED_OBJECTREF_TO_OBJECTREF(*PTR_UNCHECKED_OBJECTREF(handle));
-}
-
-#ifndef DACCESS_COMPILE
-
-inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
-}
-
-inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
-}
-
-inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
-}
-
-inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
-}
-
-inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_STRONG);
-}
-
-inline OBJECTHANDLE CreatePinningHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_PINNED);
-}
-
-inline OBJECTHANDLE CreateSizedRefHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
-}
-
-inline OBJECTHANDLE CreateAsyncPinningHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
-}
-
-inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
-}
-
-#endif // !DACCESS_COMPILE
 
 #endif // _GCHEAPUTILITIES_H_

--- a/src/Native/Runtime/gcheaputilities.h
+++ b/src/Native/Runtime/gcheaputilities.h
@@ -111,4 +111,53 @@ inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
     return UNCHECKED_OBJECTREF_TO_OBJECTREF(*PTR_UNCHECKED_OBJECTREF(handle));
 }
 
+#ifndef DACCESS_COMPILE
+
+inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+}
+
+inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+}
+
+inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+}
+
+inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_STRONG);
+}
+
+inline OBJECTHANDLE CreatePinningHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_PINNED);
+}
+
+inline OBJECTHANDLE CreateSizedRefHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
+}
+
+inline OBJECTHANDLE CreateAsyncPinningHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
+}
+
+inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
+{
+    return GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+}
+
+#endif // !DACCESS_COMPILE
+
 #endif // _GCHEAPUTILITIES_H_

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -1471,6 +1471,11 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     return true;
 }
 
+bool GCToEEInterface::ForceFullGCToBeBlocking()
+{
+    return false;
+}
+
 bool GCToEEInterface::EagerFinalized(Object* obj)
 {
     return false;

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -12,6 +12,7 @@
 
 #include "gcenv.h"
 #include "gcheaputilities.h"
+#include "gchandletableutilities.h"
 #include "profheapwalkhelper.h"
 
 #ifdef FEATURE_STANDALONE_GC
@@ -242,7 +243,7 @@ bool RedhawkGCInterface::InitializeSubsystems(GCType gcType)
         return false;
 
     // Initialize HandleTable.
-    if (!GCHeapUtilities::GetGCHandleTable()->Initialize())
+    if (!GCHandleTableUtilities::GetGCHandleTable()->Initialize())
         return false;
 
     return true;
@@ -948,7 +949,7 @@ void RedhawkGCInterface::DestroyTypedHandle(void * handle)
 
 void* RedhawkGCInterface::CreateTypedHandle(void* pObject, int type)
 {
-    return (void*)GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], (Object*)pObject, type);
+    return (void*)GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], (Object*)pObject, type);
 }
 
 void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -1462,6 +1462,15 @@ void GCToEEInterface::HandleFatalError(unsigned int exitCode)
     EEPOLICY_HANDLE_FATAL_ERROR(exitCode);
 }
 
+bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj)
+{
+    // CoreCLR does not have appdomains, so this code path is dead. Other runtimes may
+    // choose to inspect the object being finalized here.
+    // [DESKTOP TODO] Desktop looks for "agile and finalizable" objects and may choose
+    // to move them to a new app domain instead of finalizing them here.
+    return true;
+}
+
 #endif // !DACCESS_COMPILE
 
 // NOTE: this method is not in thread.cpp because it needs access to the layout of alloc_context for DAC to know the 

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -1482,6 +1482,12 @@ bool GCToEEInterface::EagerFinalized(Object* obj)
     return false;
 }
 
+MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
+{
+    assert(g_pFreeObjectMethodTable != nullptr);
+    return g_pFreeObjectMethodTable;
+}
+
 #endif // !DACCESS_COMPILE
 
 // NOTE: this method is not in thread.cpp because it needs access to the layout of alloc_context for DAC to know the 

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -948,7 +948,7 @@ void RedhawkGCInterface::DestroyTypedHandle(void * handle)
 
 void* RedhawkGCInterface::CreateTypedHandle(void* pObject, int type)
 {
-    return (void*)::CreateTypedHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], (Object*)pObject, type);
+    return (void*)GCHeapUtilities::GetGCHandleTable()->CreateHandleOfType(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], (Object*)pObject, type);
 }
 
 void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -1471,6 +1471,11 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     return true;
 }
 
+bool GCToEEInterface::EagerFinalized(Object* obj)
+{
+    return false;
+}
+
 #endif // !DACCESS_COMPILE
 
 // NOTE: this method is not in thread.cpp because it needs access to the layout of alloc_context for DAC to know the 

--- a/src/Native/gc/env/gcenv.base.h
+++ b/src/Native/gc/env/gcenv.base.h
@@ -328,16 +328,6 @@ typedef PTR_PTR_Object PTR_OBJECTREF;
 typedef PTR_Object _UNCHECKED_OBJECTREF;
 typedef PTR_PTR_Object PTR_UNCHECKED_OBJECTREF;
 
-#ifndef DACCESS_COMPILE
-struct OBJECTHANDLE__
-{
-    void* unused;
-};
-typedef struct OBJECTHANDLE__* OBJECTHANDLE;
-#else
-typedef TADDR OBJECTHANDLE;
-#endif
-
 // With no object reference wrapping the following macros are very simple.
 #define ObjectToOBJECTREF(_obj) (OBJECTREF)(_obj)
 #define OBJECTREFToObject(_obj) (Object*)(_obj)

--- a/src/Native/gc/env/gcenv.base.h
+++ b/src/Native/gc/env/gcenv.base.h
@@ -65,6 +65,7 @@ inline HRESULT HRESULT_FROM_WIN32(unsigned long x)
 #define E_UNEXPECTED            0x8000FFFF
 #define E_NOTIMPL               0x80004001
 #define E_INVALIDARG            0x80070057
+#define COR_E_EXECUTIONENGINE   0x80131506
 
 #define NOERROR                 0x0
 #define ERROR_TIMEOUT           1460

--- a/src/Native/gc/env/gcenv.ee.h
+++ b/src/Native/gc/env/gcenv.ee.h
@@ -73,6 +73,7 @@ public:
     static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
     static bool ForceFullGCToBeBlocking();
     static bool EagerFinalized(Object* obj);
+    static MethodTable* GetFreeObjectMethodTable();
 };
 
 #endif // __GCENV_EE_H__

--- a/src/Native/gc/env/gcenv.ee.h
+++ b/src/Native/gc/env/gcenv.ee.h
@@ -70,6 +70,7 @@ public:
     static void EnableFinalization(bool foundFinalizers);
 
     static void HandleFatalError(unsigned int exitCode);
+    static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/Native/gc/env/gcenv.ee.h
+++ b/src/Native/gc/env/gcenv.ee.h
@@ -72,7 +72,6 @@ public:
     static void HandleFatalError(unsigned int exitCode);
     static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
     static bool ForceFullGCToBeBlocking();
-    static bool ShouldElevateForAppDomainCleanup();
     static bool EagerFinalized(Object* obj);
 };
 

--- a/src/Native/gc/env/gcenv.ee.h
+++ b/src/Native/gc/env/gcenv.ee.h
@@ -71,6 +71,7 @@ public:
 
     static void HandleFatalError(unsigned int exitCode);
     static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
+    static bool EagerFinalized(Object* obj);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/Native/gc/env/gcenv.ee.h
+++ b/src/Native/gc/env/gcenv.ee.h
@@ -71,6 +71,8 @@ public:
 
     static void HandleFatalError(unsigned int exitCode);
     static bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj);
+    static bool ForceFullGCToBeBlocking();
+    static bool ShouldElevateForAppDomainCleanup();
     static bool EagerFinalized(Object* obj);
 };
 

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -36305,16 +36305,11 @@ CFinalize::ScanForFinalization (promote_func* pfn, int gen, BOOL mark_only_p,
 
                     assert (method_table(obj)->HasFinalizer());
 
-#ifndef FEATURE_REDHAWK
-                    if (method_table(obj) == pWeakReferenceMT || method_table(obj)->GetCanonicalMethodTable() == pWeakReferenceOfTCanonMT)
+                    if (GCToEEInterface::EagerFinalized(obj))
                     {
-                        //destruct the handle right there.
-                        FinalizeWeakReference (obj);
                         MoveItem (i, Seg, FreeList);
                     }
-                    else
-#endif //!FEATURE_REDHAWK
-                    if ((obj->GetHeader()->GetBits()) & BIT_SBLK_FINALIZER_RUN)
+                    else if ((obj->GetHeader()->GetBits()) & BIT_SBLK_FINALIZER_RUN)
                     {
                         //remove the object because we don't want to
                         //run the finalizer

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -36138,43 +36138,15 @@ CFinalize::FinalizeSegForAppDomain (AppDomain *pDomain,
         // if it has the index we are looking for. If the methodtable is null, it can't be from the
         // unloading domain, so skip it.
         if (method_table(obj) == NULL)
-            continue;
-
-        // eagerly finalize all objects except those that may be agile.
-        if (obj->GetAppDomainIndex() != pDomain->GetIndex())
-            continue;
-
-#ifndef FEATURE_REDHAWK
-        if (method_table(obj)->IsAgileAndFinalizable())
         {
-            // If an object is both agile & finalizable, we leave it in the
-            // finalization queue during unload.  This is OK, since it's agile.
-            // Right now only threads can be this way, so if that ever changes, change
-            // the assert to just continue if not a thread.
-            _ASSERTE(method_table(obj) == g_pThreadClass);
-
-            if (method_table(obj) == g_pThreadClass)
-            {
-                // However, an unstarted thread should be finalized. It could be holding a delegate
-                // in the domain we want to unload. Once the thread has been started, its
-                // delegate is cleared so only unstarted threads are a problem.
-                Thread *pThread = ((THREADBASEREF)ObjectToOBJECTREF(obj))->GetInternal();
-                if (! pThread || ! pThread->IsUnstarted())
-                {
-                    // This appdomain is going to be gone soon so let us assign
-                    // it the appdomain that's guaranteed to exist
-                    // The object is agile and the delegate should be null so we can do it
-                    obj->GetHeader()->ResetAppDomainIndexNoFailure(SystemDomain::System()->DefaultDomain()->GetIndex());
-                    continue;
-                }
-            }
-            else
-            {
-                obj->GetHeader()->ResetAppDomainIndexNoFailure(SystemDomain::System()->DefaultDomain()->GetIndex());
-                continue;
-            }
+            continue;
         }
-#endif //!FEATURE_REDHAWK
+
+        // does the EE actually want us to finalize this object?
+        if (!GCToEEInterface::ShouldFinalizeObjectForUnload(pDomain, obj))
+        {
+            continue;
+        }
 
         if (!fRunFinalizers || (obj->GetHeader()->GetBits()) & BIT_SBLK_FINALIZER_RUN)
         {

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -15150,26 +15150,21 @@ exit:
         }
     }
 
-#ifndef FEATURE_REDHAWK
-    if (n == max_generation)
+    if (n == max_generation && GCToEEInterface::ForceFullGCToBeBlocking())
     {
-        if (SystemDomain::System()->RequireAppDomainCleanup())
-        {
 #ifdef BACKGROUND_GC
-            // do not turn stress-induced collections into blocking GCs, unless there
-            // have already been more full BGCs than full NGCs
+        // do not turn stress-induced collections into blocking GCs, unless there
+        // have already been more full BGCs than full NGCs
 #if 0
-            // This exposes DevDiv 94129, so we'll leave this out for now
-            if (!settings.stress_induced || 
-                full_gc_counts[gc_type_blocking] <= full_gc_counts[gc_type_background])
+        // This exposes DevDiv 94129, so we'll leave this out for now
+        if (!settings.stress_induced ||
+            full_gc_counts[gc_type_blocking] <= full_gc_counts[gc_type_background])
 #endif // 0
 #endif // BACKGROUND_GC
-            {
-                *blocking_collection_p = TRUE;
-            }
+        {
+            *blocking_collection_p = TRUE;
         }
     }
-#endif //!FEATURE_REDHAWK
 
     return n;
 }

--- a/src/Native/gc/gc.h
+++ b/src/Native/gc/gc.h
@@ -113,6 +113,7 @@ extern "C" uint8_t* g_gc_lowest_address;
 extern "C" uint8_t* g_gc_highest_address;
 extern "C" GCHeapType g_gc_heap_type;
 extern "C" uint32_t g_max_generation;
+extern "C" MethodTable* g_gc_pFreeObjectMethodTable;
 
 ::IGCHandleTable*  CreateGCHandleTable();
 

--- a/src/Native/gc/gc.h
+++ b/src/Native/gc/gc.h
@@ -256,12 +256,6 @@ void TouchPages(void * pStart, size_t cb);
 void updateGCShadow(Object** ptr, Object* val);
 #endif
 
-// the method table for the WeakReference class
-extern MethodTable  *pWeakReferenceMT;
-// The canonical method table for WeakReference<T>
-extern MethodTable  *pWeakReferenceOfTCanonMT;
-extern void FinalizeWeakReference(Object * obj);
-
 // The single GC heap instance, shared with the VM.
 extern IGCHeapInternal* g_theGCHeap;
 

--- a/src/Native/gc/gccommon.cpp
+++ b/src/Native/gc/gccommon.cpp
@@ -43,6 +43,7 @@ uint8_t* g_gc_lowest_address  = 0;
 uint8_t* g_gc_highest_address = 0;
 GCHeapType g_gc_heap_type = GC_HEAP_INVALID;
 uint32_t g_max_generation = max_generation;
+MethodTable* g_gc_pFreeObjectMethodTable = nullptr;
 
 #ifdef GC_CONFIG_DRIVEN
 void record_global_mechanism (int mech_index)

--- a/src/Native/gc/gcee.cpp
+++ b/src/Native/gc/gcee.cpp
@@ -408,12 +408,8 @@ BlockAgain:
         dwWaitResult = WaitForGCEvent->Wait(DETECT_DEADLOCK_TIMEOUT, FALSE );
 
         if (dwWaitResult == WAIT_TIMEOUT) {
-            //  Even in retail, stop in the debugger if available.  Ideally, the
-            //  following would use DebugBreak, but debspew.h makes this a null
-            //  macro in retail.  Note that in debug, we don't use the debspew.h
-            //  macros because these take a critical section that may have been
-            //  taken by a suspended thread.
-            FreeBuildDebugBreak();
+            //  Even in retail, stop in the debugger if available.
+            GCToOSInterface::DebugBreak();
             goto BlockAgain;
         }
 

--- a/src/Native/gc/gcenv.ee.standalone.inl
+++ b/src/Native/gc/gcenv.ee.standalone.inl
@@ -231,6 +231,11 @@ ALWAYS_INLINE bool GCToEEInterface::EagerFinalized(Object* obj)
     return g_theGCToCLR->EagerFinalized(obj);
 }
 
+ALWAYS_INLINE MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->GetFreeObjectMethodTable();
+}
 #undef ALWAYS_INLINE
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/Native/gc/gcenv.ee.standalone.inl
+++ b/src/Native/gc/gcenv.ee.standalone.inl
@@ -213,6 +213,12 @@ ALWAYS_INLINE void GCToEEInterface::HandleFatalError(unsigned int exitCode)
     g_theGCToCLR->HandleFatalError(exitCode);
 }
 
+ALWAYS_INLINE bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->ShouldFinalizeObjectForUnload(pDomain, obj);
+}
+
 #undef ALWAYS_INLINE
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/Native/gc/gcenv.ee.standalone.inl
+++ b/src/Native/gc/gcenv.ee.standalone.inl
@@ -219,6 +219,12 @@ ALWAYS_INLINE bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDo
     return g_theGCToCLR->ShouldFinalizeObjectForUnload(pDomain, obj);
 }
 
+ALWAYS_INLINE bool GCToEEInterface::EagerFinalized(Object* obj)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->EagerFinalized(obj);
+}
+
 #undef ALWAYS_INLINE
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/Native/gc/gcenv.ee.standalone.inl
+++ b/src/Native/gc/gcenv.ee.standalone.inl
@@ -219,6 +219,12 @@ ALWAYS_INLINE bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDo
     return g_theGCToCLR->ShouldFinalizeObjectForUnload(pDomain, obj);
 }
 
+ALWAYS_INLINE bool GCToEEInterface::ForceFullGCToBeBlocking()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->ForceFullGCToBeBlocking();
+}
+
 ALWAYS_INLINE bool GCToEEInterface::EagerFinalized(Object* obj)
 {
     assert(g_theGCToCLR != nullptr);

--- a/src/Native/gc/gchandletable.cpp
+++ b/src/Native/gc/gchandletable.cpp
@@ -37,3 +37,21 @@ OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* table, Object* object, int 
 {
     return ::HndCreateHandle((HHANDLETABLE)table, type, ObjectToOBJECTREF(object));
 }
+
+OBJECTHANDLE GCHandleTable::CreateGlobalHandleOfType(Object* object, int type)
+{
+    return ::HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], type, ObjectToOBJECTREF(object)); 
+}
+
+OBJECTHANDLE GCHandleTable::CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo)
+{
+    return ::HndCreateHandle((HHANDLETABLE)table, type, ObjectToOBJECTREF(object), reinterpret_cast<uintptr_t>(pExtraInfo));
+}
+
+OBJECTHANDLE GCHandleTable::CreateDependentHandle(void* table, Object* primary, Object* secondary)
+{
+    OBJECTHANDLE handle = ::HndCreateHandle((HHANDLETABLE)table, HNDTYPE_DEPENDENT, ObjectToOBJECTREF(primary));
+    ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(secondary));
+
+    return handle;
+}

--- a/src/Native/gc/gchandletable.cpp
+++ b/src/Native/gc/gchandletable.cpp
@@ -32,3 +32,8 @@ void* GCHandleTable::GetHandleTableForHandle(OBJECTHANDLE handle)
 {
     return (void*)::HndGetHandleTable(handle);
 }
+
+OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* table, Object* object, int type)
+{
+    return ::HndCreateHandle((HHANDLETABLE)table, type, ObjectToOBJECTREF(object));
+}

--- a/src/Native/gc/gchandletableimpl.h
+++ b/src/Native/gc/gchandletableimpl.h
@@ -19,6 +19,12 @@ public:
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle);
 
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);
+
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo);
+
+    virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary);
+
+    virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type);
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/Native/gc/gchandletableimpl.h
+++ b/src/Native/gc/gchandletableimpl.h
@@ -17,6 +17,8 @@ public:
     virtual void* GetHandleTableContext(void* handleTable);
 
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle);
+
+    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/Native/gc/gcinterface.ee.h
+++ b/src/Native/gc/gcinterface.ee.h
@@ -156,6 +156,16 @@ public:
     // the EE can opt to elevate that collection to be a blocking GC and not a background one.
     virtual
     bool ForceFullGCToBeBlocking() = 0;
+
+    // Retrieves the method table for the free object, a special kind of object used by the GC
+    // to keep the heap traversable. Conceptually, the free object is similar to a managed array
+    // of bytes: it consists of an object header (like all objects) and a "numComponents" field,
+    // followed by some number of bytes of space that's free on the heap.
+    //
+    // The free object allows the GC to traverse the heap because it can inspect the numComponents
+    // field to see how many bytes to skip before the next object on a heap segment begins.
+    virtual
+    MethodTable* GetFreeObjectMethodTable() = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/Native/gc/gcinterface.ee.h
+++ b/src/Native/gc/gcinterface.ee.h
@@ -143,11 +143,6 @@ public:
     virtual
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj) = 0;
 
-    // Asks the EE if the GC scheduled for the given condemned generation should be
-    // elevated to a blocking collection, to clean up an app domain.
-    virtual
-    bool ShouldElevateForAppDomainCleanup() = 0;
-
     // Offers the EE the option to finalize the given object eagerly, i.e.
     // not on the finalizer thread but on the current thread. The
     // EE returns true if it finalized the object eagerly and the GC does not

--- a/src/Native/gc/gcinterface.ee.h
+++ b/src/Native/gc/gcinterface.ee.h
@@ -137,6 +137,11 @@ public:
     // Signals to the EE that the GC encountered a fatal error and can't recover.
     virtual
     void HandleFatalError(unsigned int exitCode) = 0;
+
+    // Asks the EE if it wants a particular object to be finalized when unloading
+    // an app domain.
+    virtual
+    bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/Native/gc/gcinterface.ee.h
+++ b/src/Native/gc/gcinterface.ee.h
@@ -142,6 +142,15 @@ public:
     // an app domain.
     virtual
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj) = 0;
+
+    // Offers the EE the option to finalize the given object eagerly, i.e.
+    // not on the finalizer thread but on the current thread. The
+    // EE returns true if it finalized the object eagerly and the GC does not
+    // need to do so, and false if it chose not to eagerly finalize the object
+    // and it's up to the GC to finalize it later.
+    virtual
+    bool EagerFinalized(Object* obj) = 0;
+
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/Native/gc/gcinterface.ee.h
+++ b/src/Native/gc/gcinterface.ee.h
@@ -143,6 +143,11 @@ public:
     virtual
     bool ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj) = 0;
 
+    // Asks the EE if the GC scheduled for the given condemned generation should be
+    // elevated to a blocking collection, to clean up an app domain.
+    virtual
+    bool ShouldElevateForAppDomainCleanup() = 0;
+
     // Offers the EE the option to finalize the given object eagerly, i.e.
     // not on the finalizer thread but on the current thread. The
     // EE returns true if it finalized the object eagerly and the GC does not
@@ -151,6 +156,11 @@ public:
     virtual
     bool EagerFinalized(Object* obj) = 0;
 
+    // Asks the EE if it wishes for the current GC to be a blocking GC. The GC will
+    // only invoke this callback when it intends to do a full GC, so at this point
+    // the EE can opt to elevate that collection to be a blocking GC and not a background one.
+    virtual
+    bool ForceFullGCToBeBlocking() = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -402,6 +402,12 @@ public:
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle) = 0;
 
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
+
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo) = 0;
+
+    virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary) = 0;
+
+    virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type) = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -390,6 +390,18 @@ typedef void (* record_surv_fn)(uint8_t* begin, uint8_t* end, ptrdiff_t reloc, v
 typedef void (* fq_walk_fn)(bool, void*);
 typedef void (* fq_scan_fn)(Object** ppObject, ScanContext *pSC, uint32_t dwFlags);
 typedef void (* handle_scan_fn)(Object** pRef, Object* pSec, uint32_t flags, ScanContext* context, bool isDependent);
+
+// Opaque type for tracking object pointers
+#ifndef DACCESS_COMPILE
+struct OBJECTHANDLE__
+{
+    void* unused;
+};
+typedef struct OBJECTHANDLE__* OBJECTHANDLE;
+#else
+typedef uintptr_t OBJECTHANDLE;
+#endif
+
 class IGCHandleTable {
 public:
 

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -400,6 +400,8 @@ public:
     virtual void* GetHandleTableContext(void* handleTable) = 0;
 
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle) = 0;
+
+    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/Native/gc/gcpriv.h
+++ b/src/Native/gc/gcpriv.h
@@ -28,7 +28,7 @@ inline void FATAL_GC_ERROR()
     GCToOSInterface::DebugBreak();
 #endif // DACCESS_COMPILE
     _ASSERTE(!"Fatal Error in GC.");
-    EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+    GCToEEInterface::HandleFatalError(COR_E_EXECUTIONENGINE);
 }
 
 #ifdef _MSC_VER

--- a/src/Native/gc/handletable.cpp
+++ b/src/Native/gc/handletable.cpp
@@ -313,6 +313,10 @@ OBJECTHANDLE HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF obje
     }
 #endif // _DEBUG && !FEATURE_REDHAWK
 
+    // If we are creating a variable-strength handle, verify that the
+    // requested variable handle type is valid.
+    _ASSERTE(uType != HNDTYPE_VARIABLE || IS_VALID_VHT_VALUE(lExtraInfo));
+
     VALIDATEOBJECTREF(object);
 
     // fetch the handle table pointer

--- a/src/Native/gc/objecthandle.cpp
+++ b/src/Native/gc/objecthandle.cpp
@@ -871,24 +871,6 @@ void Ref_EndSynchronousGC(uint32_t condemned, uint32_t maxgen)
 */    
 }
 
-
-OBJECTHANDLE CreateDependentHandle(HHANDLETABLE table, OBJECTREF primary, OBJECTREF secondary)
-{ 
-    CONTRACTL
-    {
-        THROWS;
-        GC_NOTRIGGER;
-        MODE_COOPERATIVE;
-    }
-    CONTRACTL_END;
-
-    OBJECTHANDLE handle = HndCreateHandle(table, HNDTYPE_DEPENDENT, primary); 
-
-    SetDependentHandleSecondary(handle, secondary);
-
-    return handle;
-}
-
 void SetDependentHandleSecondary(OBJECTHANDLE handle, OBJECTREF objref)
 { 
     CONTRACTL

--- a/src/Native/gc/objecthandle.cpp
+++ b/src/Native/gc/objecthandle.cpp
@@ -907,30 +907,6 @@ void SetDependentHandleSecondary(OBJECTHANDLE handle, OBJECTREF objref)
 //----------------------------------------------------------------------------
 
 /*
- * CreateVariableHandle.
- *
- * Creates a variable-strength handle.
- *
- * N.B. This routine is not a macro since we do validation in RETAIL.
- * We always validate the type here because it can come from external callers.
- */
-OBJECTHANDLE CreateVariableHandle(HHANDLETABLE hTable, OBJECTREF object, uint32_t type)
-{
-    WRAPPER_NO_CONTRACT;
-
-    // verify that we are being asked to create a valid type
-    if (!IS_VALID_VHT_VALUE(type))
-    {
-        // bogus value passed in
-        _ASSERTE(FALSE);
-        return NULL;
-    }
-
-    // create the handle
-    return HndCreateHandle(hTable, HNDTYPE_VARIABLE, object, (uintptr_t)type);
-}
-
-/*
 * GetVariableHandleType.
 *
 * Retrieves the dynamic type of a variable-strength handle.

--- a/src/Native/gc/objecthandle.h
+++ b/src/Native/gc/objecthandle.h
@@ -100,13 +100,6 @@ inline void DestroyHandle(OBJECTHANDLE handle)
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, handle);
 }
 
-inline OBJECTHANDLE CreateDuplicateHandle(OBJECTHANDLE handle) {
-    WRAPPER_NO_CONTRACT;
-
-    // Create a new STRONG handle in the same table as an existing handle.  
-    return HndCreateHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, HndFetchHandle(handle));
-}
-
 inline void DestroyWeakHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
@@ -176,13 +169,6 @@ inline void DestroyRefcountedHandle(OBJECTHANDLE handle)
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_REFCOUNTED, handle);
 }
 
-inline OBJECTHANDLE CreateWinRTWeakHandle(HHANDLETABLE table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
-{
-    WRAPPER_NO_CONTRACT;
-    _ASSERTE(pWinRTWeakReference != NULL);
-    return HndCreateHandle(table, HNDTYPE_WEAK_WINRT, object, reinterpret_cast<uintptr_t>(pWinRTWeakReference));
-}
-
 void DestroyWinRTWeakHandle(OBJECTHANDLE handle);
 
 #endif // FEATURE_COMINTEROP
@@ -192,7 +178,6 @@ void DestroyWinRTWeakHandle(OBJECTHANDLE handle);
 OBJECTREF GetDependentHandleSecondary(OBJECTHANDLE handle);
 
 #ifndef DACCESS_COMPILE
-OBJECTHANDLE CreateDependentHandle(HHANDLETABLE table, OBJECTREF primary, OBJECTREF secondary);
 void SetDependentHandleSecondary(OBJECTHANDLE handle, OBJECTREF secondary);
 
 inline void DestroyDependentHandle(OBJECTHANDLE handle)
@@ -268,25 +253,11 @@ public:
 
 int GetCurrentThreadHomeHeapNumber();
 
-inline OBJECTHANDLE CreateGlobalTypedHandle(OBJECTREF object, int type)
-{ 
-    WRAPPER_NO_CONTRACT;
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], type, object); 
-}
-
 inline void DestroyGlobalTypedHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandleOfUnknownType(HndGetHandleTable(handle), handle);
-}
-
-inline OBJECTHANDLE CreateGlobalHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_DEFAULT, object); 
 }
 
 inline void DestroyGlobalHandle(OBJECTHANDLE handle)
@@ -296,26 +267,11 @@ inline void DestroyGlobalHandle(OBJECTHANDLE handle)
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, handle);
 }
 
-inline OBJECTHANDLE CreateGlobalWeakHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_WEAK_DEFAULT, object); 
-}
-
 inline void DestroyGlobalWeakHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_DEFAULT, handle);
-}
-
-inline OBJECTHANDLE CreateGlobalShortWeakHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_WEAK_SHORT, object);     
 }
 
 inline void DestroyGlobalShortWeakHandle(OBJECTHANDLE handle)
@@ -329,26 +285,11 @@ inline void DestroyGlobalShortWeakHandle(OBJECTHANDLE handle)
 typedef Holder<OBJECTHANDLE,DoNothing<OBJECTHANDLE>,DestroyGlobalShortWeakHandle> GlobalShortWeakHandleHolder;
 #endif
 
-inline OBJECTHANDLE CreateGlobalLongWeakHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_WEAK_LONG, object); 
-}
-
 inline void DestroyGlobalLongWeakHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_LONG, handle);
-}
-
-inline OBJECTHANDLE CreateGlobalStrongHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-    CONDITIONAL_CONTRACT_VIOLATION(ModeViolation, object == NULL);
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_STRONG, object); 
 }
 
 inline void DestroyGlobalStrongHandle(OBJECTHANDLE handle)
@@ -362,13 +303,6 @@ inline void DestroyGlobalStrongHandle(OBJECTHANDLE handle)
 typedef Holder<OBJECTHANDLE,DoNothing<OBJECTHANDLE>,DestroyGlobalStrongHandle> GlobalStrongHandleHolder;
 #endif
 
-inline OBJECTHANDLE CreateGlobalPinningHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_PINNED, object); 
-}
-
 inline void DestroyGlobalPinningHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
@@ -377,13 +311,6 @@ inline void DestroyGlobalPinningHandle(OBJECTHANDLE handle)
 }
 
 #ifdef FEATURE_COMINTEROP
-inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_REFCOUNTED, object); 
-}
-
 inline void DestroyGlobalRefcountedHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;

--- a/src/Native/gc/objecthandle.h
+++ b/src/Native/gc/objecthandle.h
@@ -78,25 +78,11 @@ struct HandleTableBucket
  * Convenience macros and prototypes for the various handle types we define
  */
 
-inline OBJECTHANDLE CreateTypedHandle(HHANDLETABLE table, OBJECTREF object, int type)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, type, object); 
-}
-
 inline void DestroyTypedHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandleOfUnknownType(HndGetHandleTable(handle), handle);
-}
-
-inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_DEFAULT, object); 
 }
 
 inline void DestroyHandle(OBJECTHANDLE handle)
@@ -121,14 +107,6 @@ inline OBJECTHANDLE CreateDuplicateHandle(OBJECTHANDLE handle) {
     return HndCreateHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, HndFetchHandle(handle));
 }
 
-
-inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_WEAK_DEFAULT, object); 
-}
-
 inline void DestroyWeakHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
@@ -136,26 +114,11 @@ inline void DestroyWeakHandle(OBJECTHANDLE handle)
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_DEFAULT, handle);
 }
 
-inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_WEAK_SHORT, object); 
-}
-
 inline void DestroyShortWeakHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_SHORT, handle);
-}
-
-
-inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_WEAK_LONG, object); 
 }
 
 inline void DestroyLongWeakHandle(OBJECTHANDLE handle)
@@ -169,25 +132,11 @@ inline void DestroyLongWeakHandle(OBJECTHANDLE handle)
 typedef Holder<OBJECTHANDLE,DoNothing<OBJECTHANDLE>,DestroyLongWeakHandle> LongWeakHandleHolder;
 #endif
 
-inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_STRONG, object); 
-}
-
 inline void DestroyStrongHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
 
     HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_STRONG, handle);
-}
-
-inline OBJECTHANDLE CreatePinningHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_PINNED, object); 
 }
 
 inline void DestroyPinningHandle(OBJECTHANDLE handle)
@@ -201,13 +150,6 @@ inline void DestroyPinningHandle(OBJECTHANDLE handle)
 typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyPinningHandle, NULL> PinningHandleHolder;
 #endif
 
-inline OBJECTHANDLE CreateAsyncPinningHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_ASYNCPINNED, object); 
-}
-
 inline void DestroyAsyncPinningHandle(OBJECTHANDLE handle)
 { 
     WRAPPER_NO_CONTRACT;
@@ -219,13 +161,6 @@ inline void DestroyAsyncPinningHandle(OBJECTHANDLE handle)
 typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyAsyncPinningHandle, NULL> AsyncPinningHandleHolder;
 #endif
 
-inline OBJECTHANDLE CreateSizedRefHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_SIZEDREF, object, (uintptr_t)0);
-}
-
 void DestroySizedRefHandle(OBJECTHANDLE handle);
 
 #ifndef FEATURE_REDHAWK
@@ -233,12 +168,6 @@ typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroySizedRefHandle, NU
 #endif
 
 #ifdef FEATURE_COMINTEROP
-inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    return HndCreateHandle(table, HNDTYPE_REFCOUNTED, object); 
-}
 
 inline void DestroyRefcountedHandle(OBJECTHANDLE handle)
 { 

--- a/src/Native/gc/objecthandle.h
+++ b/src/Native/gc/objecthandle.h
@@ -189,8 +189,6 @@ inline void DestroyDependentHandle(OBJECTHANDLE handle)
 #endif // !DACCESS_COMPILE
 
 #ifndef DACCESS_COMPILE
-
-OBJECTHANDLE CreateVariableHandle(HHANDLETABLE hTable, OBJECTREF object, uint32_t type);
 uint32_t     GetVariableHandleType(OBJECTHANDLE handle);
 void         UpdateVariableHandleType(OBJECTHANDLE handle, uint32_t type);
 uint32_t     CompareExchangeVariableHandleType(OBJECTHANDLE handle, uint32_t oldType, uint32_t newType);

--- a/src/Native/gc/sample/GCSample.cpp
+++ b/src/Native/gc/sample/GCSample.cpp
@@ -201,7 +201,7 @@ int __cdecl main(int argc, char* argv[])
         return -1;
 
     // Create strong handle and store the object into it
-    OBJECTHANDLE oh = CreateGlobalHandle(pObj);
+    OBJECTHANDLE oh = HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_DEFAULT, pObj);
     if (oh == NULL)
         return -1;
 
@@ -224,7 +224,7 @@ int __cdecl main(int argc, char* argv[])
     }
 
     // Create weak handle that points to our object
-    OBJECTHANDLE ohWeak = CreateGlobalWeakHandle(HndFetchHandle(oh));
+    OBJECTHANDLE ohWeak = HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], HNDTYPE_WEAK_DEFAULT, HndFetchHandle(oh));
     if (ohWeak == NULL)
         return -1;
 

--- a/src/Native/gc/sample/gcenv.ee.cpp
+++ b/src/Native/gc/sample/gcenv.ee.cpp
@@ -286,6 +286,11 @@ bool GCToEEInterface::EagerFinalized(Object* obj)
     return false;
 }
 
+MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
+{
+    return g_pFreeObjectMethodTable;
+}
+
 bool IsGCSpecialThread()
 {
     // TODO: Implement for background GC

--- a/src/Native/gc/sample/gcenv.ee.cpp
+++ b/src/Native/gc/sample/gcenv.ee.cpp
@@ -270,6 +270,11 @@ void GCToEEInterface::HandleFatalError(unsigned int exitCode)
     abort();
 }
 
+bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* obj)
+{
+    return true;
+}
+
 bool IsGCSpecialThread()
 {
     // TODO: Implement for background GC

--- a/src/Native/gc/sample/gcenv.ee.cpp
+++ b/src/Native/gc/sample/gcenv.ee.cpp
@@ -275,6 +275,12 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     return true;
 }
 
+bool GCToEEInterface::EagerFinalized(Object* obj)
+{
+    // The sample does not finalize anything eagerly.
+    return false;
+}
+
 bool IsGCSpecialThread()
 {
     // TODO: Implement for background GC

--- a/src/Native/gc/sample/gcenv.ee.cpp
+++ b/src/Native/gc/sample/gcenv.ee.cpp
@@ -275,6 +275,11 @@ bool GCToEEInterface::ShouldFinalizeObjectForUnload(AppDomain* pDomain, Object* 
     return true;
 }
 
+bool GCToEEInterface::ForceFullGCToBeBlocking()
+{
+    return false;
+}
+
 bool GCToEEInterface::EagerFinalized(Object* obj)
 {
     // The sample does not finalize anything eagerly.


### PR DESCRIPTION
This port continues https://github.com/dotnet/corert/pull/7342
Porting strategy: extracting patches via `format-patch` from coreclr, adjusting paths, then `am` them on corert.

**Glossary:**
- already merged: change already exists in corert
- gc only port: change only affected the gc directory and patch applied with no conflicts
- manual port: change applied with custom changes
- omitted changes: contains changes to files that do not exists in corert and were discarded

**Changes since [last commit](https://github.com/dotnet/coreclr/commit/ed57233f4d26114d45b1293ced80a09f879f72cf):**
- https://github.com/dotnet/coreclr/commit/41617fee235d22d9e6dc1fa31548de63637551fa (manual port)
- https://github.com/dotnet/coreclr/commit/be8504bd8a63962c84567990f0b84019f299166c (manual port)
- https://github.com/dotnet/coreclr/commit/7ba3cc8174dec2626a403f5ccd35c79a3bf6cf77 (manual port)
- https://github.com/dotnet/coreclr/commit/e17f40a186c294f977e336cab049d9026cf40c78 (manual port)
- https://github.com/dotnet/coreclr/commit/273e63414deccefd1ad048062e4d1ebfe5e5eb50 (manual port)
- https://github.com/dotnet/coreclr/commit/f9d0333d8955c11a2e8f495f0a12d6384fb95541 (gc only port)
- https://github.com/dotnet/coreclr/commit/7721f89f517f09f90d46a1078f0d26caf3b310c0 (manual port, omitted changes)
- https://github.com/dotnet/coreclr/commit/447521434ab80ea97a42108a429e3773e71f7c66 (gc only port, omitted changes)
- https://github.com/dotnet/coreclr/commit/ea55c4a25945d8ccb39d686b89f1fa729b4ebe23 (gc only port)
- https://github.com/dotnet/coreclr/commit/2dfc74df1f9fe238eb2ec25c4764b8b65432b010 (manual port)
- https://github.com/dotnet/coreclr/commit/09b7f0a0f44798108a33d7e698420f147c45461b (manual port)

**Points of interest**:
Some of the commits moved features to the runtime that were disabled in the GC with `#ifndef FEATURE_REDHAWK`, i've transplanted the equivalent to `gcrhenv.cpp`, do tell if you rather wish to remove it.