### PR TITLE
Port GC changes from coreclr - 5

### DIFF
--- a/src/Native/Runtime/HandleTableHelpers.cpp
+++ b/src/Native/Runtime/HandleTableHelpers.cpp
@@ -18,12 +18,12 @@
 
 COOP_PINVOKE_HELPER(OBJECTHANDLE, RhpHandleAlloc, (Object *pObject, int type))
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], pObject, type);
+    return GCHandleTableUtilities::GetGCHandleTable()->GetGlobalHandleStore()->CreateHandleOfType(pObject, type);
 }
 
 COOP_PINVOKE_HELPER(OBJECTHANDLE, RhpHandleAllocDependent, (Object *pPrimary, Object *pSecondary))
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateDependentHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], pPrimary, pSecondary);
+    return GCHandleTableUtilities::GetGCHandleTable()->GetGlobalHandleStore()->CreateDependentHandle(pPrimary, pSecondary);
 }
 
 COOP_PINVOKE_HELPER(void, RhHandleFree, (OBJECTHANDLE handle))
@@ -65,7 +65,7 @@ COOP_PINVOKE_HELPER(void, RhUnregisterRefCountedHandleCallback, (void * pCallout
 
 COOP_PINVOKE_HELPER(OBJECTHANDLE, RhpHandleAllocVariable, (Object * pObject, UInt32 type)) 
 {
-    return CreateVariableHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], pObject, type);
+    return CreateVariableHandle(GCHandleTableUtilities::GetGCHandleTable()->GetGlobalHandleStore(), pObject, type);
 }
 
 COOP_PINVOKE_HELPER(UInt32, RhHandleGetVariableType, (OBJECTHANDLE handle))

--- a/src/Native/Runtime/gchandletableutilities.h
+++ b/src/Native/Runtime/gchandletableutilities.h
@@ -39,6 +39,13 @@ inline OBJECTREF ObjectFromHandle(OBJECTHANDLE handle)
     return UNCHECKED_OBJECTREF_TO_OBJECTREF(*PTR_UNCHECKED_OBJECTREF(handle));
 }
 
+inline BOOL ObjectHandleIsNull(OBJECTHANDLE handle)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return *(Object **)handle == NULL;
+}
+
 #ifndef DACCESS_COMPILE
 
 // Handle creation convenience functions

--- a/src/Native/Runtime/gchandletableutilities.h
+++ b/src/Native/Runtime/gchandletableutilities.h
@@ -50,49 +50,54 @@ inline BOOL ObjectHandleIsNull(OBJECTHANDLE handle)
 
 // Handle creation convenience functions
 
-inline OBJECTHANDLE CreateHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
 }
 
-inline OBJECTHANDLE CreateWeakHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateWeakHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
 }
 
-inline OBJECTHANDLE CreateShortWeakHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateShortWeakHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
 }
 
-inline OBJECTHANDLE CreateLongWeakHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateLongWeakHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
 }
 
-inline OBJECTHANDLE CreateStrongHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateStrongHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_STRONG);
 }
 
-inline OBJECTHANDLE CreatePinningHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreatePinningHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_PINNED);
 }
 
-inline OBJECTHANDLE CreateSizedRefHandle(HHANDLETABLE table, OBJECTREF object)
-{
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
-}
-
-inline OBJECTHANDLE CreateAsyncPinningHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateAsyncPinningHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
 }
 
-inline OBJECTHANDLE CreateRefcountedHandle(HHANDLETABLE table, OBJECTREF object)
+inline OBJECTHANDLE CreateRefcountedHandle(void* table, OBJECTREF object)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+}
+
+inline OBJECTHANDLE CreateSizedRefHandle(void* table, OBJECTREF object)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
+}
+
+inline OBJECTHANDLE CreateSizedRefHandle(void* table, OBJECTREF object, int heapToAffinitizeTo)
+{
+    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF, heapToAffinitizeTo);
 }
 
 // Global handle creation convenience functions
@@ -138,7 +143,7 @@ inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
 // Special handle creation convenience functions
 
 #ifdef FEATURE_COMINTEROP
-inline OBJECTHANDLE CreateWinRTWeakHandle(HHANDLETABLE table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
+inline OBJECTHANDLE CreateWinRTWeakHandle(void* table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
                                                                                  OBJECTREFToObject(object),
@@ -148,7 +153,7 @@ inline OBJECTHANDLE CreateWinRTWeakHandle(HHANDLETABLE table, OBJECTREF object, 
 #endif // FEATURE_COMINTEROP
 
 // Creates a variable-strength handle
-inline OBJECTHANDLE CreateVariableHandle(HHANDLETABLE table, OBJECTREF object, uint32_t type)
+inline OBJECTHANDLE CreateVariableHandle(void* table, OBJECTREF object, uint32_t type)
 {
     return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
                                                                                  OBJECTREFToObject(object),

--- a/src/Native/Runtime/gchandletableutilities.h
+++ b/src/Native/Runtime/gchandletableutilities.h
@@ -149,6 +149,135 @@ inline OBJECTHANDLE CreateVariableHandle(HHANDLETABLE table, OBJECTREF object, u
                                                                                  (void*)((uintptr_t)type));
 }
 
+// Handle destruction convenience functions
+
+inline void DestroyHandle(OBJECTHANDLE handle)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+        CAN_TAKE_LOCK;
+        SO_TOLERANT;
+    }
+    CONTRACTL_END;
+
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_DEFAULT);
+}
+
+inline void DestroyWeakHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_DEFAULT);
+}
+
+inline void DestroyShortWeakHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_SHORT);
+}
+
+inline void DestroyLongWeakHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_LONG);
+}
+
+inline void DestroyStrongHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_STRONG);
+}
+
+inline void DestroyPinningHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_PINNED);
+}
+
+inline void DestroyAsyncPinningHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_ASYNCPINNED);
+}
+
+inline void DestroyRefcountedHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_REFCOUNTED);
+}
+
+inline void DestroyDependentHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_DEPENDENT);
+}
+
+inline void  DestroyVariableHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_VARIABLE);
+}
+
+inline void DestroyGlobalHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_DEFAULT);
+}
+
+inline void DestroyGlobalWeakHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_DEFAULT);
+}
+
+inline void DestroyGlobalShortWeakHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_SHORT);
+}
+
+inline void DestroyGlobalLongWeakHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_LONG);
+}
+
+inline void DestroyGlobalStrongHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_STRONG);
+}
+
+inline void DestroyGlobalPinningHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_PINNED);
+}
+
+inline void DestroyGlobalRefcountedHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_REFCOUNTED);
+}
+
+inline void DestroyTypedHandle(OBJECTHANDLE handle)
+{
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfUnknownType(handle);
+}
+
+#ifdef FEATURE_COMINTEROP
+inline void DestroyWinRTWeakHandle(OBJECTHANDLE handle)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+        CAN_TAKE_LOCK;
+        SO_TOLERANT;
+    }
+    CONTRACTL_END;
+
+    // Release the WinRT weak reference if we have one. We're assuming that this will not reenter the
+    // runtime, since if we are pointing at a managed object, we should not be using HNDTYPE_WEAK_WINRT
+    // but rather HNDTYPE_WEAK_SHORT or HNDTYPE_WEAK_LONG.
+    void* pExtraInfo = GCHandleTableUtilities::GetGCHandleTable()->GetExtraInfoFromHandle(handle);
+    IWeakReference* pWinRTWeakReference = reinterpret_cast<IWeakReference*>(pExtraInfo);
+    if (pWinRTWeakReference != nullptr)
+    {
+        pWinRTWeakReference->Release();
+    }
+
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfType(handle, HNDTYPE_WEAK_WINRT);
+}
+#endif
+
 #endif // !DACCESS_COMPILE
 
 #endif // _GCHANDLETABLEUTILITIES_H_

--- a/src/Native/Runtime/gchandletableutilities.h
+++ b/src/Native/Runtime/gchandletableutilities.h
@@ -50,54 +50,54 @@ inline BOOL ObjectHandleIsNull(OBJECTHANDLE handle)
 
 // Handle creation convenience functions
 
-inline OBJECTHANDLE CreateHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_DEFAULT);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_DEFAULT);
 }
 
-inline OBJECTHANDLE CreateWeakHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_DEFAULT);
 }
 
-inline OBJECTHANDLE CreateShortWeakHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateShortWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_SHORT);
 }
 
-inline OBJECTHANDLE CreateLongWeakHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateLongWeakHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_WEAK_LONG);
 }
 
-inline OBJECTHANDLE CreateStrongHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateStrongHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_STRONG);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_STRONG);
 }
 
-inline OBJECTHANDLE CreatePinningHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreatePinningHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_PINNED);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_PINNED);
 }
 
-inline OBJECTHANDLE CreateAsyncPinningHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateAsyncPinningHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_ASYNCPINNED);
 }
 
-inline OBJECTHANDLE CreateRefcountedHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateRefcountedHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_REFCOUNTED);
 }
 
-inline OBJECTHANDLE CreateSizedRefHandle(void* table, OBJECTREF object)
+inline OBJECTHANDLE CreateSizedRefHandle(IGCHandleStore* store, OBJECTREF object)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_SIZEDREF);
 }
 
-inline OBJECTHANDLE CreateSizedRefHandle(void* table, OBJECTREF object, int heapToAffinitizeTo)
+inline OBJECTHANDLE CreateSizedRefHandle(IGCHandleStore* store, OBJECTREF object, int heapToAffinitizeTo)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(table, OBJECTREFToObject(object), HNDTYPE_SIZEDREF, heapToAffinitizeTo);
+    return store->CreateHandleOfType(OBJECTREFToObject(object), HNDTYPE_SIZEDREF, heapToAffinitizeTo);
 }
 
 // Global handle creation convenience functions
@@ -143,22 +143,16 @@ inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
 // Special handle creation convenience functions
 
 #ifdef FEATURE_COMINTEROP
-inline OBJECTHANDLE CreateWinRTWeakHandle(void* table, OBJECTREF object, IWeakReference* pWinRTWeakReference)
+inline OBJECTHANDLE CreateWinRTWeakHandle(IGCHandleStore* store, OBJECTREF object, IWeakReference* pWinRTWeakReference)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
-                                                                                 OBJECTREFToObject(object),
-                                                                                 HNDTYPE_WEAK_WINRT,
-                                                                                 (void*)pWinRTWeakReference);
+    return store->CreateHandleWithExtraInfo(OBJECTREFToObject(object), HNDTYPE_WEAK_WINRT, (void*)pWinRTWeakReference);
 }
 #endif // FEATURE_COMINTEROP
 
 // Creates a variable-strength handle
-inline OBJECTHANDLE CreateVariableHandle(void* table, OBJECTREF object, uint32_t type)
+inline OBJECTHANDLE CreateVariableHandle(IGCHandleStore* store, OBJECTREF object, uint32_t type)
 {
-    return GCHandleTableUtilities::GetGCHandleTable()->CreateHandleWithExtraInfo(table,
-                                                                                 OBJECTREFToObject(object),
-                                                                                 HNDTYPE_VARIABLE,
-                                                                                 (void*)((uintptr_t)type));
+    return store->CreateHandleWithExtraInfo(OBJECTREFToObject(object), HNDTYPE_VARIABLE, (void*)((uintptr_t)type));
 }
 
 // Handle destruction convenience functions

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -949,7 +949,7 @@ void RedhawkGCInterface::DestroyTypedHandle(void * handle)
 
 void* RedhawkGCInterface::CreateTypedHandle(void* pObject, int type)
 {
-    return (void*)GCHandleTableUtilities::GetGCHandleTable()->CreateHandleOfType(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], (Object*)pObject, type);
+    return (void*)GCHandleTableUtilities::GetGCHandleTable()->GetGlobalHandleStore()->CreateHandleOfType((Object*)pObject, type);
 }
 
 void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -944,7 +944,7 @@ void RedhawkGCInterface::SetLastAllocEEType(EEType * pEEType)
 
 void RedhawkGCInterface::DestroyTypedHandle(void * handle)
 {
-    ::DestroyTypedHandle((OBJECTHANDLE)handle);
+    GCHandleTableUtilities::GetGCHandleTable()->DestroyHandleOfUnknownType((OBJECTHANDLE)handle);
 }
 
 void* RedhawkGCInterface::CreateTypedHandle(void* pObject, int type)

--- a/src/Native/gc/gchandletable.cpp
+++ b/src/Native/gc/gchandletable.cpp
@@ -28,11 +28,6 @@ void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
     return (void*)((uintptr_t)::HndGetHandleTableADIndex(::HndGetHandleTable(handle)).m_dwIndex);
 }
 
-void* GCHandleTable::GetHandleTableForHandle(OBJECTHANDLE handle)
-{
-    return (void*)::HndGetHandleTable(handle);
-}
-
 OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* table, Object* object, int type)
 {
     return ::HndCreateHandle((HHANDLETABLE)table, type, ObjectToOBJECTREF(object));
@@ -54,6 +49,11 @@ OBJECTHANDLE GCHandleTable::CreateDependentHandle(void* table, Object* primary, 
     ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(secondary));
 
     return handle;
+}
+
+OBJECTHANDLE GCHandleTable::CreateDuplicateHandle(OBJECTHANDLE handle)
+{
+    return ::HndCreateHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, ::HndFetchHandle(handle));
 }
 
 void GCHandleTable::DestroyHandleOfType(OBJECTHANDLE handle, int type)

--- a/src/Native/gc/gchandletable.cpp
+++ b/src/Native/gc/gchandletable.cpp
@@ -8,9 +8,53 @@
 #include "gchandletableimpl.h"
 #include "objecthandle.h"
 
+GCHandleStore* g_gcGlobalHandleStore;
+
 IGCHandleTable* CreateGCHandleTable()
 {
-    return new(nothrow) GCHandleTable();
+    return new (nothrow) GCHandleTable();
+}
+
+void GCHandleStore::Uproot()
+{
+    Ref_RemoveHandleTableBucket(_underlyingBucket);
+}
+
+bool GCHandleStore::ContainsHandle(OBJECTHANDLE handle)
+{
+    return _underlyingBucket->Contains(handle);
+}
+
+OBJECTHANDLE GCHandleStore::CreateHandleOfType(Object* object, int type)
+{
+    HHANDLETABLE handletable = _underlyingBucket->pTable[GetCurrentThreadHomeHeapNumber()];
+    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
+}
+
+OBJECTHANDLE GCHandleStore::CreateHandleOfType(Object* object, int type, int heapToAffinitizeTo)
+{
+    HHANDLETABLE handletable = _underlyingBucket->pTable[heapToAffinitizeTo];
+    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
+}
+
+OBJECTHANDLE GCHandleStore::CreateHandleWithExtraInfo(Object* object, int type, void* pExtraInfo)
+{
+    HHANDLETABLE handletable = _underlyingBucket->pTable[GetCurrentThreadHomeHeapNumber()];
+    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object), reinterpret_cast<uintptr_t>(pExtraInfo));
+}
+
+OBJECTHANDLE GCHandleStore::CreateDependentHandle(Object* primary, Object* secondary)
+{
+    HHANDLETABLE handletable = _underlyingBucket->pTable[GetCurrentThreadHomeHeapNumber()];
+    OBJECTHANDLE handle = ::HndCreateHandle(handletable, HNDTYPE_DEPENDENT, ObjectToOBJECTREF(primary));
+    ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(secondary));
+
+    return handle;
+}
+
+GCHandleStore::~GCHandleStore()
+{
+    Ref_DestroyHandleTableBucket(_underlyingBucket);
 }
 
 bool GCHandleTable::Initialize()
@@ -23,19 +67,25 @@ void GCHandleTable::Shutdown()
     Ref_Shutdown();
 }
 
-void* GCHandleTable::GetGlobalHandleStore()
+IGCHandleStore* GCHandleTable::GetGlobalHandleStore()
 {
-    return (void*)g_HandleTableMap.pBuckets[0];
+    return g_gcGlobalHandleStore;
 }
 
-void* GCHandleTable::CreateHandleStore(void* context)
+IGCHandleStore* GCHandleTable::CreateHandleStore(void* context)
 {
 #ifndef FEATURE_REDHAWK
-    return (void*)::Ref_CreateHandleTableBucket(ADIndex((DWORD)(uintptr_t)context));
+    HandleTableBucket* newBucket = ::Ref_CreateHandleTableBucket(ADIndex((DWORD)(uintptr_t)context));
+    return new (nothrow) GCHandleStore(newBucket);
 #else
     assert("CreateHandleStore is not implemented when FEATURE_REDHAWK is defined!");
     return nullptr;
 #endif
+}
+
+void GCHandleTable::DestroyHandleStore(IGCHandleStore* store)
+{
+    delete store;
 }
 
 void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
@@ -43,51 +93,9 @@ void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
     return (void*)((uintptr_t)::HndGetHandleTableADIndex(::HndGetHandleTable(handle)).m_dwIndex);
 }
 
-void GCHandleTable::DestroyHandleStore(void* store)
-{
-    Ref_DestroyHandleTableBucket((HandleTableBucket*) store);
-}
-
-void GCHandleTable::UprootHandleStore(void* store)
-{
-    Ref_RemoveHandleTableBucket((HandleTableBucket*) store);
-}
-
-bool GCHandleTable::ContainsHandle(void* store, OBJECTHANDLE handle)
-{
-    return ((HandleTableBucket*)store)->Contains(handle);
-}
-
-OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* store, Object* object, int type)
-{
-    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[GetCurrentThreadHomeHeapNumber()];
-    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
-}
-
-OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* store, Object* object, int type, int heapToAffinitizeTo)
-{
-    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[heapToAffinitizeTo];
-    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
-}
-
 OBJECTHANDLE GCHandleTable::CreateGlobalHandleOfType(Object* object, int type)
 {
     return ::HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], type, ObjectToOBJECTREF(object)); 
-}
-
-OBJECTHANDLE GCHandleTable::CreateHandleWithExtraInfo(void* store, Object* object, int type, void* pExtraInfo)
-{
-    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[GetCurrentThreadHomeHeapNumber()];
-    return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object), reinterpret_cast<uintptr_t>(pExtraInfo));
-}
-
-OBJECTHANDLE GCHandleTable::CreateDependentHandle(void* store, Object* primary, Object* secondary)
-{
-    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[GetCurrentThreadHomeHeapNumber()];
-    OBJECTHANDLE handle = ::HndCreateHandle(handletable, HNDTYPE_DEPENDENT, ObjectToOBJECTREF(primary));
-    ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(secondary));
-
-    return handle;
 }
 
 OBJECTHANDLE GCHandleTable::CreateDuplicateHandle(OBJECTHANDLE handle)

--- a/src/Native/gc/gchandletable.cpp
+++ b/src/Native/gc/gchandletable.cpp
@@ -23,6 +23,16 @@ void GCHandleTable::Shutdown()
     Ref_Shutdown();
 }
 
+void* GCHandleTable::GetGlobalHandleTable()
+{
+    return (void*)g_HandleTableMap.pBuckets[0];
+}
+
+void* GCHandleTable::GetNewHandleTable(void* context)
+{
+    return (void*)::Ref_CreateHandleTableBucket(ADIndex((uintptr_t)context));
+}
+
 void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
 {
     return (void*)((uintptr_t)::HndGetHandleTableADIndex(::HndGetHandleTable(handle)).m_dwIndex);

--- a/src/Native/gc/gchandletable.cpp
+++ b/src/Native/gc/gchandletable.cpp
@@ -55,3 +55,18 @@ OBJECTHANDLE GCHandleTable::CreateDependentHandle(void* table, Object* primary, 
 
     return handle;
 }
+
+void GCHandleTable::DestroyHandleOfType(OBJECTHANDLE handle, int type)
+{
+    ::HndDestroyHandle(::HndGetHandleTable(handle), type, handle);
+}
+
+void GCHandleTable::DestroyHandleOfUnknownType(OBJECTHANDLE handle)
+{
+    ::HndDestroyHandleOfUnknownType(::HndGetHandleTable(handle), handle);
+}
+
+void* GCHandleTable::GetExtraInfoFromHandle(OBJECTHANDLE handle)
+{
+    return (void*)::HndGetHandleExtraInfo(handle);
+}

--- a/src/Native/gc/gchandletable.cpp
+++ b/src/Native/gc/gchandletable.cpp
@@ -23,9 +23,9 @@ void GCHandleTable::Shutdown()
     Ref_Shutdown();
 }
 
-void* GCHandleTable::GetHandleTableContext(void* handleTable)
+void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
 {
-    return (void*)((uintptr_t)::HndGetHandleTableADIndex((HHANDLETABLE)handleTable).m_dwIndex);
+    return (void*)((uintptr_t)::HndGetHandleTableADIndex(::HndGetHandleTable(handle)).m_dwIndex);
 }
 
 void* GCHandleTable::GetHandleTableForHandle(OBJECTHANDLE handle)

--- a/src/Native/gc/gchandletable.cpp
+++ b/src/Native/gc/gchandletable.cpp
@@ -23,14 +23,19 @@ void GCHandleTable::Shutdown()
     Ref_Shutdown();
 }
 
-void* GCHandleTable::GetGlobalHandleTable()
+void* GCHandleTable::GetGlobalHandleStore()
 {
     return (void*)g_HandleTableMap.pBuckets[0];
 }
 
-void* GCHandleTable::GetNewHandleTable(void* context)
+void* GCHandleTable::CreateHandleStore(void* context)
 {
-    return (void*)::Ref_CreateHandleTableBucket(ADIndex((uintptr_t)context));
+#ifndef FEATURE_REDHAWK
+    return (void*)::Ref_CreateHandleTableBucket(ADIndex((DWORD)(uintptr_t)context));
+#else
+    assert("CreateHandleStore is not implemented when FEATURE_REDHAWK is defined!");
+    return nullptr;
+#endif
 }
 
 void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
@@ -38,30 +43,30 @@ void* GCHandleTable::GetHandleContext(OBJECTHANDLE handle)
     return (void*)((uintptr_t)::HndGetHandleTableADIndex(::HndGetHandleTable(handle)).m_dwIndex);
 }
 
-void GCHandleTable::DestroyHandleTable(void* table)
+void GCHandleTable::DestroyHandleStore(void* store)
 {
-    Ref_DestroyHandleTableBucket((HandleTableBucket*) table);
+    Ref_DestroyHandleTableBucket((HandleTableBucket*) store);
 }
 
-void GCHandleTable::UprootHandleTable(void* table)
+void GCHandleTable::UprootHandleStore(void* store)
 {
-    Ref_RemoveHandleTableBucket((HandleTableBucket*) table);
+    Ref_RemoveHandleTableBucket((HandleTableBucket*) store);
 }
 
-bool GCHandleTable::ContainsHandle(void* table, OBJECTHANDLE handle)
+bool GCHandleTable::ContainsHandle(void* store, OBJECTHANDLE handle)
 {
-    return ((HandleTableBucket*)table)->Contains(handle);
+    return ((HandleTableBucket*)store)->Contains(handle);
 }
 
-OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* table, Object* object, int type)
+OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* store, Object* object, int type)
 {
-    HHANDLETABLE handletable = ((HandleTableBucket*)table)->pTable[GetCurrentThreadHomeHeapNumber()];
+    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[GetCurrentThreadHomeHeapNumber()];
     return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
 }
 
-OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* table, Object* object, int type, int heapToAffinitizeTo)
+OBJECTHANDLE GCHandleTable::CreateHandleOfType(void* store, Object* object, int type, int heapToAffinitizeTo)
 {
-    HHANDLETABLE handletable = ((HandleTableBucket*)table)->pTable[heapToAffinitizeTo];
+    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[heapToAffinitizeTo];
     return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object));
 }
 
@@ -70,15 +75,15 @@ OBJECTHANDLE GCHandleTable::CreateGlobalHandleOfType(Object* object, int type)
     return ::HndCreateHandle(g_HandleTableMap.pBuckets[0]->pTable[GetCurrentThreadHomeHeapNumber()], type, ObjectToOBJECTREF(object)); 
 }
 
-OBJECTHANDLE GCHandleTable::CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo)
+OBJECTHANDLE GCHandleTable::CreateHandleWithExtraInfo(void* store, Object* object, int type, void* pExtraInfo)
 {
-    HHANDLETABLE handletable = ((HandleTableBucket*)table)->pTable[GetCurrentThreadHomeHeapNumber()];
+    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[GetCurrentThreadHomeHeapNumber()];
     return ::HndCreateHandle(handletable, type, ObjectToOBJECTREF(object), reinterpret_cast<uintptr_t>(pExtraInfo));
 }
 
-OBJECTHANDLE GCHandleTable::CreateDependentHandle(void* table, Object* primary, Object* secondary)
+OBJECTHANDLE GCHandleTable::CreateDependentHandle(void* store, Object* primary, Object* secondary)
 {
-    HHANDLETABLE handletable = ((HandleTableBucket*)table)->pTable[GetCurrentThreadHomeHeapNumber()];
+    HHANDLETABLE handletable = ((HandleTableBucket*)store)->pTable[GetCurrentThreadHomeHeapNumber()];
     OBJECTHANDLE handle = ::HndCreateHandle(handletable, HNDTYPE_DEPENDENT, ObjectToOBJECTREF(primary));
     ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(secondary));
 

--- a/src/Native/gc/gchandletableimpl.h
+++ b/src/Native/gc/gchandletableimpl.h
@@ -14,6 +14,10 @@ public:
 
     virtual void Shutdown();
 
+    virtual void* GetGlobalHandleTable();
+
+    virtual void* GetNewHandleTable(void* context);
+
     virtual void* GetHandleContext(OBJECTHANDLE handle);
 
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);

--- a/src/Native/gc/gchandletableimpl.h
+++ b/src/Native/gc/gchandletableimpl.h
@@ -20,7 +20,15 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle);
 
+    virtual void DestroyHandleTable(void* table);
+
+    virtual void UprootHandleTable(void* table);
+
+    virtual bool ContainsHandle(void* table, OBJECTHANDLE handle);
+
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);
+
+    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type, int heapToAffinitizeTo);
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo);
 

--- a/src/Native/gc/gchandletableimpl.h
+++ b/src/Native/gc/gchandletableimpl.h
@@ -14,7 +14,7 @@ public:
 
     virtual void Shutdown();
 
-    virtual void* GetHandleTableContext(void* handleTable);
+    virtual void* GetHandleContext(OBJECTHANDLE handle);
 
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle);
 

--- a/src/Native/gc/gchandletableimpl.h
+++ b/src/Native/gc/gchandletableimpl.h
@@ -25,6 +25,12 @@ public:
     virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary);
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type);
+
+    virtual void DestroyHandleOfType(OBJECTHANDLE handle, int type);
+
+    virtual void DestroyHandleOfUnknownType(OBJECTHANDLE handle);
+
+    virtual void* GetExtraInfoFromHandle(OBJECTHANDLE handle);
 };
 
 #endif  // GCHANDLETABLE_H_

--- a/src/Native/gc/gchandletableimpl.h
+++ b/src/Native/gc/gchandletableimpl.h
@@ -16,8 +16,6 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle);
 
-    virtual void* GetHandleTableForHandle(OBJECTHANDLE handle);
-
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo);
@@ -25,6 +23,8 @@ public:
     virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary);
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type);
+
+    virtual OBJECTHANDLE CreateDuplicateHandle(OBJECTHANDLE handle);
 
     virtual void DestroyHandleOfType(OBJECTHANDLE handle, int type);
 

--- a/src/Native/gc/gchandletableimpl.h
+++ b/src/Native/gc/gchandletableimpl.h
@@ -14,25 +14,25 @@ public:
 
     virtual void Shutdown();
 
-    virtual void* GetGlobalHandleTable();
+    virtual void* GetGlobalHandleStore();
 
-    virtual void* GetNewHandleTable(void* context);
+    virtual void* CreateHandleStore(void* context);
 
     virtual void* GetHandleContext(OBJECTHANDLE handle);
 
-    virtual void DestroyHandleTable(void* table);
+    virtual void DestroyHandleStore(void* store);
 
-    virtual void UprootHandleTable(void* table);
+    virtual void UprootHandleStore(void* store);
 
-    virtual bool ContainsHandle(void* table, OBJECTHANDLE handle);
+    virtual bool ContainsHandle(void* store, OBJECTHANDLE handle);
 
-    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type);
+    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type);
 
-    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type, int heapToAffinitizeTo);
+    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type, int heapToAffinitizeTo);
 
-    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo);
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* store, Object* object, int type, void* pExtraInfo);
 
-    virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary);
+    virtual OBJECTHANDLE CreateDependentHandle(void* store, Object* primary, Object* secondary);
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type);
 

--- a/src/Native/gc/gchandletableimpl.h
+++ b/src/Native/gc/gchandletableimpl.h
@@ -6,6 +6,34 @@
 #define GCHANDLETABLE_H_
 
 #include "gcinterface.h"
+#include "objecthandle.h"
+
+class GCHandleStore : public IGCHandleStore
+{
+public:
+    GCHandleStore(HandleTableBucket *bucket) 
+        : _underlyingBucket(bucket)
+        { }
+
+    virtual void Uproot();
+
+    virtual bool ContainsHandle(OBJECTHANDLE handle);
+
+    virtual OBJECTHANDLE CreateHandleOfType(Object* object, int type);
+
+    virtual OBJECTHANDLE CreateHandleOfType(Object* object, int type, int heapToAffinitizeTo);
+
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(Object* object, int type, void* pExtraInfo);
+
+    virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary);
+
+    virtual ~GCHandleStore();
+
+private:
+    HandleTableBucket* _underlyingBucket;
+};
+
+extern GCHandleStore* g_gcGlobalHandleStore;
 
 class GCHandleTable : public IGCHandleTable
 {
@@ -14,25 +42,13 @@ public:
 
     virtual void Shutdown();
 
-    virtual void* GetGlobalHandleStore();
-
-    virtual void* CreateHandleStore(void* context);
-
     virtual void* GetHandleContext(OBJECTHANDLE handle);
 
-    virtual void DestroyHandleStore(void* store);
+    virtual IGCHandleStore* GetGlobalHandleStore();
 
-    virtual void UprootHandleStore(void* store);
+    virtual IGCHandleStore* CreateHandleStore(void* context);
 
-    virtual bool ContainsHandle(void* store, OBJECTHANDLE handle);
-
-    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type);
-
-    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type, int heapToAffinitizeTo);
-
-    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* store, Object* object, int type, void* pExtraInfo);
-
-    virtual OBJECTHANDLE CreateDependentHandle(void* store, Object* primary, Object* secondary);
+    virtual void DestroyHandleStore(IGCHandleStore* store);
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type);
 

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -402,6 +402,24 @@ typedef struct OBJECTHANDLE__* OBJECTHANDLE;
 typedef uintptr_t OBJECTHANDLE;
 #endif
 
+class IGCHandleStore {
+public:
+
+    virtual void Uproot() = 0;
+
+    virtual bool ContainsHandle(OBJECTHANDLE handle) = 0;
+
+    virtual OBJECTHANDLE CreateHandleOfType(Object* object, int type) = 0;
+
+    virtual OBJECTHANDLE CreateHandleOfType(Object* object, int type, int heapToAffinitizeTo) = 0;
+
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(Object* object, int type, void* pExtraInfo) = 0;
+
+    virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary) = 0;
+
+    virtual ~IGCHandleStore() {};
+};
+
 class IGCHandleTable {
 public:
 
@@ -411,23 +429,11 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle) = 0;
 
-    virtual void* GetGlobalHandleStore() = 0;
+    virtual IGCHandleStore* GetGlobalHandleStore() = 0;
 
-    virtual void* CreateHandleStore(void* context) = 0;
+    virtual IGCHandleStore* CreateHandleStore(void* context) = 0;
 
-    virtual void DestroyHandleStore(void* store) = 0;
-
-    virtual void UprootHandleStore(void* store) = 0;
-
-    virtual bool ContainsHandle(void* store, OBJECTHANDLE handle) = 0;
-
-    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type) = 0;
-
-    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type, int heapToAffinitizeTo) = 0;
-
-    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* store, Object* object, int type, void* pExtraInfo) = 0;
-
-    virtual OBJECTHANDLE CreateDependentHandle(void* store, Object* primary, Object* secondary) = 0;
+    virtual void DestroyHandleStore(IGCHandleStore* store) = 0;
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type) = 0;
 

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -409,7 +409,7 @@ public:
 
     virtual void Shutdown() = 0;
 
-    virtual void* GetHandleTableContext(void* handleTable) = 0;
+    virtual void* GetHandleContext(OBJECTHANDLE handle) = 0;
 
     virtual void* GetHandleTableForHandle(OBJECTHANDLE handle) = 0;
 

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -411,23 +411,23 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle) = 0;
 
-    virtual void* GetGlobalHandleTable() = 0;
+    virtual void* GetGlobalHandleStore() = 0;
 
-    virtual void* GetNewHandleTable(void* context) = 0;
+    virtual void* CreateHandleStore(void* context) = 0;
 
-    virtual void DestroyHandleTable(void* table) = 0;
+    virtual void DestroyHandleStore(void* store) = 0;
 
-    virtual void UprootHandleTable(void* table) = 0;
+    virtual void UprootHandleStore(void* store) = 0;
 
-    virtual bool ContainsHandle(void* table, OBJECTHANDLE handle) = 0;
+    virtual bool ContainsHandle(void* store, OBJECTHANDLE handle) = 0;
 
-    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
+    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type) = 0;
 
-    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type, int heapToAffinitizeTo) = 0;
+    virtual OBJECTHANDLE CreateHandleOfType(void* store, Object* object, int type, int heapToAffinitizeTo) = 0;
 
-    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo) = 0;
+    virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* store, Object* object, int type, void* pExtraInfo) = 0;
 
-    virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary) = 0;
+    virtual OBJECTHANDLE CreateDependentHandle(void* store, Object* primary, Object* secondary) = 0;
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type) = 0;
 

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -411,8 +411,6 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle) = 0;
 
-    virtual void* GetHandleTableForHandle(OBJECTHANDLE handle) = 0;
-
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo) = 0;
@@ -420,6 +418,8 @@ public:
     virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary) = 0;
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type) = 0;
+
+    virtual OBJECTHANDLE CreateDuplicateHandle(OBJECTHANDLE handle) = 0;
 
     virtual void DestroyHandleOfType(OBJECTHANDLE handle, int type) = 0;
 

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -420,6 +420,12 @@ public:
     virtual OBJECTHANDLE CreateDependentHandle(void* table, Object* primary, Object* secondary) = 0;
 
     virtual OBJECTHANDLE CreateGlobalHandleOfType(Object* object, int type) = 0;
+
+    virtual void DestroyHandleOfType(OBJECTHANDLE handle, int type) = 0;
+
+    virtual void DestroyHandleOfUnknownType(OBJECTHANDLE handle) = 0;
+
+    virtual void* GetExtraInfoFromHandle(OBJECTHANDLE handle) = 0;
 };
 
 // IGCHeap is the interface that the VM will use when interacting with the GC.

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -411,6 +411,10 @@ public:
 
     virtual void* GetHandleContext(OBJECTHANDLE handle) = 0;
 
+    virtual void* GetGlobalHandleTable() = 0;
+
+    virtual void* GetNewHandleTable(void* context) = 0;
+
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo) = 0;

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -415,7 +415,15 @@ public:
 
     virtual void* GetNewHandleTable(void* context) = 0;
 
+    virtual void DestroyHandleTable(void* table) = 0;
+
+    virtual void UprootHandleTable(void* table) = 0;
+
+    virtual bool ContainsHandle(void* table, OBJECTHANDLE handle) = 0;
+
     virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type) = 0;
+
+    virtual OBJECTHANDLE CreateHandleOfType(void* table, Object* object, int type, int heapToAffinitizeTo) = 0;
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(void* table, Object* object, int type, void* pExtraInfo) = 0;
 

--- a/src/Native/gc/handletable.cpp
+++ b/src/Native/gc/handletable.cpp
@@ -1338,24 +1338,6 @@ void  Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket 
 }
 #endif // !FEATURE_REDHAWK
 
-BOOL Ref_ContainHandle(HandleTableBucket *pBucket, OBJECTHANDLE handle)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-    }
-    CONTRACTL_END;
-
-    int limit = getNumberOfSlots();
-    for (int n = 0; n < limit; n ++ )
-    {
-        if (TableContainHandle(Table(pBucket->pTable[n]), handle))
-            return TRUE;
-    }
-
-    return FALSE;
-}
 /*--------------------------------------------------------------------------*/
 
 

--- a/src/Native/gc/handletable.h
+++ b/src/Native/gc/handletable.h
@@ -216,18 +216,6 @@ FORCEINLINE BOOL HndIsNull(OBJECTHANDLE handle)
 }
 
 
-
-/*
- * inline handle checking
- */
-FORCEINLINE BOOL HndCheckForNullUnchecked(OBJECTHANDLE handle)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    return (handle == NULL || (*(_UNCHECKED_OBJECTREF *)handle) == NULL);
-}
-
-
 /*
  *
  * Checks handle value for null or special value used for free handles in cache.

--- a/src/Native/gc/handletablecore.cpp
+++ b/src/Native/gc/handletablecore.cpp
@@ -1003,7 +1003,8 @@ void SegmentRelocateAsyncPinHandles (TableSegment *pSegment, HandleTable *pTarge
                     overlapped->m_userObject = NULL;
                 }
                 BashMTForPinnedObject(ObjectToOBJECTREF(value));
-                overlapped->m_pinSelf = CreateAsyncPinningHandle((HHANDLETABLE)pTargetTable,ObjectToOBJECTREF(value));
+
+                overlapped->m_pinSelf = HndCreateHandle((HHANDLETABLE)pTargetTable, HNDTYPE_ASYNCPINNED, ObjectToOBJECTREF(value));
                 *pValue = NULL;
             }
             pValue ++;

--- a/src/Native/gc/handletablescan.cpp
+++ b/src/Native/gc/handletablescan.cpp
@@ -949,7 +949,7 @@ static void VerifyObjectAndAge(_UNCHECKED_OBJECTREF *pValue, _UNCHECKED_OBJECTRE
     if (minAge >= GEN_MAX_AGE || (minAge > thisAge && thisAge < static_cast<int>(g_theGCHeap->GetMaxGeneration())))
     {
         _ASSERTE(!"Fatal Error in HandleTable.");
-        EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+        GCToEEInterface::HandleFatalError(COR_E_EXECUTIONENGINE);
     }
 }
 

--- a/src/Native/gc/objecthandle.cpp
+++ b/src/Native/gc/objecthandle.cpp
@@ -1856,51 +1856,6 @@ bool HandleTableBucket::Contains(OBJECTHANDLE handle)
     return FALSE;
 }
 
-void DestroySizedRefHandle(OBJECTHANDLE handle)
-{ 
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        SO_TOLERANT;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
-    HHANDLETABLE hTable = HndGetHandleTable(handle);
-    HndDestroyHandle(hTable , HNDTYPE_SIZEDREF, handle);
-    AppDomain* pDomain = SystemDomain::GetAppDomainAtIndex(HndGetHandleTableADIndex(hTable));
-    pDomain->DecNumSizedRefHandles();
-}
-
-#ifdef FEATURE_COMINTEROP
-
-void DestroyWinRTWeakHandle(OBJECTHANDLE handle)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        CAN_TAKE_LOCK;
-        SO_TOLERANT;
-    }
-    CONTRACTL_END;
-
-    // Release the WinRT weak reference if we have one.  We're assuming that this will not reenter the
-    // runtime, since if we are pointing at a managed object, we should not be using a HNDTYPE_WEAK_WINRT
-    // but rather a HNDTYPE_WEAK_SHORT or HNDTYPE_WEAK_LONG.
-    IWeakReference* pWinRTWeakReference = reinterpret_cast<IWeakReference*>(HndGetHandleExtraInfo(handle));
-    if (pWinRTWeakReference != NULL)
-    {
-        pWinRTWeakReference->Release();
-    }
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_WINRT, handle);
-}
-
-#endif // FEATURE_COMINTEROP
-
 #endif // !DACCESS_COMPILE
 
 OBJECTREF GetDependentHandleSecondary(OBJECTHANDLE handle)

--- a/src/Native/gc/objecthandle.cpp
+++ b/src/Native/gc/objecthandle.cpp
@@ -19,6 +19,8 @@
 #include "objecthandle.h"
 #include "handletablepriv.h"
 
+#include "gchandletableimpl.h"
+
 #ifdef FEATURE_COMINTEROP
 #include "comcallablewrapper.h"
 #endif // FEATURE_COMINTEROP
@@ -663,6 +665,10 @@ bool Ref_Initialize()
         g_HandleTableMap.dwMaxIndex = INITIAL_HANDLE_TABLE_ARRAY_SIZE;
         g_HandleTableMap.pNext = NULL;
 
+        g_gcGlobalHandleStore = new (nothrow) GCHandleStore(g_HandleTableMap.pBuckets[0]);
+        if (g_gcGlobalHandleStore == NULL)
+            goto CleanupAndFail;
+
         // Allocate contexts used during dependent handle promotion scanning. There's one of these for every GC
         // heap since they're scanned in parallel.
         g_pDependentHandleContexts = new (nothrow) DhContext[n_slots];
@@ -671,6 +677,7 @@ bool Ref_Initialize()
 
         return true;
     }
+
 
 CleanupAndFail:
     if (pBuckets != NULL)

--- a/src/Native/gc/objecthandle.h
+++ b/src/Native/gc/objecthandle.h
@@ -73,119 +73,10 @@ struct HandleTableBucket
                                     (flag == VHT_STRONG)     || \
                                     (flag == VHT_PINNED))
 
-#ifndef DACCESS_COMPILE
-/*
- * Convenience macros and prototypes for the various handle types we define
- */
-
-inline void DestroyTypedHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandleOfUnknownType(HndGetHandleTable(handle), handle);
-}
-
-inline void DestroyHandle(OBJECTHANDLE handle)
-{ 
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        CAN_TAKE_LOCK;
-        SO_TOLERANT;
-    }
-    CONTRACTL_END;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, handle);
-}
-
-inline void DestroyWeakHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_DEFAULT, handle);
-}
-
-inline void DestroyShortWeakHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_SHORT, handle);
-}
-
-inline void DestroyLongWeakHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_LONG, handle);
-}
-
-#ifndef FEATURE_REDHAWK
-typedef Holder<OBJECTHANDLE,DoNothing<OBJECTHANDLE>,DestroyLongWeakHandle> LongWeakHandleHolder;
-#endif
-
-inline void DestroyStrongHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_STRONG, handle);
-}
-
-inline void DestroyPinningHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_PINNED, handle);
-}
-
-#ifndef FEATURE_REDHAWK
-typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyPinningHandle, NULL> PinningHandleHolder;
-#endif
-
-inline void DestroyAsyncPinningHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_ASYNCPINNED, handle);
-}
-
-#ifndef FEATURE_REDHAWK
-typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyAsyncPinningHandle, NULL> AsyncPinningHandleHolder;
-#endif
-
-void DestroySizedRefHandle(OBJECTHANDLE handle);
-
-#ifndef FEATURE_REDHAWK
-typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroySizedRefHandle, NULL> SizeRefHandleHolder;
-#endif
-
-#ifdef FEATURE_COMINTEROP
-
-inline void DestroyRefcountedHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_REFCOUNTED, handle);
-}
-
-void DestroyWinRTWeakHandle(OBJECTHANDLE handle);
-
-#endif // FEATURE_COMINTEROP
-
-#endif // !DACCESS_COMPILE
-
 OBJECTREF GetDependentHandleSecondary(OBJECTHANDLE handle);
 
 #ifndef DACCESS_COMPILE
 void SetDependentHandleSecondary(OBJECTHANDLE handle, OBJECTREF secondary);
-
-inline void DestroyDependentHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-	HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_DEPENDENT, handle);
-}
 #endif // !DACCESS_COMPILE
 
 #ifndef DACCESS_COMPILE
@@ -193,129 +84,13 @@ uint32_t     GetVariableHandleType(OBJECTHANDLE handle);
 void         UpdateVariableHandleType(OBJECTHANDLE handle, uint32_t type);
 uint32_t     CompareExchangeVariableHandleType(OBJECTHANDLE handle, uint32_t oldType, uint32_t newType);
 
-inline void  DestroyVariableHandle(OBJECTHANDLE handle)
-{
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_VARIABLE, handle);
-}
-
 void GCHandleValidatePinnedObject(OBJECTREF obj);
 
-/*
- * Holder for OBJECTHANDLE
- */
-
-#ifndef FEATURE_REDHAWK
-typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyHandle > OHWrapper;
-
-class OBJECTHANDLEHolder : public OHWrapper
-{
-public:
-    FORCEINLINE OBJECTHANDLEHolder(OBJECTHANDLE p = NULL) : OHWrapper(p)
-    {
-        LIMITED_METHOD_CONTRACT;
-    }
-    FORCEINLINE void operator=(OBJECTHANDLE p)
-    {
-        WRAPPER_NO_CONTRACT;
-
-        OHWrapper::operator=(p);
-    }
-};
-#endif
-
-#ifdef FEATURE_COMINTEROP
-
-typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, DestroyRefcountedHandle> RefCountedOHWrapper;
-
-class RCOBJECTHANDLEHolder : public RefCountedOHWrapper
-{
-public:
-    FORCEINLINE RCOBJECTHANDLEHolder(OBJECTHANDLE p = NULL) : RefCountedOHWrapper(p)
-    {
-        LIMITED_METHOD_CONTRACT;
-    }
-    FORCEINLINE void operator=(OBJECTHANDLE p)
-    {
-        WRAPPER_NO_CONTRACT;
-
-        RefCountedOHWrapper::operator=(p);
-    }
-};
-
-#endif // FEATURE_COMINTEROP
 /*
  * Convenience prototypes for using the global handles
  */
 
 int GetCurrentThreadHomeHeapNumber();
-
-inline void DestroyGlobalTypedHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandleOfUnknownType(HndGetHandleTable(handle), handle);
-}
-
-inline void DestroyGlobalHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_DEFAULT, handle);
-}
-
-inline void DestroyGlobalWeakHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_DEFAULT, handle);
-}
-
-inline void DestroyGlobalShortWeakHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_SHORT, handle);
-}
-
-#ifndef FEATURE_REDHAWK
-typedef Holder<OBJECTHANDLE,DoNothing<OBJECTHANDLE>,DestroyGlobalShortWeakHandle> GlobalShortWeakHandleHolder;
-#endif
-
-inline void DestroyGlobalLongWeakHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_WEAK_LONG, handle);
-}
-
-inline void DestroyGlobalStrongHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_STRONG, handle);
-}
-
-#ifndef FEATURE_REDHAWK
-typedef Holder<OBJECTHANDLE,DoNothing<OBJECTHANDLE>,DestroyGlobalStrongHandle> GlobalStrongHandleHolder;
-#endif
-
-inline void DestroyGlobalPinningHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_PINNED, handle);
-}
-
-#ifdef FEATURE_COMINTEROP
-inline void DestroyGlobalRefcountedHandle(OBJECTHANDLE handle)
-{ 
-    WRAPPER_NO_CONTRACT;
-
-    HndDestroyHandle(HndGetHandleTable(handle), HNDTYPE_REFCOUNTED, handle);
-}
-#endif // FEATURE_COMINTEROP
 
 inline void ResetOBJECTHANDLE(OBJECTHANDLE handle)
 {

--- a/src/Native/gc/objecthandle.h
+++ b/src/Native/gc/objecthandle.h
@@ -111,7 +111,6 @@ BOOL Ref_HandleAsyncPinHandles();
 void Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget);
 void Ref_RemoveHandleTableBucket(HandleTableBucket *pBucket);
 void Ref_DestroyHandleTableBucket(HandleTableBucket *pBucket);
-BOOL Ref_ContainHandle(HandleTableBucket *pBucket, OBJECTHANDLE handle);
 
 /*
  * GC-time scanning entrypoints

--- a/src/Native/gc/objecthandle.h
+++ b/src/Native/gc/objecthandle.h
@@ -30,8 +30,6 @@
 #define StoreObjectInHandle(handle, object)        HndAssignHandle(handle, object)
 #define InterlockedCompareExchangeObjectInHandle(handle, object, oldObj)        HndInterlockedCompareExchangeHandle(handle, object, oldObj)
 #define StoreFirstObjectInHandle(handle, object)   HndFirstAssignHandle(handle, object)
-#define ObjectHandleIsNull(handle)                 HndIsNull(handle)
-#define IsHandleNullUnchecked(handle)              HndCheckForNullUnchecked(handle)
 
 typedef DPTR(struct HandleTableMap) PTR_HandleTableMap;
 typedef DPTR(struct HandleTableBucket) PTR_HandleTableBucket;

--- a/src/Native/gc/sample/GCSample.cpp
+++ b/src/Native/gc/sample/GCSample.cpp
@@ -229,7 +229,7 @@ int __cdecl main(int argc, char* argv[])
         return -1;
 
     // Destroy the strong handle so that nothing will be keeping out object alive
-    DestroyGlobalHandle(oh);
+    HndDestroyHandle(HndGetHandleTable(oh), HNDTYPE_DEFAULT, oh);
 
     // Explicitly trigger full GC
     pGCHeap->GarbageCollect();


### PR DESCRIPTION
This port continues https://github.com/dotnet/corert/pull/7358
Porting strategy: extracting patches via `format-patch` from coreclr, adjusting paths, then `am` them on corert.

**Glossary:**
- already merged: change already exists in corert
- gc only port: change only affected the gc directory and patch applied with no conflicts
- manual port: change applied with custom changes
- omitted changes: contains changes to files that do not exists in corert and were discarded

**Changes since [last commit](https://github.com/dotnet/coreclr/commit/09b7f0a0f44798108a33d7e698420f147c45461b):**
- https://github.com/dotnet/coreclr/commit/ac0ba59034c46da198b12812899e34dec21990e9 (manual port)
- https://github.com/dotnet/coreclr/commit/efd4d357f009e4509a6147f390d2d9fde7d717d0 (gc only port)
- https://github.com/dotnet/coreclr/commit/6f013232079c2a2dd9f0f58362443b5ec5b43c15 (gc only port)
- https://github.com/dotnet/coreclr/commit/ea22d55fc0392cf858d4c1c17d504523a1e18732 (gc only port, omitted changes)
- https://github.com/dotnet/coreclr/commit/734f13c964610d1f4fee08611beca1aa02de0082 (gc only port)
- https://github.com/dotnet/coreclr/commit/bf7cf40e14b8cf35c68be089735dd16081db9dc4 (gc only port, omitted changes)
- https://github.com/dotnet/coreclr/commit/3e6334b8797731bc24a2b9c69a7b7073a92b66a9 (gc only port, omitted changes)
- https://github.com/dotnet/coreclr/commit/ab43a5fbeccca1e4948dd140592361fe7c3335c3 (gc only port, omitted changes)
- https://github.com/dotnet/coreclr/commit/da00894a5d657b3ba06ebf6e004e5a5a0976434b (manual port, omitted changes)
- https://github.com/dotnet/coreclr/commit/56776b20f5902ef60d43cb502d734193b2521fca (gc only port)