### PR TITLE
Add the enum value for manifest metadata to R2R header constants

### DIFF
--- a/src/Common/src/Internal/Runtime/ModuleHeaders.cs
+++ b/src/Common/src/Internal/Runtime/ModuleHeaders.cs
@@ -61,6 +61,7 @@ namespace Internal.Runtime
         InstanceMethodEntryPoints = 109,
         InliningInfo = 110, // Added in v2.1
         ProfileDataInfo = 111, // Added in v2.2
+        ManifestMetadata = 112, // Added in v2.3
 
         //
         // CoreRT ReadyToRun sections


### PR DESCRIPTION
Not the real implementation, just the enum now I have it in fresh
memory from the R2RDump change :-).

Thanks

Tomas