### PR TITLE
Experimental fix for infinite generic expansion in CPAOT

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
@@ -73,6 +73,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     constrainedType: null,
                     originalMethod: canonMethod,
                     methodToken: _method.Token,
+                    parentMethod: this,
                     isUnboxingStub: false,
                     isInstantiatingStub: false,
                     signatureContext: _signatureContext);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -21,6 +21,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private readonly MethodDesc _method;
         public SignatureContext SignatureContext { get; }
 
+        /// <summary>
+        /// First method node the compilation of which requested this node as a dependency.
+        /// </summary>
+        public IMethodNode ParentMethod { get;  }
+
         private ObjectData _methodCode;
         private FrameInfo[] _frameInfos;
         private byte[] _gcInfo;
@@ -29,11 +34,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private NativeVarInfo[] _debugVarInfos;
         private DebugEHClauseInfo[] _debugEHClauseInfos;
 
-        public MethodWithGCInfo(MethodDesc methodDesc, SignatureContext signatureContext)
+        public MethodWithGCInfo(MethodDesc methodDesc, IMethodNode parentMethod, SignatureContext signatureContext)
         {
             GCInfoNode = new MethodGCInfoNode(this);
             _method = methodDesc;
             SignatureContext = signatureContext;
+            ParentMethod = parentMethod;
         }
 
         public void SetCode(ObjectData data)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -742,7 +742,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private readonly Dictionary<TypeAndMethod, ISymbolNode> _delegateCtors = new Dictionary<TypeAndMethod, ISymbolNode>();
 
-        public ISymbolNode DelegateCtor(TypeDesc delegateType, MethodDesc targetMethod, ModuleToken methodToken, SignatureContext signatureContext)
+        public ISymbolNode DelegateCtor(TypeDesc delegateType, MethodDesc targetMethod, ModuleToken methodToken, IMethodNode parentMethod, SignatureContext signatureContext)
         {
             TypeAndMethod ctorKey = new TypeAndMethod(delegateType, targetMethod, methodToken: methodToken, isUnboxingStub: false, isInstantiatingStub: false);
             if (!_delegateCtors.TryGetValue(ctorKey, out ISymbolNode ctorNode))
@@ -752,6 +752,7 @@ namespace ILCompiler.DependencyAnalysis
                     constrainedType: null, 
                     originalMethod: null,
                     methodToken: methodToken,
+                    parentMethod: parentMethod,
                     isUnboxingStub: false,
                     isInstantiatingStub: false,
                     signatureContext: signatureContext);

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -291,7 +291,11 @@ namespace Internal.JitInterface
 
             pLookup.lookupKind.needsRuntimeLookup = false;
             pLookup.constLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.DelegateCtor(
-                    delegateTypeDesc, targetMethod, new ModuleToken(_tokenContext, (mdToken)pTargetMethod.token), _signatureContext));
+                    delegateTypeDesc, 
+                    targetMethod, 
+                    new ModuleToken(_tokenContext, (mdToken)pTargetMethod.token), 
+                    _methodCodeNode, 
+                    _signatureContext));
         }
 
         private ISymbolNode GetHelperFtnUncached(CorInfoHelpFunc ftnNum)
@@ -1190,11 +1194,15 @@ namespace Internal.JitInterface
 
                         // READYTORUN: FUTURE: Direct calls if possible
                         pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
-                            _compilation.NodeFactory.ImportedMethodNode(methodToCall, constrainedType, originalMethod,
-                            new ModuleToken(callerModule, pResolvedToken.token),
-                            isUnboxingStub: false,
-                            isInstantiatingStub: useInstantiatingStub,
-                            _signatureContext));
+                            _compilation.NodeFactory.ImportedMethodNode(
+                                methodToCall, 
+                                constrainedType, 
+                                originalMethod,
+                                new ModuleToken(callerModule, pResolvedToken.token),
+                                parentMethod: _methodCodeNode,
+                                isUnboxingStub: false,
+                                isInstantiatingStub: useInstantiatingStub,
+                                _signatureContext));
                     }
                     break;
 


### PR DESCRIPTION
As usual, writing the e-mail on this subject helped me clear my
thoughts and I subsequently realized there's a rather elegant way
to do this very cheaply (at least in some cases): we just add the
notion of a "parent method" to MethodWithGCInfo and, upon creation
of a new MethodEntrypoint, we throw if the history linked list
contains the same generic method, just instantiated with a different
parameter variants.

I don't insist on merging this in if you think it's fundamentally
flawed or incomplete; I just wanted to point it out as an easy option
to fix some occurrences of this issue; it does fix compilation of
the test

JIT\Regression\clr-x64-JIT\v4.0\devdiv374539\DevDiv_374539\DevDiv_374539.exe

I mentioned in the e-mail. I'm looking forward to feedback.

Thanks

Tomas