### PR TITLE
Fixes for deficiencies in generic method & field encoding

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -132,7 +132,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public void AddModuleTokenForField(FieldDesc field, ModuleToken token)
         {
-            if (_compilationModuleGroup.ContainsType(field.OwningType))
+            if (_compilationModuleGroup.ContainsType(field.OwningType) && field.OwningType is EcmaType)
             {
                 // We don't need to store handles within the current compilation group
                 // as we can read them directly from the ECMA objects.
@@ -140,7 +140,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
 
             TypeDesc owningCanonType = field.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific);
-            FieldDesc canonField = owningCanonType.GetField(field.Name);
+            FieldDesc canonField = field;
+            if (owningCanonType != field.OwningType)
+            {
+                canonField = _typeSystemContext.GetFieldForInstantiatedType(field.GetTypicalFieldDefinition(), (InstantiatedType)owningCanonType);
+            }
 
             _fieldToRefTokens[canonField] = token;
             switch (token.TokenType)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -97,7 +97,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             if (throwIfNotFound)
             {
-                throw new NotImplementedException();
+                throw new NotImplementedException(field.ToString());
             }
             else
             {
@@ -139,11 +139,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return;
             }
 
-            _fieldToRefTokens[field] = token;
+            TypeDesc owningCanonType = field.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific);
+            FieldDesc canonField = owningCanonType.GetField(field.Name);
+
+            _fieldToRefTokens[canonField] = token;
             switch (token.TokenType)
             {
                 case CorTokenType.mdtMemberRef:
-                    AddModuleTokenForFieldReference(field.OwningType, token);
+                    AddModuleTokenForFieldReference(owningCanonType, token);
                     break;
 
                 default:

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -528,7 +528,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 fieldSigFlags |= (uint)ReadyToRunFieldSigFlags.READYTORUN_FIELD_SIG_OwnerType;
 
                 // Convert field to canonical form as this is what the field - module token lookup stores
-                field = field.Context.GetFieldForInstantiatedType(field, (InstantiatedType)canonOwnerType);
+                field = field.Context.GetFieldForInstantiatedType(field.GetTypicalFieldDefinition(), (InstantiatedType)canonOwnerType);
             }
 
             ModuleToken fieldToken = context.GetModuleTokenForField(field);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -528,7 +528,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 fieldSigFlags |= (uint)ReadyToRunFieldSigFlags.READYTORUN_FIELD_SIG_OwnerType;
 
                 // Convert field to canonical form as this is what the field - module token lookup stores
-                field = canonOwnerType.GetField(field.Name);
+                field = field.Context.GetFieldForInstantiatedType(field, (InstantiatedType)canonOwnerType);
             }
 
             ModuleToken fieldToken = context.GetModuleTokenForField(field);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -207,6 +207,8 @@ namespace ILCompiler.DependencyAnalysis
 
         private ISymbolNode CreateMethodHandleHelper(MethodWithToken method, SignatureContext signatureContext)
         {
+            bool useInstantiatingStub = method.Method.GetCanonMethodTarget(CanonicalFormKind.Specific) != method.Method;
+
             return new PrecodeHelperImport(
                 _codegenNodeFactory,
                 _codegenNodeFactory.MethodSignature(
@@ -215,7 +217,7 @@ namespace ILCompiler.DependencyAnalysis
                     constrainedType: null,
                     method.Token,
                     isUnboxingStub: false,
-                    isInstantiatingStub: method.Method.HasInstantiation,
+                    isInstantiatingStub: useInstantiatingStub,
                     signatureContext));
         }
 


### PR DESCRIPTION
This change seems to be fixing one of the last CPAOT compilation
buckets by making the logic for emitting field signatures more
robust. I have also tried to improve the logic for choosing
whether to emit method instantiation stub to make the import cells
better match between CPAOT and Crossgen.

Thanks

Tomas