### PR TITLE
Add support for NativeLibrary.SetDllImportResolver

### DIFF
--- a/src/Common/src/Internal/Runtime/InteropConstants.cs
+++ b/src/Common/src/Internal/Runtime/InteropConstants.cs
@@ -20,5 +20,10 @@ namespace Internal.Runtime
         /// Shift used to encode field count
         /// </summary>
         public const int FieldCountShift = 2;
+
+        /// <summary>
+        /// Flag set in ModuleFixupCell if DllImportSearchPath is specified for the DllImport.
+        /// </summary>
+        public const uint HasDllImportSearchPath = 0x80000000;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -235,12 +235,12 @@ namespace ILCompiler.DependencyAnalysis
                 return new ExternSymbolNode(name);
             });
 
-            _pInvokeModuleFixups = new NodeCache<string, PInvokeModuleFixupNode>((string name) =>
+            _pInvokeModuleFixups = new NodeCache<PInvokeModuleData, PInvokeModuleFixupNode>((PInvokeModuleData moduleData) =>
             {
-                return new PInvokeModuleFixupNode(name);
+                return new PInvokeModuleFixupNode(moduleData);
             });
 
-            _pInvokeMethodFixups = new NodeCache<Tuple<string, string, PInvokeFlags>, PInvokeMethodFixupNode>((Tuple<string, string, PInvokeFlags> key) =>
+            _pInvokeMethodFixups = new NodeCache<Tuple<PInvokeModuleData, string, PInvokeFlags>, PInvokeMethodFixupNode>((Tuple<PInvokeModuleData, string, PInvokeFlags> key) =>
             {
                 return new PInvokeMethodFixupNode(key.Item1, key.Item2, key.Item3);
             });
@@ -688,18 +688,18 @@ namespace ILCompiler.DependencyAnalysis
             return _externSymbols.GetOrAdd(name);
         }
 
-        private NodeCache<string, PInvokeModuleFixupNode> _pInvokeModuleFixups;
+        private NodeCache<PInvokeModuleData, PInvokeModuleFixupNode> _pInvokeModuleFixups;
 
-        public ISymbolNode PInvokeModuleFixup(string moduleName)
+        public ISymbolNode PInvokeModuleFixup(PInvokeModuleData moduleData)
         {
-            return _pInvokeModuleFixups.GetOrAdd(moduleName);
+            return _pInvokeModuleFixups.GetOrAdd(moduleData);
         }
 
-        private NodeCache<Tuple<string, string, PInvokeFlags>, PInvokeMethodFixupNode> _pInvokeMethodFixups;
+        private NodeCache<Tuple<PInvokeModuleData, string, PInvokeFlags>, PInvokeMethodFixupNode> _pInvokeMethodFixups;
 
-        public PInvokeMethodFixupNode PInvokeMethodFixup(string moduleName, string entryPointName, PInvokeFlags flags)
+        public PInvokeMethodFixupNode PInvokeMethodFixup(PInvokeModuleData moduleData, string entryPointName, PInvokeFlags flags)
         {
-            return _pInvokeMethodFixups.GetOrAdd(Tuple.Create(moduleName, entryPointName, flags));
+            return _pInvokeMethodFixups.GetOrAdd(Tuple.Create(moduleData, entryPointName, flags));
         }
 
         private NodeCache<TypeDesc, VTableSliceNode> _vTableNodes;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/PInvokeMethodFixupNode.cs
@@ -15,13 +15,13 @@ namespace ILCompiler.DependencyAnalysis
     /// </summary>
     public class PInvokeMethodFixupNode : ObjectNode, ISymbolDefinitionNode
     {
-        private string _moduleName;
-        private string _entryPointName;
-        private PInvokeFlags _flags;
+        private readonly PInvokeModuleData _moduleData;
+        private readonly string _entryPointName;
+        private readonly PInvokeFlags _flags;
 
-        public PInvokeMethodFixupNode(string moduleName, string entryPointName, PInvokeFlags flags)
+        public PInvokeMethodFixupNode(PInvokeModuleData moduleData, string entryPointName, PInvokeFlags flags)
         {
-            _moduleName = moduleName;
+            _moduleData = moduleData;
             _entryPointName = entryPointName;
             _flags = flags;
         }
@@ -29,7 +29,7 @@ namespace ILCompiler.DependencyAnalysis
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
             sb.Append("__pinvoke_");
-            sb.Append(_moduleName);
+            _moduleData.AppendMangledName(nameMangler, sb);
             sb.Append("__");
             sb.Append(_entryPointName);
             if(!_flags.ExactSpelling)
@@ -80,7 +80,7 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             // Module fixup cell
-            builder.EmitPointerReloc(factory.PInvokeModuleFixup(_moduleName));
+            builder.EmitPointerReloc(factory.PInvokeModuleFixup(_moduleData));
 
             builder.EmitInt(_flags.ExactSpelling ? 0 : (int)_flags.CharSet);
 
@@ -95,7 +95,7 @@ namespace ILCompiler.DependencyAnalysis
             if (flagsCompare != 0)
                 return flagsCompare;
 
-            var moduleCompare = string.Compare(_moduleName, ((PInvokeMethodFixupNode)other)._moduleName);
+            var moduleCompare = _moduleData.CompareTo(((PInvokeMethodFixupNode)other)._moduleData, comparer);
             if (moduleCompare != 0)
                 return moduleCompare;
 

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/ReflectionExecutionDomainCallbacks.cs
@@ -49,6 +49,7 @@ namespace Internal.Runtime.Augments
 
         public abstract string GetBetterDiagnosticInfoIfAvailable(RuntimeTypeHandle runtimeTypeHandle);
         public abstract MethodBase GetMethodBaseFromStartAddressIfAvailable(IntPtr methodStartAddress);
+        public abstract Assembly GetAssemblyForHandle(RuntimeTypeHandle typeHandle);
 
 #if PROJECTN
         public abstract int ValueTypeGetHashCodeUsingReflection(object valueType);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ReflectionHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ReflectionHelpers.cs
@@ -32,7 +32,7 @@ namespace Internal.Runtime.CompilerHelpers
         [System.Runtime.CompilerServices.DependencyReductionRoot]
         public static Assembly GetExecutingAssembly(RuntimeTypeHandle typeHandle)
         {
-            return Type.GetTypeFromHandle(typeHandle).Assembly;
+            return RuntimeAugments.Callbacks.GetAssemblyForHandle(typeHandle);
         }
 
         // This supports MethodBase.GetCurrentMethod() intrinsic expansion in the compiler

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -60,6 +60,9 @@
     <Compile Include="..\..\Common\src\Internal\Runtime\RuntimeConstants.cs">
       <Link>Internal\Runtime\RuntimeConstants.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\Internal\Runtime\InteropConstants.cs">
+      <Link>Internal\Runtime\InteropConstants.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\ExceptionStringID.cs">
       <Link>ExceptionStringID.cs</Link>
     </Compile>

--- a/src/System.Private.DisabledReflection/src/Internal/Reflection/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.DisabledReflection/src/Internal/Reflection/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -13,6 +13,7 @@ namespace Internal.Reflection
     {
         public override Exception CreateMissingMetadataException(Type typeWithMissingMetadata) => throw new NotImplementedException();
         public override Type GetArrayTypeForHandle(RuntimeTypeHandle typeHandle) => RuntimeTypeInfo.GetRuntimeTypeInfo(typeHandle);
+        public override Assembly GetAssemblyForHandle(RuntimeTypeHandle typeHandle) => new RuntimeAssembly(typeHandle);
         public override string GetBetterDiagnosticInfoIfAvailable(RuntimeTypeHandle runtimeTypeHandle) => null;
         public override Type GetByRefTypeForHandle(RuntimeTypeHandle typeHandle) => RuntimeTypeInfo.GetRuntimeTypeInfo(typeHandle);
         public override Type GetConstructedGenericTypeForHandle(RuntimeTypeHandle typeHandle) => RuntimeTypeInfo.GetRuntimeTypeInfo(typeHandle);

--- a/src/System.Private.DisabledReflection/src/Internal/Reflection/RuntimeAssembly.cs
+++ b/src/System.Private.DisabledReflection/src/Internal/Reflection/RuntimeAssembly.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+
+namespace Internal.Reflection
+{
+    internal sealed class RuntimeAssembly : Assembly
+    {
+        private readonly RuntimeTypeHandle _moduleType;
+
+        public RuntimeAssembly(RuntimeTypeHandle moduleType)
+        {
+            _moduleType = moduleType;
+        }
+
+        public override bool Equals(object o)
+        {
+            return o is RuntimeAssembly other && other._moduleType.Equals(_moduleType);
+        }
+
+        public override int GetHashCode()
+        {
+            return _moduleType.GetHashCode();
+        }
+    }
+}

--- a/src/System.Private.DisabledReflection/src/System.Private.DisabledReflection.csproj
+++ b/src/System.Private.DisabledReflection/src/System.Private.DisabledReflection.csproj
@@ -18,6 +18,7 @@
       <Link>System\Collections\HashHelpers.cs</Link>
     </Compile>
     <Compile Include="Internal\Reflection\ReflectionExecutionDomainCallbacksImplementation.cs" />
+    <Compile Include="Internal\Reflection\RuntimeAssembly.cs" />
     <Compile Include="Internal\Reflection\RuntimeTypeInfo.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\LibraryInitializer.cs" />
   </ItemGroup>

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -114,6 +114,11 @@ namespace Internal.Reflection.Execution
             return ReflectionCoreExecution.ExecutionDomain.GetMethod(declaringTypeHandle, methodHandle, genericMethodTypeArgumentHandles: null);
         }
 
+        public sealed override Assembly GetAssemblyForHandle(RuntimeTypeHandle typeHandle)
+        {
+            return Type.GetTypeFromHandle(typeHandle).Assembly;
+        }
+
         public sealed override IntPtr TryGetStaticClassConstructionContext(RuntimeTypeHandle runtimeTypeHandle)
         {
             return _executionEnvironment.TryGetStaticClassConstructionContext(runtimeTypeHandle);


### PR DESCRIPTION
Touches a lot of files, but most of it is just piping.

This also ensures correct behavior when `DefaultDllImportSearchPaths` is specified.

* In the compiler, preserve information about `DefaultDllImportSearchPathsAttribute` custom attribute applied to the assembly. Also preserve the EEType pointer to the assembly's module type. We attach this information the the module fixup cell.
* When resolving the p/invoke at runtime, use `DefaultDllImportSearchPaths` that the compiled embedded. Also retrieve the assembly that the p/invoke was declared in and call the user provided callback.

I'm also tweaking `Assembly.GetExecutingAssembly` so that the common pattern of registering DllImportResolved in the current assembly works when reflection is disabled.