### PR TITLE
Port GC changes from coreclr - 7

### DIFF
--- a/src/Native/Runtime/CMakeLists.txt
+++ b/src/Native/Runtime/CMakeLists.txt
@@ -45,6 +45,7 @@ set(COMMON_RUNTIME_SOURCES
     # module.cpp
     # RHCodeMan.cpp
 
+    ../gc/gcconfig.cpp
     ../gc/gchandletable.cpp
     ../gc/gccommon.cpp
     ../gc/gceewks.cpp

--- a/src/Native/Runtime/gcenv.h
+++ b/src/Native/Runtime/gcenv.h
@@ -262,3 +262,8 @@ void SetGCSpecialThread(ThreadType threadType);
 // it accurately in full GCs if the handle count is requested.
 extern DWORD g_dwHandles;
 #endif // ENABLE_PERF_COUNTERS || FEATURE_EVENT_TRACE
+
+/* _TRUNCATE */
+#if !defined (_TRUNCATE)
+#define _TRUNCATE ((size_t)-1)
+#endif  /* !defined (_TRUNCATE) */

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -170,6 +170,8 @@ CrstStatic g_SuspendEELock;
 #endif // _MSC_VER
 EEType g_FreeObjectEEType;
 
+extern "C" bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleManager** gcHandleManager, GcDacVars* gcDacVars);
+
 // static 
 bool RedhawkGCInterface::InitializeSubsystems(GCType gcType)
 {

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -1071,6 +1071,11 @@ void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
 #endif
 }
 
+bool GCToEEInterface::TrapReturningThreads()
+{
+    return !!g_TrapReturningThreads;
+}
+
 #ifndef DACCESS_COMPILE
 
 // Context passed to the above.

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -207,7 +207,6 @@ bool RedhawkGCInterface::InitializeSubsystems(GCType gcType)
 
     // Set the GC heap type.
     bool fUseServerGC = (gcType == GCType_Server);
-    InitializeHeapType(fUseServerGC);
     g_heap_type = fUseServerGC ? GC_HEAP_SVR : GC_HEAP_WKS;
 
     // Create the GC heap itself.
@@ -1491,6 +1490,105 @@ MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
 {
     assert(g_pFreeObjectMethodTable != nullptr);
     return g_pFreeObjectMethodTable;
+}
+
+bool GCToEEInterface::GetBooleanConfigValue(const char* key, bool* value)
+{
+    // these configuration values are given to us via startup flags.
+    if (strcmp(key, "gcServer") == 0)
+    {
+        *value = g_heap_type == GC_HEAP_SVR;
+        return true;
+    }
+
+    if (strcmp(key, "gcConcurrent") == 0)
+    {
+        *value = g_pConfig->GetGCconcurrent() != 0;
+        return true;
+    }
+
+    if (strcmp(key, "GCRetainVM") == 0)
+    {
+        *value = !!g_pConfig->GetGCRetainVM();
+        return true;
+    }
+
+    if (strcmp(key, "gcConservative") == 0)
+    {
+        *value = g_pConfig->GetGCConservative();
+        return true;
+    }
+
+    if (strcmp(key, "gcForceCompact") == 0)
+    {
+        *value = g_pConfig->GetGCForceCompact() != 0;
+        return true;
+    }
+
+    if (strcmp(key, "GCStressMix") == 0)
+    {
+        *value = g_pConfig->IsGCStressMix();
+        return true;
+    }
+
+    if (strcmp(key, "GCBreakOnOOM") == 0)
+    {
+        *value = g_pConfig->IsGCBreakOnOOMEnabled();
+        return true;
+    }
+
+    if (strcmp(key, "GCNoAffinitize") == 0)
+    {
+        *value = g_pConfig->GetGCNoAffinitize();
+        return true;
+    }
+
+    return false;
+}
+
+bool GCToEEInterface::GetIntConfigValue(const char* key, int64_t* value)
+{
+    if (strcmp(key, "HeapVerify") == 0)
+    {
+        *value = g_pConfig->GetHeapVerifyLevel();
+        return true;
+    }
+
+    if (strcmp(key, "GCLOHCompact") == 0)
+    {
+        *value = g_pConfig->GetGCLOHCompactionMode();
+        return true;
+    }
+
+    if (strcmp(key, "GCHeapCount") == 0)
+    {
+        *value = g_pConfig->GetGCHeapCount();
+        return true;
+    }
+
+    if (strcmp(key, "GCgen0size") == 0)
+    {
+        *value = g_pConfig->GetGCgen0size();
+        return true;
+    }
+
+    if (strcmp(key, "GCLatencyMode") == 0)
+    {
+        *value = g_pConfig->GetGCLatencyMode();
+        return true;
+    }
+
+    return false;
+}
+
+bool GCToEEInterface::GetStringConfigValue(const char* key, const char** value)
+{
+    return false;
+}
+
+void GCToEEInterface::FreeStringConfigValue(const char* value)
+{
+    delete[] value;
 }
 
 #endif // !DACCESS_COMPILE

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -1071,6 +1071,11 @@ void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
 #endif
 }
 
+Thread* GCToEEInterface::GetThread()
+{
+    return ::GetThread();
+}
+
 bool GCToEEInterface::TrapReturningThreads()
 {
     return !!g_TrapReturningThreads;

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -1855,6 +1855,11 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
     return (st == 0);
 }
 
+uint32_t GCToOSInterface::GetTotalProcessorCount()
+{
+    return g_SystemInfo.dwNumberOfProcessors;
+}
+
 // Initialize the critical section
 void CLRCriticalSection::Initialize()
 {

--- a/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/Native/Runtime/windows/PalRedhawkMinWin.cpp
@@ -1851,6 +1851,11 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
     return true;
 }
 
+uint32_t GCToOSInterface::GetTotalProcessorCount()
+{
+    return g_SystemInfo.dwNumberOfProcessors;
+}
+
 // Initialize the critical section
 void CLRCriticalSection::Initialize()
 {

--- a/src/Native/gc/env/gcenv.base.h
+++ b/src/Native/gc/env/gcenv.base.h
@@ -100,6 +100,8 @@ inline HRESULT HRESULT_FROM_WIN32(unsigned long x)
 #define _vsnprintf_s(string, sizeInBytes, count, format, args) vsnprintf(string, sizeInBytes, format, args)
 #define sprintf_s snprintf
 #define swprintf_s swprintf
+#define _snprintf_s(string, sizeInBytes, count, format, ...) \
+  snprintf(string, sizeInBytes, format, ## __VA_ARGS__)
 #endif
 
 #ifdef UNICODE

--- a/src/Native/gc/env/gcenv.ee.h
+++ b/src/Native/gc/env/gcenv.ee.h
@@ -74,6 +74,10 @@ public:
     static bool ForceFullGCToBeBlocking();
     static bool EagerFinalized(Object* obj);
     static MethodTable* GetFreeObjectMethodTable();
+    static bool GetBooleanConfigValue(const char* key, bool* value);
+    static bool GetIntConfigValue(const char* key, int64_t* value);
+    static bool GetStringConfigValue(const char* key, const char** value);
+    static void FreeStringConfigValue(const char* key);
 };
 
 #endif // __GCENV_EE_H__

--- a/src/Native/gc/env/gcenv.ee.h
+++ b/src/Native/gc/env/gcenv.ee.h
@@ -50,6 +50,7 @@ public:
     static void EnablePreemptiveGC(Thread * pThread);
     static void DisablePreemptiveGC(Thread * pThread);
     static bool TrapReturningThreads();
+    static Thread* GetThread();
 
     static gc_alloc_context * GetAllocContext(Thread * pThread);
     static bool CatchAtSafePoint(Thread * pThread);

--- a/src/Native/gc/env/gcenv.ee.h
+++ b/src/Native/gc/env/gcenv.ee.h
@@ -49,6 +49,7 @@ public:
     static bool IsPreemptiveGCDisabled(Thread * pThread);
     static void EnablePreemptiveGC(Thread * pThread);
     static void DisablePreemptiveGC(Thread * pThread);
+    static bool TrapReturningThreads();
 
     static gc_alloc_context * GetAllocContext(Thread * pThread);
     static bool CatchAtSafePoint(Thread * pThread);

--- a/src/Native/gc/env/gcenv.os.h
+++ b/src/Native/gc/env/gcenv.os.h
@@ -158,6 +158,15 @@ public:
     //  flags     - flags to control special settings like write watching
     // Return:
     //  Starting virtual address of the reserved range
+    // Notes:
+    //  Previous uses of this API aligned the `size` parameter to the platform
+    //  allocation granularity. This is not required by POSIX or Windows. Windows will
+    //  round the size up to the nearest page boundary. POSIX does not specify what is done,
+    //  but Linux probably also rounds up. If an implementation of GCToOSInterface needs to
+    //  align to the allocation granularity, it will do so in its implementation.
+    //
+    //  Windows guarantees that the returned mapping will be aligned to the allocation
+    //  granularity.
     static void* VirtualReserve(size_t size, size_t alignment, uint32_t flags);
 
     // Release virtual memory range previously reserved using VirtualReserve
@@ -357,6 +366,12 @@ public:
     // Return:
     //  Time stamp in milliseconds
     static uint32_t GetLowPrecisionTimeStamp();
+
+    // Gets the total number of processors on the machine, not taking
+    // into account current process affinity.
+    // Return:
+    //  Number of processors on the machine
+    static uint32_t GetTotalProcessorCount();
 };
 
 #endif // __GCENV_OS_H__

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -1499,7 +1499,7 @@ void WaitLongerNoInstru (int i)
     }
 
     // if we're waiting for gc to finish, we should block immediately
-    if (!g_TrapReturningThreads)
+    if (!GCToEEInterface::TrapReturningThreads())
     {
         if  (g_num_processors > 1)
         {
@@ -1519,7 +1519,7 @@ void WaitLongerNoInstru (int i)
     // is in a tight loop.  If the thread has high priority, the perf is going to be very BAD.
     if (pCurThread)
     {
-        if (bToggleGC || g_TrapReturningThreads)
+        if (bToggleGC || GCToEEInterface::TrapReturningThreads())
         {
 #ifdef _DEBUG
             // In debug builds, all enter_spin_lock operations go through this code.  If a GC has
@@ -1540,7 +1540,7 @@ void WaitLongerNoInstru (int i)
             }
         }
     }
-    else if (g_TrapReturningThreads)
+    else if (GCToEEInterface::TrapReturningThreads())
     {
         g_theGCHeap->WaitUntilGCComplete();
     }

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -4381,12 +4381,12 @@ static size_t get_valid_segment_size (BOOL large_seg=FALSE)
     if (!large_seg)
     {
         initial_seg_size = INITIAL_ALLOC;
-        seg_size = GCConfig::GetSegmentSize();
+        seg_size = static_cast<size_t>(GCConfig::GetSegmentSize());
     }
     else
     {
         initial_seg_size = LHEAP_ALLOC;
-        seg_size = GCConfig::GetSegmentSize() / 2;
+        seg_size = static_cast<size_t>(GCConfig::GetSegmentSize()) / 2;
     }
 
 #ifdef MULTIPLE_HEAPS
@@ -9824,7 +9824,7 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
             return E_FAIL;
 
         // GCLogFileSize in MBs.
-        gc_log_file_size = GCConfig::GetLogFileSize();
+        gc_log_file_size = static_cast<size_t>(GCConfig::GetLogFileSize());
 
         if (gc_log_file_size <= 0 || gc_log_file_size > 500)
         {
@@ -35482,7 +35482,7 @@ size_t GCHeap::GetValidSegmentSize(bool large_seg)
 // Get the max gen0 heap size, making sure it conforms.
 size_t GCHeap::GetValidGen0MaxSize(size_t seg_size)
 {
-    size_t gen0size = GCConfig::GetGen0Size();
+    size_t gen0size = static_cast<size_t>(GCConfig::GetGen0Size());
 
     if ((gen0size == 0) || !g_theGCHeap->IsValidGen0MaxSize(gen0size))
     {

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -2670,6 +2670,9 @@ size_t gc_heap::eph_gen_starts_size = 0;
 heap_segment* gc_heap::segment_standby_list;
 size_t        gc_heap::last_gc_index = 0;
 size_t        gc_heap::min_segment_size = 0;
+size_t        gc_heap::soh_segment_size = 0;
+size_t        gc_heap::min_loh_segment_size = 0;
+size_t        gc_heap::segment_info_size = 0;
 
 #ifdef GC_CONFIG_DRIVEN
 size_t gc_heap::time_init = 0;
@@ -2966,8 +2969,12 @@ gc_heap::dt_low_ephemeral_space_p (gc_tuning_point tp)
             
             dprintf (GTC_LOG, ("h%d: plan eph size is %Id, new gen0 is %Id", 
                 heap_number, plan_ephemeral_size, new_gen0size));
-            ret = ((size_t)(heap_segment_reserved (ephemeral_heap_segment) - (heap_segment_mem (ephemeral_heap_segment))) <
-                    (plan_ephemeral_size + new_gen0size));
+
+            // If we were in no_gc_region we could have allocated a larger than normal segment,
+            // and the next seg we allocate will be a normal sized seg so if we can't fit the new
+            // ephemeral generations there, do an ephemeral promotion.
+            ret = ((soh_segment_size - segment_info_size) < (plan_ephemeral_size + new_gen0size));
+
             break;
         }
         default:
@@ -4377,9 +4384,6 @@ void virtual_free (void* add, size_t size)
                  size, (size_t)add, (size_t)((uint8_t*)add+size)));
 }
 
-// We have a few places that call this but the seg size doesn't change so call it
-// once and save the result.
-// TODO: move back after we do this.
 static size_t get_valid_segment_size (BOOL large_seg=FALSE)
 {
     size_t seg_size, initial_seg_size;
@@ -4468,7 +4472,7 @@ gc_heap::compute_new_ephemeral_size()
 heap_segment*
 gc_heap::soh_get_segment_to_expand()
 {
-    size_t size = get_valid_segment_size();
+    size_t size = soh_segment_size;
 
     ordered_plug_indices_init = FALSE;
     use_bestfit = FALSE;
@@ -9174,16 +9178,7 @@ heap_segment* gc_heap::make_heap_segment (uint8_t* new_pages, size_t size, int h
     //overlay the heap_segment
     heap_segment* new_segment = (heap_segment*)new_pages;
 
-    uint8_t* start = 0;
-#ifdef BACKGROUND_GC
-    //leave the first page to contain only segment info
-    //because otherwise we could need to revisit the first page frequently in 
-    // background GC.
-    start = new_pages + OS_PAGE_SIZE;
-#else
-    start = new_pages +
-        Align (sizeof (heap_segment), get_alignment_constant (FALSE));
-#endif //BACKGROUND_GC
+    uint8_t* start = new_pages + segment_info_size;
     heap_segment_mem (new_segment) = start;
     heap_segment_used (new_segment) = start;
     heap_segment_reserved (new_segment) = new_pages + size;
@@ -9942,6 +9937,15 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
 #endif //BACKGROUND_GC
 #endif //WRITE_WATCH
 
+#ifdef BACKGROUND_GC
+    // leave the first page to contain only segment info
+    // because otherwise we could need to revisit the first page frequently in 
+    // background GC.
+    segment_info_size = OS_PAGE_SIZE;
+#else
+    segment_info_size = Align (sizeof (heap_segment), get_alignment_constant (FALSE));
+#endif //BACKGROUND_GC
+
     reserved_memory = 0;
     unsigned block_count;
 #ifdef MULTIPLE_HEAPS
@@ -10044,12 +10048,8 @@ gc_heap::init_semi_shared()
     eph_gen_starts_size = (Align (min_obj_size)) * max_generation;
 
 #ifdef MARK_LIST
-    size_t gen0size = GCHeap::GetValidGen0MaxSize(get_valid_segment_size());
-    MAYBE_UNUSED_VAR(gen0size);
-
 #ifdef MULTIPLE_HEAPS
-
-    mark_list_size = min (150*1024, max (8192, get_valid_segment_size()/(2*10*32)));
+    mark_list_size = min (150*1024, max (8192, soh_segment_size/(2*10*32)));
     g_mark_list = make_mark_list (mark_list_size*n_heaps);
 
     min_balance_threshold = alloc_quantum_balance_units * CLR_SIZE * 2;
@@ -10063,13 +10063,12 @@ gc_heap::init_semi_shared()
 
 #else //MULTIPLE_HEAPS
 
-    mark_list_size = max (8192, get_valid_segment_size()/(64*32));
+    mark_list_size = max (8192, soh_segment_size/(64*32));
     g_mark_list = make_mark_list (mark_list_size);
 
 #endif //MULTIPLE_HEAPS
 
-    dprintf (3, ("gen0 size: %d, mark_list_size: %d",
-                 gen0size, mark_list_size));
+    dprintf (3, ("mark_list_size: %d", mark_list_size));
 
     if (!g_mark_list)
     {
@@ -10442,7 +10441,7 @@ gc_heap::init_gc_heap (int  h_number)
     }
 #endif //!SEG_MAPPING_TABLE
 
-    heap_segment* seg = get_initial_segment (get_valid_segment_size(), h_number);
+    heap_segment* seg = get_initial_segment (soh_segment_size, h_number);
     if (!seg)
         return 0;
 
@@ -10507,7 +10506,7 @@ gc_heap::init_gc_heap (int  h_number)
     }
 #endif //!SEG_MAPPING_TABLE
     //Create the large segment generation
-    heap_segment* lseg = get_initial_segment(get_valid_segment_size(TRUE), h_number);
+    heap_segment* lseg = get_initial_segment(min_loh_segment_size, h_number);
     if (!lseg)
         return 0;
     lseg->flags |= heap_segment_flags_loh;
@@ -12621,7 +12620,7 @@ BOOL gc_heap::bgc_loh_should_allocate()
 
 size_t gc_heap::get_large_seg_size (size_t size)
 {
-    size_t default_seg_size = get_valid_segment_size(TRUE);
+    size_t default_seg_size = min_loh_segment_size;
 #ifdef SEG_MAPPING_TABLE
     size_t align_size =  default_seg_size;
 #else //SEG_MAPPING_TABLE
@@ -15895,9 +15894,8 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
         allocation_no_gc_loh = total_size;
     }
 
-    size_t soh_segment_size = get_valid_segment_size();
     int soh_align_const = get_alignment_constant (TRUE);
-    size_t max_soh_allocated = soh_segment_size - OS_PAGE_SIZE - eph_gen_starts_size;
+    size_t max_soh_allocated = (soh_segment_size - segment_info_size - eph_gen_starts_size);
     size_t size_per_heap = 0;
     const double scale_factor = 1.05;
 
@@ -16259,7 +16257,7 @@ done:
         return TRUE;
     else
     {
-        // We are done with starting the no gc region.
+        // We are done with starting the no_gc_region.
         current_no_gc_region_info.started = TRUE;
         return FALSE;
     }
@@ -29511,7 +29509,7 @@ bool gc_heap::init_dynamic_data()
 #endif //GC_CONFIG_DRIVEN
 
     // get the registry setting for generation 0 size
-    size_t gen0size = GCHeap::GetValidGen0MaxSize(get_valid_segment_size());
+    size_t gen0size = GCHeap::GetValidGen0MaxSize(soh_segment_size);
 
     dprintf (2, ("gen 0 size: %Id", gen0size));
 
@@ -29540,11 +29538,11 @@ bool gc_heap::init_dynamic_data()
 #endif // BACKGROUND_GC
 
 #ifdef MULTIPLE_HEAPS
-    dd->max_size = max (6*1024*1024, min ( Align(get_valid_segment_size()/2), 200*1024*1024));
+    dd->max_size = max (6*1024*1024, min ( Align(soh_segment_size/2), 200*1024*1024));
 #else //MULTIPLE_HEAPS
     dd->max_size = (can_use_concurrent ?
                     6*1024*1024 :
-                    max (6*1024*1024,  min ( Align(get_valid_segment_size()/2), 200*1024*1024)));
+                    max (6*1024*1024,  min ( Align(soh_segment_size/2), 200*1024*1024)));
 #endif //MULTIPLE_HEAPS
     dd->new_allocation = dd->min_gc_size;
     dd->gc_new_allocation = dd->new_allocation;
@@ -29565,11 +29563,11 @@ bool gc_heap::init_dynamic_data()
     dd->min_size = dd->min_gc_size;
 //  dd->max_size = 2397152;
 #ifdef MULTIPLE_HEAPS
-    dd->max_size = max (6*1024*1024, Align(get_valid_segment_size()/2));
+    dd->max_size = max (6*1024*1024, Align(soh_segment_size/2));
 #else //MULTIPLE_HEAPS
     dd->max_size = (can_use_concurrent ?
                     6*1024*1024 :
-                    max (6*1024*1024, Align(get_valid_segment_size()/2)));
+                    max (6*1024*1024, Align(soh_segment_size/2)));
 #endif //MULTIPLE_HEAPS
     dd->new_allocation = dd->min_gc_size;
     dd->gc_new_allocation = dd->new_allocation;
@@ -30156,7 +30154,7 @@ void gc_heap::decommit_ephemeral_segment_pages()
     {
         size_t new_slack_space = 
 #ifdef BIT64
-                    max(min(min(get_valid_segment_size()/32, dd_max_size(dd)), (generation_size (max_generation) / 10)), dd_desired_allocation(dd));
+                    max(min(min(soh_segment_size/32, dd_max_size(dd)), (generation_size (max_generation) / 10)), dd_desired_allocation(dd));
 #else
 #ifdef FEATURE_CORECLR
                     dd_desired_allocation (dd);
@@ -33523,7 +33521,6 @@ HRESULT GCHeap::Init(size_t hn)
 //System wide initialization
 HRESULT GCHeap::Initialize ()
 {
-
     HRESULT hr = S_OK;
 
     if (!GCToOSInterface::Initialize())
@@ -33540,7 +33537,9 @@ HRESULT GCHeap::Initialize ()
 #endif //TRACE_GC
 
     size_t seg_size = get_valid_segment_size();
+    gc_heap::soh_segment_size = seg_size;
     size_t large_seg_size = get_valid_segment_size(TRUE);
+    gc_heap::min_loh_segment_size = large_seg_size;
     gc_heap::min_segment_size = min (seg_size, large_seg_size);
 
 #ifdef MULTIPLE_HEAPS

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -18,6 +18,7 @@
 //
 
 #include "gcpriv.h"
+#include "softwarewritewatch.h"
 
 #define USE_INTROSORT
 
@@ -2152,6 +2153,19 @@ uint8_t* align_lower_page (uint8_t* add)
 {
     return (uint8_t*)align_lower_page ((size_t)add);
 }
+
+inline
+size_t align_write_watch_lower_page (size_t add)
+{
+    return (add & ~(WRITE_WATCH_UNIT_SIZE - 1));
+}
+
+inline
+uint8_t* align_write_watch_lower_page (uint8_t* add)
+{
+    return (uint8_t*)align_lower_page ((size_t)add);
+}
+
 
 inline
 BOOL power_of_two_p (size_t integer)
@@ -26191,7 +26205,7 @@ void gc_heap::revisit_written_page (uint8_t* page,
     }
     else
     {
-        if (((last_page + OS_PAGE_SIZE) == page)
+        if (((last_page + WRITE_WATCH_UNIT_SIZE) == page)
             || (start_address <= last_object))
         {
             o = last_object;
@@ -26206,9 +26220,9 @@ void gc_heap::revisit_written_page (uint8_t* page,
 
     dprintf (3,("page %Ix start: %Ix, %Ix[ ",
                (size_t)page, (size_t)o,
-               (size_t)(min (high_address, page + OS_PAGE_SIZE))));
+               (size_t)(min (high_address, page + WRITE_WATCH_UNIT_SIZE))));
 
-    while (o < (min (high_address, page + OS_PAGE_SIZE)))
+    while (o < (min (high_address, page + WRITE_WATCH_UNIT_SIZE)))
     {
         size_t s;
 
@@ -26263,7 +26277,7 @@ void gc_heap::revisit_written_page (uint8_t* page,
             {
                 dprintf (3, ("going through %Ix", (size_t)o));
                 go_through_object (method_table(o), o, s, poo, start_address, use_start, (o + s),
-                                    if ((uint8_t*)poo >= min (high_address, page + OS_PAGE_SIZE))
+                                    if ((uint8_t*)poo >= min (high_address, page + WRITE_WATCH_UNIT_SIZE))
                                     {
                                         no_more_loop_p = TRUE;
                                         goto end_limit;
@@ -26280,7 +26294,7 @@ void gc_heap::revisit_written_page (uint8_t* page,
                 large_objects_p &&
 #endif // !FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
                 ((CObjectHeader*)o)->IsFree() &&
-                (next_o > min (high_address, page + OS_PAGE_SIZE)))
+                (next_o > min (high_address, page + WRITE_WATCH_UNIT_SIZE)))
             {
                 // We need to not skip the object here because of this corner scenario:
                 // A large object was being allocated during BGC mark so we first made it 
@@ -26317,7 +26331,7 @@ end_limit:
 #ifdef MULTIPLE_HEAPS
     if (concurrent_p)
     {
-        assert (last_object < (min (high_address, page + OS_PAGE_SIZE)));
+        assert (last_object < (min (high_address, page + WRITE_WATCH_UNIT_SIZE)));
     }
     else
 #endif //MULTIPLE_HEAPS
@@ -26326,7 +26340,7 @@ end_limit:
     }
 
     dprintf (3,("Last object: %Ix", (size_t)last_object));
-    last_page = align_lower_page (o);
+    last_page = align_write_watch_lower_page (o);
 }
 
 // When reset_only_p is TRUE, we should only reset pages that are in range
@@ -26507,7 +26521,7 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
                     }
 
                     if (bcount >= array_size){
-                        base_address = background_written_addresses [array_size-1] + OS_PAGE_SIZE;
+                        base_address = background_written_addresses [array_size-1] + WRITE_WATCH_UNIT_SIZE;
                         bcount = array_size;
                     }
                 }

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -749,7 +749,7 @@ public:
             if (color == join_struct.lock_color)
             {
 respin:
-                int spin_count = 4096 * g_SystemInfo.dwNumberOfProcessors;
+                int spin_count = 4096 * g_num_processors;
                 for (int j = 0; j < spin_count; j++)
                 {
                     if (color != join_struct.lock_color)
@@ -850,7 +850,7 @@ respin:
                 if (!join_struct.wait_done)
                 {
         respin:
-                    int spin_count = 2 * 4096 * g_SystemInfo.dwNumberOfProcessors;
+                    int spin_count = 2 * 4096 * g_num_processors;
                     for (int j = 0; j < spin_count; j++)
                     {
                         if (join_struct.wait_done)
@@ -1045,7 +1045,7 @@ class exclusive_sync
 public:
     void init()
     {
-        spin_count = 32 * (g_SystemInfo.dwNumberOfProcessors - 1);
+        spin_count = 32 * (g_num_processors - 1);
         rwp_object = 0;
         needs_checking = 0;
         for (int i = 0; i < max_pending_allocs; i++)
@@ -1501,7 +1501,7 @@ void WaitLongerNoInstru (int i)
     // if we're waiting for gc to finish, we should block immediately
     if (!g_TrapReturningThreads)
     {
-        if  (g_SystemInfo.dwNumberOfProcessors > 1)
+        if  (g_num_processors > 1)
         {
             YieldProcessor();           // indicate to the processor that we are spining
             if  (i & 0x01f)
@@ -1573,12 +1573,12 @@ retry:
         {
             if ((++i & 7) && !IsGCInProgress())
             {
-                if  (g_SystemInfo.dwNumberOfProcessors > 1)
+                if  (g_num_processors > 1)
                 {
 #ifndef MULTIPLE_HEAPS
-                    int spin_count = 1024 * g_SystemInfo.dwNumberOfProcessors;
+                    int spin_count = 1024 * g_num_processors;
 #else //!MULTIPLE_HEAPS
-                    int spin_count = 32 * g_SystemInfo.dwNumberOfProcessors;
+                    int spin_count = 32 * g_num_processors;
 #endif //!MULTIPLE_HEAPS
                     for (int j = 0; j < spin_count; j++)
                     {
@@ -1689,7 +1689,7 @@ void WaitLonger (int i
 #ifdef SYNCHRONIZATION_STATS
         (spin_lock->num_switch_thread_w)++;
 #endif //SYNCHRONIZATION_STATS
-        if  (g_SystemInfo.dwNumberOfProcessors > 1)
+        if  (g_num_processors > 1)
         {
             YieldProcessor();           // indicate to the processor that we are spining
             if  (i & 0x01f)
@@ -1734,12 +1734,12 @@ retry:
         {
             if ((++i & 7) && !gc_heap::gc_started)
             {
-                if  (g_SystemInfo.dwNumberOfProcessors > 1)
+                if  (g_num_processors > 1)
                 {
 #ifndef MULTIPLE_HEAPS
-                    int spin_count = 1024 * g_SystemInfo.dwNumberOfProcessors;
+                    int spin_count = 1024 * g_num_processors;
 #else //!MULTIPLE_HEAPS
-                    int spin_count = 32 * g_SystemInfo.dwNumberOfProcessors;
+                    int spin_count = 32 * g_num_processors;
 #endif //!MULTIPLE_HEAPS
                     for (int j = 0; j < spin_count; j++)
                     {
@@ -4394,9 +4394,9 @@ static size_t get_valid_segment_size (BOOL large_seg=FALSE)
     if (!large_seg)
 #endif // BIT64
     {
-        if (g_SystemInfo.dwNumberOfProcessors > 4)
+        if (g_num_processors > 4)
             initial_seg_size /= 2;
-        if (g_SystemInfo.dwNumberOfProcessors > 8)
+        if (g_num_processors > 8)
             initial_seg_size /= 2;
     }
 #endif //MULTIPLE_HEAPS
@@ -5335,7 +5335,7 @@ void gc_heap::gc_thread_function ()
         }
         else
         {
-            int spin_count = 32 * (g_SystemInfo.dwNumberOfProcessors - 1);
+            int spin_count = 32 * (g_num_processors - 1);
 
             // wait until RestartEE has progressed to a stage where we can restart user threads
             while (!gc_heap::internal_gc_done && !GCHeap::SafeToRestartManagedThreads())
@@ -7010,9 +7010,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
     // it is impossible for alloc_size to overflow due bounds on each of 
     // its components.
     size_t alloc_size = sizeof (uint8_t)*(sizeof(card_table_info) + cs + bs + cb + wws + st + ms);
-    size_t alloc_size_aligned = Align (alloc_size, g_SystemInfo.dwAllocationGranularity-1);
-
-    uint8_t* mem = (uint8_t*)GCToOSInterface::VirtualReserve (alloc_size_aligned, 0, virtual_reserve_flags);
+    uint8_t* mem = (uint8_t*)GCToOSInterface::VirtualReserve (alloc_size, 0, virtual_reserve_flags);
 
     if (!mem)
         return 0;
@@ -7026,7 +7024,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
     if (!GCToOSInterface::VirtualCommit (mem, commit_size))
     {
         dprintf (2, ("Card table commit failed"));
-        GCToOSInterface::VirtualRelease (mem, alloc_size_aligned);
+        GCToOSInterface::VirtualRelease (mem, alloc_size);
         return 0;
     }
 
@@ -7036,7 +7034,7 @@ uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
     card_table_lowest_address (ct) = start;
     card_table_highest_address (ct) = end;
     card_table_brick_table (ct) = (short*)((uint8_t*)ct + cs);
-    card_table_size (ct) = alloc_size_aligned;
+    card_table_size (ct) = alloc_size;
     card_table_next (ct) = 0;
 
 #ifdef CARD_BUNDLE
@@ -7217,11 +7215,10 @@ int gc_heap::grow_brick_card_tables (uint8_t* start,
         // it is impossible for alloc_size to overflow due bounds on each of 
         // its components.
         size_t alloc_size = sizeof (uint8_t)*(sizeof(card_table_info) + cs + bs + cb + wws + st + ms);
-        size_t alloc_size_aligned = Align (alloc_size, g_SystemInfo.dwAllocationGranularity-1);
         dprintf (GC_TABLE_LOG, ("card table: %Id; brick table: %Id; card bundle: %Id; sw ww table: %Id; seg table: %Id; mark array: %Id",
                                   cs, bs, cb, wws, st, ms));
 
-        uint8_t* mem = (uint8_t*)GCToOSInterface::VirtualReserve (alloc_size_aligned, 0, virtual_reserve_flags);
+        uint8_t* mem = (uint8_t*)GCToOSInterface::VirtualReserve (alloc_size, 0, virtual_reserve_flags);
 
         if (!mem)
         {
@@ -7418,7 +7415,7 @@ fail:
 #endif
 
             //delete (uint32_t*)((uint8_t*)ct - sizeof(card_table_info));
-            if (!GCToOSInterface::VirtualRelease (mem, alloc_size_aligned))
+            if (!GCToOSInterface::VirtualRelease (mem, alloc_size))
             {
                 dprintf (GC_TABLE_LOG, ("GCToOSInterface::VirtualRelease failed"));
                 assert (!"release failed");
@@ -10261,9 +10258,9 @@ retry:
     {
         while (gc_done_event_lock >= 0)
         {
-            if  (g_SystemInfo.dwNumberOfProcessors > 1)
+            if  (g_num_processors > 1)
             {
-                int spin_count = 32 * g_SystemInfo.dwNumberOfProcessors;
+                int spin_count = 32 * g_num_processors;
                 for (int j = 0; j < spin_count; j++)
                 {
                     if  (gc_done_event_lock < 0)
@@ -33473,6 +33470,8 @@ HRESULT GCHeap::Initialize ()
 
 
     g_gc_pFreeObjectMethodTable = GCToEEInterface::GetFreeObjectMethodTable();
+    g_num_processors = GCToOSInterface::GetTotalProcessorCount();
+    assert(g_num_processors != 0);
 
 //Initialize the static members.
 #ifdef TRACE_GC
@@ -33513,7 +33512,7 @@ HRESULT GCHeap::Initialize ()
 
     gc_heap::mem_one_percent = gc_heap::total_physical_mem / 100;
 #ifndef MULTIPLE_HEAPS
-    gc_heap::mem_one_percent /= g_SystemInfo.dwNumberOfProcessors;
+    gc_heap::mem_one_percent /= g_num_processors;
 #endif //!MULTIPLE_HEAPS
 
     // We should only use this if we are in the "many process" mode which really is only applicable
@@ -33525,7 +33524,7 @@ HRESULT GCHeap::Initialize ()
     int available_mem_th = 10;
     if (gc_heap::total_physical_mem >= ((uint64_t)80 * 1024 * 1024 * 1024))
     {
-        int adjusted_available_mem_th = 3 + (int)((float)47 / (float)(g_SystemInfo.dwNumberOfProcessors));
+        int adjusted_available_mem_th = 3 + (int)((float)47 / (float)(g_num_processors));
         available_mem_th = min (available_mem_th, adjusted_available_mem_th);
     }
 

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -21,7 +21,6 @@
 
 #define USE_INTROSORT
 
-
 #if defined(BACKGROUND_GC) && defined(FEATURE_EVENT_TRACE)
 BOOL bgc_heap_walk_for_etw_p = FALSE;
 #endif //BACKGROUND_GC && FEATURE_EVENT_TRACE
@@ -176,7 +175,7 @@ size_t GetHighPrecisionTimeStamp()
 GCStatistics g_GCStatistics;
 GCStatistics g_LastGCStatistics;
 
-TCHAR* GCStatistics::logFileName = NULL;
+char* GCStatistics::logFileName = NULL;
 FILE*  GCStatistics::logFile = NULL;
 
 void GCStatistics::AddGCStats(const gc_mechanisms& settings, size_t timeInMSec)
@@ -1426,15 +1425,6 @@ int mark_time, plan_time, sweep_time, reloc_time, compact_time;
 #ifndef MULTIPLE_HEAPS
 
 #endif // MULTIPLE_HEAPS
-
-#ifdef TRACE_GC
-
-int     print_level     = DEFAULT_GC_PRN_LVL;  //level of detail of the debug trace
-BOOL    trace_gc        = FALSE;
-int       gc_trace_fac = 0;
-hlet* hlet::bindings = 0;
-
-#endif //TRACE_GC
 
 void reset_memory (uint8_t* o, size_t sizeo);
 
@@ -3793,7 +3783,7 @@ public:
         _ASSERTE(pMT->SanityCheck());
 
         bool noRangeChecks =
-            (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_NO_RANGE_CHECKS) == EEConfig::HEAPVERIFY_NO_RANGE_CHECKS;
+            (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_NO_RANGE_CHECKS) == GCConfig::HEAPVERIFY_NO_RANGE_CHECKS;
 
         BOOL fSmallObjectHeapPtr = FALSE, fLargeObjectHeapPtr = FALSE;
         if (!noRangeChecks)
@@ -3817,7 +3807,7 @@ public:
 #endif // FEATURE_64BIT_ALIGNMENT
 
 #ifdef VERIFY_HEAP
-        if (bDeep && (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC))
+        if (bDeep && (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC))
             g_theGCHeap->ValidateObjectMember(this);
 #endif
         if (fSmallObjectHeapPtr)
@@ -3908,7 +3898,7 @@ public:
         //This introduces a bug in the free list management. 
         //((void**) this)[-1] = 0;    // clear the sync block,
         assert (*numComponentsPtr >= 0);
-        if (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
+        if (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
             memset (((uint8_t*)this)+sizeof(ArrayBase), 0xcc, *numComponentsPtr);
 #endif //VERIFY_HEAP
     }
@@ -4391,12 +4381,12 @@ static size_t get_valid_segment_size (BOOL large_seg=FALSE)
     if (!large_seg)
     {
         initial_seg_size = INITIAL_ALLOC;
-        seg_size = g_pConfig->GetSegmentSize();
+        seg_size = GCConfig::GetSegmentSize();
     }
     else
     {
         initial_seg_size = LHEAP_ALLOC;
-        seg_size = g_pConfig->GetSegmentSize() / 2;
+        seg_size = GCConfig::GetSegmentSize() / 2;
     }
 
 #ifdef MULTIPLE_HEAPS
@@ -5681,7 +5671,7 @@ void gc_mechanisms::first_init()
 #ifdef BACKGROUND_GC
     pause_mode = gc_heap::gc_can_use_concurrent ? pause_interactive : pause_batch;
 #ifdef _DEBUG
-    int debug_pause_mode = g_pConfig->GetGCLatencyMode();
+    int debug_pause_mode = static_cast<int>(GCConfig::GetLatencyMode());
     if (debug_pause_mode >= 0)
     {
         assert (debug_pause_mode <= pause_sustained_low_latency);
@@ -9354,7 +9344,7 @@ void gc_heap::rearrange_large_heap_segments()
     while (seg)
     {
         heap_segment* next_seg = heap_segment_next (seg);
-        delete_heap_segment (seg, (g_pConfig->GetGCRetainVM() != 0));
+        delete_heap_segment (seg, GCConfig::GetRetainVM());
         seg = next_seg;
     }
     freeable_large_heap_segment = 0;
@@ -9397,7 +9387,7 @@ void gc_heap::rearrange_heap_segments(BOOL compacting)
                 assert (prev_seg);
                 assert (seg != ephemeral_heap_segment);
                 heap_segment_next (prev_seg) = next_seg;
-                delete_heap_segment (seg, (g_pConfig->GetGCRetainVM() != 0));
+                delete_heap_segment (seg, GCConfig::GetRetainVM());
 
                 dprintf (2, ("Deleting heap segment %Ix", (size_t)seg));
             }
@@ -9803,28 +9793,20 @@ void gc_heap::adjust_ephemeral_limits ()
 }
 
 #if defined(TRACE_GC) || defined(GC_CONFIG_DRIVEN)
-FILE* CreateLogFile(const CLRConfig::ConfigStringInfo & info, BOOL is_config)
+FILE* CreateLogFile(const GCConfigStringHolder& temp_logfile_name, bool is_config)
 {
     FILE* logFile;
-    TCHAR * temp_logfile_name = NULL;
-    CLRConfig::GetConfigValue(info, &temp_logfile_name);
 
-    TCHAR logfile_name[MAX_LONGPATH+1];
-    if (temp_logfile_name != 0)
+    if (!temp_logfile_name.Get())
     {
-        _tcscpy(logfile_name, temp_logfile_name);
+        return nullptr;
     }
 
-    size_t logfile_name_len = _tcslen(logfile_name);
-    TCHAR* szPid = logfile_name + logfile_name_len;
-    size_t remaining_space = MAX_LONGPATH + 1 - logfile_name_len;
-
-    _stprintf_s(szPid, remaining_space, _T(".%d%s"), GCToOSInterface::GetCurrentProcessId(), (is_config ? _T(".config.log") : _T(".log")));
-
-    logFile = _tfopen(logfile_name, _T("wb"));
-
-    delete temp_logfile_name;
-
+    char logfile_name[MAX_LONGPATH+1];
+    uint32_t pid = GCToOSInterface::GetCurrentProcessId();
+    const char* suffix = is_config ? ".config.log" : ".log";
+    _snprintf_s(logfile_name, MAX_LONGPATH+1, _TRUNCATE, "%s.%d%s", temp_logfile_name.Get(), pid, suffix);
+    logFile = fopen(logfile_name, "wb");
     return logFile;
 }
 #endif //TRACE_GC || GC_CONFIG_DRIVEN
@@ -9837,18 +9819,17 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
 )
 {
 #ifdef TRACE_GC
-    int log_last_gcs = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_GCLogEnabled);
-    if (log_last_gcs)
+    if (GCConfig::GetLogEnabled())
     {
-        gc_log = CreateLogFile(CLRConfig::UNSUPPORTED_GCLogFile, FALSE);
+        gc_log = CreateLogFile(GCConfig::GetLogFile(), false);
 
         if (gc_log == NULL)
             return E_FAIL;
 
         // GCLogFileSize in MBs.
-        gc_log_file_size = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_GCLogFileSize);
+        gc_log_file_size = GCConfig::GetLogFileSize();
 
-        if (gc_log_file_size > 500)
+        if (gc_log_file_size <= 0 || gc_log_file_size > 500)
         {
             fclose (gc_log);
             return E_FAIL;
@@ -9869,10 +9850,9 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
 #endif // TRACE_GC
 
 #ifdef GC_CONFIG_DRIVEN
-    gc_config_log_on = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_GCConfigLogEnabled);
-    if (gc_config_log_on)
+    if (GCConfig::GetConfigLogEnabled())
     {
-        gc_config_log = CreateLogFile(CLRConfig::UNSUPPORTED_GCConfigLogFile, TRUE);
+        gc_config_log = CreateLogFile(GCConfig::GetConfigLogFile(), true);
 
         if (gc_config_log == NULL)
             return E_FAIL;
@@ -9884,7 +9864,7 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
             return E_FAIL;
         }
 
-        compact_ratio = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_GCCompactRatio);
+        compact_ratio = static_cast<int>(GCConfig::GetCompactRatio());
 
         //         h#  | GC  | gen | C   | EX   | NF  | BF  | ML  | DM  || PreS | PostS | Merge | Conv | Pre | Post | PrPo | PreP | PostP | 
         cprintf (("%2s | %6s | %1s | %1s | %2s | %2s | %2s | %2s | %2s || %5s | %5s | %5s | %5s | %5s | %5s | %5s | %5s | %5s |",
@@ -9911,10 +9891,15 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
 #endif //GC_CONFIG_DRIVEN
 
 #ifdef GC_STATS
-    GCStatistics::logFileName = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_GCMixLog);
-    if (GCStatistics::logFileName != NULL)
+    GCConfigStringHolder logFileName = GCConfig::GetMixLogFile();
+    if (logFileName.Get() != nullptr)
     {
-        GCStatistics::logFile = _tfopen(GCStatistics::logFileName, _T("a"));
+        GCStatistics::logFileName = _strdup(logFileName.Get());
+        GCStatistics::logFile = fopen(GCStatistics::logFileName, "a");
+        if (!GCStatistics::logFile)
+        {
+            return E_FAIL;
+        }
     }
 #endif // GC_STATS
 
@@ -9923,7 +9908,7 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
 #ifdef WRITE_WATCH
     hardware_write_watch_api_supported();
 #ifdef BACKGROUND_GC
-    if (can_use_write_watch_for_gc_heap() && g_pConfig->GetGCconcurrent() != 0)
+    if (can_use_write_watch_for_gc_heap() && GCConfig::GetConcurrentGC())
     {
         gc_can_use_concurrent = true;
 #ifndef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
@@ -10023,11 +10008,6 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
 
 #endif //MULTIPLE_HEAPS
 
-#ifdef TRACE_GC
-    print_level = g_pConfig->GetGCprnLvl();
-    gc_trace_fac = g_pConfig->GetGCtraceFac();
-#endif //TRACE_GC
-
     if (!init_semi_shared())
     {
         hres = E_FAIL;
@@ -10109,14 +10089,14 @@ gc_heap::init_semi_shared()
     should_expand_in_full_gc = FALSE;
 
 #ifdef FEATURE_LOH_COMPACTION
-    loh_compaction_always_p = (g_pConfig->GetGCLOHCompactionMode() != 0);
+    loh_compaction_always_p = GCConfig::GetLOHCompactionMode() != 0;
     loh_compaction_mode = loh_compaction_default;
 #endif //FEATURE_LOH_COMPACTION
 
 #ifdef BACKGROUND_GC
     memset (ephemeral_fgc_counts, 0, sizeof (ephemeral_fgc_counts));
-    bgc_alloc_spin_count = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_BGCSpinCount);
-    bgc_alloc_spin = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_BGCSpin);
+    bgc_alloc_spin_count = static_cast<uint32_t>(GCConfig::GetBGCSpinCount());
+    bgc_alloc_spin = static_cast<uint32_t>(GCConfig::GetBGCSpin());
 
     {   
         int number_bgc_threads = 1;
@@ -11548,7 +11528,7 @@ void gc_heap::handle_oom (int heap_num, oom_reason reason, size_t alloc_size,
 
     // Break early - before the more_space_lock is release so no other threads
     // could have allocated on the same heap when OOM happened.
-    if (g_pConfig->IsGCBreakOnOOMEnabled())
+    if (GCConfig::GetBreakOnOOM())
     {
         GCToOSInterface::DebugBreak();
     }
@@ -11941,7 +11921,7 @@ void gc_heap::bgc_loh_alloc_clr (uint8_t* alloc_start,
 #ifdef VERIFY_HEAP
     // since we filled in 0xcc for free object when we verify heap,
     // we need to make sure we clear those bytes.
-    if (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
+    if (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
     {
         if (size_to_clear < saved_size_to_clear)
         {
@@ -13150,7 +13130,7 @@ int gc_heap::try_allocate_more_space (alloc_context* acontext, size_t size,
 #ifdef SYNCHRONIZATION_STATS
         good_suspension++;
 #endif //SYNCHRONIZATION_STATS
-        BOOL fStress = (g_pConfig->GetGCStressLevel() & EEConfig::GCSTRESS_TRANSITION) != 0;
+        BOOL fStress = (g_pConfig->GetGCStressLevel() & GCConfig::GCSTRESS_TRANSITION) != 0;
         if (!fStress)
         {
             //Rendez vous early (MP scaling issue)
@@ -14498,6 +14478,8 @@ int gc_heap::joined_generation_to_condemn (BOOL should_evaluate_elevation,
     // We can only do Concurrent GC Stress if the caller did not explicitly ask for all
     // generations to be collected,
 
+    // [LOCALGC TODO] STRESS_HEAP is not defined for a standalone GC so there are multiple
+    // things that need to be fixed in this code block.
     if (n_original != max_generation &&
         g_pConfig->GetGCStressLevel() && gc_can_use_concurrent)
     {
@@ -15557,7 +15539,6 @@ void gc_heap::gc1()
     }
 
     descr_generations (FALSE);
-    descr_card_table();
 
     verify_soh_segment_list();
 
@@ -15591,7 +15572,7 @@ void gc_heap::gc1()
         // value. If we ever allow randomly adjusting this as the process runs,
         // we cannot call it this way as joins need to match - we must have the same
         // value for all heaps like we do with bgc_heap_walk_for_etw_p.
-        || (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
+        || (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
 #endif
 #if defined(FEATURE_EVENT_TRACE) && defined(BACKGROUND_GC)
         || (bgc_heap_walk_for_etw_p && settings.concurrent)
@@ -15653,7 +15634,7 @@ void gc_heap::gc1()
 #endif //BACKGROUND_GC
 
 #ifdef VERIFY_HEAP
-        if (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
+        if (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
             verify_heap (FALSE);
 #endif // VERIFY_HEAP
 
@@ -16634,14 +16615,6 @@ int gc_heap::garbage_collect (int n)
     if (gc_t_join.joined())
 #endif //MULTIPLE_HEAPS
     {
-#ifdef TRACE_GC
-        int gc_count = (int)dd_collection_count (dynamic_data_of (0));
-        if (gc_count >= g_pConfig->GetGCtraceStart())
-            trace_gc = 1;
-        if (gc_count >=  g_pConfig->GetGCtraceEnd())
-            trace_gc = 0;
-#endif //TRACE_GC
-
 #ifdef MULTIPLE_HEAPS
 #if !defined(SEG_MAPPING_TABLE) && !defined(FEATURE_BASICFREEZE)
         //delete old slots from the segment table
@@ -16788,12 +16761,12 @@ int gc_heap::garbage_collect (int n)
 //    descr_card_table();
 
 #ifdef VERIFY_HEAP
-    if ((g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC) &&
-       !(g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_POST_GC_ONLY))
+    if ((GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC) &&
+       !(GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_POST_GC_ONLY))
     {
         verify_heap (TRUE);
     }
-    if (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_BARRIERCHECK)
+    if (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_BARRIERCHECK)
         checkGCWriteBarrier();
 
 #endif // VERIFY_HEAP
@@ -17165,7 +17138,7 @@ uint8_t* gc_heap::find_object (uint8_t* interior, uint8_t* low)
         heap_segment* seg = find_segment_per_heap (interior, FALSE);
         if (seg
 #ifdef FEATURE_CONSERVATIVE_GC
-            && (!g_pConfig->GetGCConservative() || interior <= heap_segment_allocated(seg))
+            && (GCConfig::GetConservativeGC() || interior <= heap_segment_allocated(seg))
 #endif
             )
         {
@@ -17173,7 +17146,7 @@ uint8_t* gc_heap::find_object (uint8_t* interior, uint8_t* low)
             // we don't have brick entry for it, and we may incorrectly treat it as on large object heap.
             int align_const = get_alignment_constant (heap_segment_read_only_p (seg)
 #ifdef FEATURE_CONSERVATIVE_GC
-                                                       || (g_pConfig->GetGCConservative() && !heap_segment_loh_p (seg))
+                                                       || (GCConfig::GetConservativeGC() && !heap_segment_loh_p (seg))
 #endif
                                                       );
             //int align_const = get_alignment_constant (heap_segment_read_only_p (seg));
@@ -18643,7 +18616,7 @@ void gc_heap::background_promote (Object** ppObject, ScanContext* sc, uint32_t f
 #ifdef FEATURE_CONSERVATIVE_GC
     // For conservative GC, a value on stack may point to middle of a free object.
     // In this case, we don't need to promote the pointer.
-    if (g_pConfig->GetGCConservative() && ((CObjectHeader*)o)->IsFree())
+    if (GCConfig::GetConservativeGC() && ((CObjectHeader*)o)->IsFree())
     {
         return;
     }
@@ -23754,7 +23727,7 @@ void gc_heap::relocate_survivor_helper (uint8_t* plug, uint8_t* plug_end)
 void gc_heap::verify_pins_with_post_plug_info (const char* msg)
 {
 #if defined  (_DEBUG) && defined (VERIFY_HEAP)
-    if (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
+    if (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
     {
         if (!verify_pinned_queue_p)
             return;
@@ -26636,7 +26609,7 @@ void gc_heap::background_promote_callback (Object** ppObject, ScanContext* sc,
 #ifdef FEATURE_CONSERVATIVE_GC
     // For conservative GC, a value on stack may point to middle of a free object.
     // In this case, we don't need to promote the pointer.
-    if (g_pConfig->GetGCConservative() && ((CObjectHeader*)o)->IsFree())
+    if (GCConfig::GetConservativeGC() && ((CObjectHeader*)o)->IsFree())
     {
         return;
     }
@@ -29232,7 +29205,7 @@ gc_heap::realloc_plugs (generation* consing_gen, heap_segment* seg,
 void gc_heap::verify_no_pins (uint8_t* start, uint8_t* end)
 {
 #ifdef VERIFY_HEAP
-    if (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
+    if (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
     {
         BOOL contains_pinned_plugs = FALSE;
         size_t mi = 0;
@@ -30299,7 +30272,7 @@ BOOL gc_heap::decide_on_compacting (int condemned_gen_number,
 #endif // GC_STATS
 #endif //STRESS_HEAP
 
-    if (g_pConfig->GetGCForceCompact())
+    if (GCConfig::GetForceCompact())
         should_compact = TRUE;
 
     if ((condemned_gen_number == max_generation) && last_gc_before_oom)
@@ -30636,7 +30609,7 @@ CObjectHeader* gc_heap::allocate_large_object (size_t jsize, int64_t& alloc_byte
 
     if (jsize >= maxObjectSize)
     {
-        if (g_pConfig->IsGCBreakOnOOMEnabled())
+        if (GCConfig::GetBreakOnOOM())
         {
             GCToOSInterface::DebugBreak();
         }
@@ -30862,8 +30835,8 @@ void gc_heap::set_mem_verify (uint8_t* start, uint8_t* end, uint8_t b)
 #ifdef VERIFY_HEAP
     if (end > start)
     {
-        if ((g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC) &&
-           !(g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_NO_MEM_FILL))
+        if ((GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC) &&
+           !(GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_NO_MEM_FILL))
         {
             dprintf (3, ("setting mem to %c [%Ix, [%Ix", b, start, end));
             memset (start, b, (end - start));
@@ -32018,36 +31991,6 @@ void gc_heap::descr_segment (heap_segment* seg )
 #endif // TRACE_GC
 }
 
-void gc_heap::descr_card_table ()
-{
-#ifdef TRACE_GC
-    if (trace_gc && (print_level >= 4))
-    {
-        ptrdiff_t  min = -1;
-        dprintf(3,("Card Table set at: "));
-        for (size_t i = card_of (lowest_address); i < card_of (highest_address); i++)
-        {
-            if (card_set_p (i))
-            {
-                if (min == -1)
-                {
-                    min = i;
-                }
-            }
-            else
-            {
-                if (! ((min == -1)))
-                {
-                    dprintf (3,("[%Ix %Ix[, ",
-                            (size_t)card_address (min), (size_t)card_address (i)));
-                    min = -1;
-                }
-            }
-        }
-    }
-#endif //TRACE_GC
-}
-
 void gc_heap::descr_generations_to_profiler (gen_walk_fn fn, void *context)
 {
 #ifdef MULTIPLE_HEAPS
@@ -32431,7 +32374,7 @@ BOOL gc_heap::bgc_mark_array_range (heap_segment* seg,
 void gc_heap::bgc_verify_mark_array_cleared (heap_segment* seg)
 {
 #if defined (VERIFY_HEAP) && defined (MARK_ARRAY)
-    if (recursive_gc_sync::background_running_p() && g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
+    if (recursive_gc_sync::background_running_p() && GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
     {
         uint8_t* range_beg = 0;
         uint8_t* range_end = 0;
@@ -32615,7 +32558,7 @@ void gc_heap::verify_mark_array_cleared (heap_segment* seg)
 void gc_heap::verify_mark_array_cleared ()
 {
 #if defined (VERIFY_HEAP) && defined (MARK_ARRAY)
-    if (recursive_gc_sync::background_running_p() && g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
+    if (recursive_gc_sync::background_running_p() && GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
     {
         generation* gen = generation_of (max_generation);
         heap_segment* seg = heap_segment_rw (generation_start_segment (gen));
@@ -32645,7 +32588,7 @@ void gc_heap::verify_mark_array_cleared ()
 void gc_heap::verify_seg_end_mark_array_cleared()
 {
 #if defined (VERIFY_HEAP) && defined (MARK_ARRAY)
-    if (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
+    if (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
     {
         generation* gen = generation_of (max_generation);
         heap_segment* seg = heap_segment_rw (generation_start_segment (gen));
@@ -32707,7 +32650,7 @@ void gc_heap::verify_seg_end_mark_array_cleared()
 void gc_heap::verify_soh_segment_list()
 {
 #ifdef VERIFY_HEAP
-    if (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
+    if (GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_GC)
     {
         generation* gen = generation_of (max_generation);
         heap_segment* seg = heap_segment_rw (generation_start_segment (gen));
@@ -32893,7 +32836,7 @@ gc_heap::verify_free_lists ()
 void
 gc_heap::verify_heap (BOOL begin_gc_p)
 {
-    int             heap_verify_level = g_pConfig->GetHeapVerifyLevel();
+    int             heap_verify_level = static_cast<int>(GCConfig::GetHeapVerifyLevel());
     size_t          last_valid_brick = 0;
     BOOL            bCurrentBrickInvalid = FALSE;
     BOOL            large_brick_p = TRUE;
@@ -32955,7 +32898,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
     if (!settings.concurrent)
 #endif //BACKGROUND_GC
     {
-        if (!(heap_verify_level & EEConfig::HEAPVERIFY_NO_MEM_FILL))
+        if (!(heap_verify_level & GCConfig::HEAPVERIFY_NO_MEM_FILL))
         {
             //uninit the unused portions of segments.
             generation* gen1 = large_object_generation;
@@ -33235,7 +33178,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
 #endif //BACKGROUND_GC
 
             BOOL deep_verify_obj = can_verify_deep;
-            if ((heap_verify_level & EEConfig::HEAPVERIFY_DEEP_ON_COMPACT) && !settings.compaction)
+            if ((heap_verify_level & GCConfig::HEAPVERIFY_DEEP_ON_COMPACT) && !settings.compaction)
                 deep_verify_obj = FALSE;
 
             ((CObjectHeader*)curr_object)->ValidateHeap((Object*)curr_object, deep_verify_obj);
@@ -33528,6 +33471,7 @@ HRESULT GCHeap::Initialize ()
         return E_FAIL;
     }
 
+
     g_gc_pFreeObjectMethodTable = GCToEEInterface::GetFreeObjectMethodTable();
 
 //Initialize the static members.
@@ -33543,10 +33487,10 @@ HRESULT GCHeap::Initialize ()
     gc_heap::min_segment_size = min (seg_size, large_seg_size);
 
 #ifdef MULTIPLE_HEAPS
-    if (g_pConfig->GetGCNoAffinitize())
+    if (GCConfig::GetNoAffinitize())
         gc_heap::gc_thread_no_affinitize_p = true;
 
-    uint32_t nhp_from_config = g_pConfig->GetGCHeapCount();
+    uint32_t nhp_from_config = static_cast<uint32_t>(GCConfig::GetHeapCount());
     // GetGCProcessCpuCount only returns up to 64 procs.
     uint32_t nhp_from_process = CPUGroupInfo::CanEnableGCCPUGroups() ?
                                 CPUGroupInfo::GetNumActiveProcessors():
@@ -33849,7 +33793,7 @@ void GCHeap::Promote(Object** ppObject, ScanContext* sc, uint32_t flags)
 #ifdef FEATURE_CONSERVATIVE_GC
     // For conservative GC, a value on stack may point to middle of a free object.
     // In this case, we don't need to promote the pointer.
-    if (g_pConfig->GetGCConservative()
+    if (GCConfig::GetConservativeGC()
         && ((CObjectHeader*)o)->IsFree())
     {
         return;
@@ -34122,14 +34066,7 @@ bool GCHeap::StressHeap(gc_alloc_context * context)
                     str->SetMethodTable (g_pStringClass);
                     str->SetStringLength (strLen);
 
-#if CHECK_APP_DOMAIN_LEAKS
-                    if (g_pConfig->AppDomainLeaks() && str->SetAppDomainNoThrow())
-                    {
-#endif
-                        HndAssignHandle(m_StressObjs[i], ObjectToOBJECTREF(str));
-#if CHECK_APP_DOMAIN_LEAKS
-                    }
-#endif
+                    HndAssignHandle(m_StressObjs[i], ObjectToOBJECTREF(str));
                 }
                 i = (i + 1) % NUM_HEAP_STRESS_OBJS;
                 if (i == m_CurStressObj) break;
@@ -35546,7 +35483,7 @@ size_t GCHeap::GetValidSegmentSize(bool large_seg)
 // Get the max gen0 heap size, making sure it conforms.
 size_t GCHeap::GetValidGen0MaxSize(size_t seg_size)
 {
-    size_t gen0size = g_pConfig->GetGCgen0size();
+    size_t gen0size = GCConfig::GetGen0Size();
 
     if ((gen0size == 0) || !g_theGCHeap->IsValidGen0MaxSize(gen0size))
     {
@@ -35752,7 +35689,7 @@ bool CFinalize::Initialize()
     {
         ASSERT (m_Array);
         STRESS_LOG_OOM_STACK(sizeof(Object*[100]));
-        if (g_pConfig->IsGCBreakOnOOMEnabled())
+        if (GCConfig::GetBreakOnOOM())
         {
             GCToOSInterface::DebugBreak();
         }
@@ -35861,7 +35798,7 @@ CFinalize::RegisterForFinalization (int gen, Object* obj, size_t size)
                 ((CObjectHeader*)obj)->SetFree(size);
             }
             STRESS_LOG_OOM_STACK(0);
-            if (g_pConfig->IsGCBreakOnOOMEnabled())
+            if (GCConfig::GetBreakOnOOM())
             {
                 GCToOSInterface::DebugBreak();
             }
@@ -36542,7 +36479,7 @@ void deleteGCShadow()
     // Called at startup and right after a GC, get a snapshot of the GC Heap
 void initGCShadow()
 {
-    if (!(g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_BARRIERCHECK))
+    if (!(GCConfig::GetHeapVerifyLevel() & GCConfig::HEAPVERIFY_BARRIERCHECK))
         return;
 
     size_t len = g_gc_highest_address - g_gc_lowest_address;

--- a/src/Native/gc/gc.h
+++ b/src/Native/gc/gc.h
@@ -38,6 +38,7 @@ Module Name:
 #else
 #include "env/gcenv.ee.h"
 #endif // BUILD_AS_STANDALONE
+#include "gcconfig.h"
 
 /*
  * Promotion Function Prototypes

--- a/src/Native/gc/gc.h
+++ b/src/Native/gc/gc.h
@@ -116,6 +116,7 @@ extern "C" uint8_t* g_gc_highest_address;
 extern "C" GCHeapType g_gc_heap_type;
 extern "C" uint32_t g_max_generation;
 extern "C" MethodTable* g_gc_pFreeObjectMethodTable;
+extern "C" uint32_t g_num_processors;
 
 ::IGCHandleManager*  CreateGCHandleManager();
 

--- a/src/Native/gc/gc.h
+++ b/src/Native/gc/gc.h
@@ -27,16 +27,17 @@ Module Name:
 
 #include "gcinterface.h"
 #include "env/gcenv.os.h"
-#include "env/gcenv.ee.h"
 
-#ifdef FEATURE_STANDALONE_GC
+#ifdef BUILD_AS_STANDALONE
 #include "gcenv.ee.standalone.inl"
 
 // GCStress does not currently work with Standalone GC
 #ifdef STRESS_HEAP
  #undef STRESS_HEAP
 #endif // STRESS_HEAP
-#endif // FEATURE_STANDALONE_GC
+#else
+#include "env/gcenv.ee.h"
+#endif // BUILD_AS_STANDALONE
 
 /*
  * Promotion Function Prototypes

--- a/src/Native/gc/gccommon.cpp
+++ b/src/Native/gc/gccommon.cpp
@@ -44,6 +44,7 @@ uint8_t* g_gc_highest_address = 0;
 GCHeapType g_gc_heap_type = GC_HEAP_INVALID;
 uint32_t g_max_generation = max_generation;
 MethodTable* g_gc_pFreeObjectMethodTable = nullptr;
+uint32_t g_num_processors = 0;
 
 #ifdef GC_CONFIG_DRIVEN
 void record_global_mechanism (int mech_index)

--- a/src/Native/gc/gccommon.cpp
+++ b/src/Native/gc/gccommon.cpp
@@ -17,9 +17,9 @@
 IGCHeapInternal* g_theGCHeap;
 IGCHandleManager* g_theGCHandleManager;
 
-#ifdef FEATURE_STANDALONE_GC
+#ifdef BUILD_AS_STANDALONE
 IGCToCLR* g_theGCToCLR;
-#endif // FEATURE_STANDALONE_GC
+#endif // BUILD_AS_STANDALONE
 
 #ifdef GC_CONFIG_DRIVEN
 size_t gc_global_mechanisms[MAX_GLOBAL_GC_MECHANISMS_COUNT];
@@ -143,7 +143,30 @@ namespace SVR
     extern void PopulateDacVars(GcDacVars* dacVars);
 }
 
-bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleManager** gcHandleManager, GcDacVars* gcDacVars)
+//------------------------------------------------------------------
+// Externally-facing GC symbols, used to initialize the GC
+// -----------------------------------------------------------------
+
+#ifdef _MSC_VER
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT __attribute__ ((visibility ("default")))
+#endif // _MSC_VER
+
+#ifdef BUILD_AS_STANDALONE
+#define GC_API extern "C" DLLEXPORT
+#else
+#define GC_API extern "C"
+#endif // BUILD_AS_STANDALONE
+
+GC_API
+bool
+InitializeGarbageCollector(
+    /* In */  IGCToCLR* clrToGC,
+    /* Out */ IGCHeap** gcHeap,
+    /* Out */ IGCHandleManager** gcHandleManager,
+    /* Out */ GcDacVars* gcDacVars
+    )
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -184,7 +207,7 @@ bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleMa
 
     g_theGCHeap = heap;
 
-#ifdef FEATURE_STANDALONE_GC
+#ifdef BUILD_AS_STANDALONE
     assert(clrToGC != nullptr);
     g_theGCToCLR = clrToGC;
 #else

--- a/src/Native/gc/gcconfig.cpp
+++ b/src/Native/gc/gcconfig.cpp
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "common.h"
+#include "gcenv.h"
+#include "gc.h"
+
+#define BOOL_CONFIG(name, key, default, unused_doc)            \
+  bool GCConfig::Get##name() { return s_##name; }              \
+  bool GCConfig::s_##name = default;
+
+#define INT_CONFIG(name, key, default, unused_doc)             \
+  int64_t GCConfig::Get##name() { return s_##name; }           \
+  int64_t GCConfig::s_##name = default;
+
+// String configs are not cached because 1) they are rare and
+// not on hot paths and 2) they involve transfers of ownership
+// of EE-allocated strings, which is potentially complicated.
+#define STRING_CONFIG(name, key, unused_doc)                   \
+  GCConfigStringHolder GCConfig::Get##name()                   \
+  {                                                            \
+      const char* resultStr = nullptr;                         \
+      GCToEEInterface::GetStringConfigValue(key, &resultStr);  \
+      return GCConfigStringHolder(resultStr);                  \
+  }
+
+GC_CONFIGURATION_KEYS
+
+#undef BOOL_CONFIG
+#undef INT_CONFIG
+#undef STRING_CONFIG
+
+void GCConfig::Initialize()
+{
+#define BOOL_CONFIG(name, key, default, unused_doc)          \
+    GCToEEInterface::GetBooleanConfigValue(key, &s_##name);
+
+#define INT_CONFIG(name, key, default, unused_doc)           \
+    GCToEEInterface::GetIntConfigValue(key, &s_##name);
+
+#define STRING_CONFIG(unused_name, unused_key, unused_doc)
+
+GC_CONFIGURATION_KEYS
+
+#undef BOOL_CONFIG
+#undef INT_CONFIG
+}

--- a/src/Native/gc/gcconfig.h
+++ b/src/Native/gc/gcconfig.h
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef __GCCONFIG_H__
+#define __GCCONFIG_H__
+
+// gcconfig.h - GC configuration management and retrieval.
+//
+// This file and the GCConfig class are designed to be the primary entry point
+// for querying configuration information from within the GC.
+
+// GCConfigStringHolder is a wrapper around a configuration string obtained
+// from the EE. Such strings must be disposed using GCToEEInterface::FreeStringConfigValue,
+// so this class ensures that is done correctly.
+//
+// The name is unfortunately a little long, but "ConfigStringHolder" is already taken by the
+// EE's config mechanism.
+class GCConfigStringHolder
+{
+private:
+    const char* m_str;
+
+public:
+    // Constructs a new GCConfigStringHolder around a string obtained from
+    // GCToEEInterface::GetStringConfigValue.
+    explicit GCConfigStringHolder(const char* str)
+      : m_str(str) {}
+
+    // No copy operators - this type cannot be copied.
+    GCConfigStringHolder(const GCConfigStringHolder&) = delete;
+    GCConfigStringHolder& operator=(const GCConfigStringHolder&) = delete;
+
+    // This type is returned by-value by string config functions, so it
+    // requires a move constructor.
+    GCConfigStringHolder(GCConfigStringHolder&&) = default;
+
+    // Frees a string config value by delegating to GCToEEInterface::FreeStringConfigValue.
+    ~GCConfigStringHolder()
+    {
+        if (m_str)
+        {
+            GCToEEInterface::FreeStringConfigValue(m_str);
+        }
+
+        m_str = nullptr;
+    }
+
+    // Retrieves the wrapped config string.
+    const char* Get() const { return m_str; }
+};
+
+// Each one of these keys produces a method on GCConfig with the name "Get{name}", where {name}
+// is the first parameter of the *_CONFIG macros below.
+#define GC_CONFIGURATION_KEYS \
+  BOOL_CONFIG(ServerGC,     "gcServer",     false, "Whether we should be using Server GC")     \
+  BOOL_CONFIG(ConcurrentGC, "gcConcurrent", true,  "Whether we should be using Concurrent GC") \
+  BOOL_CONFIG(ConservativeGC, "gcConservative", false, "Enables/Disables conservative GC")     \
+  BOOL_CONFIG(ForceCompact, "gcForceCompact", false,                                           \
+      "When set to true, always do compacting GC")                                             \
+  BOOL_CONFIG(RetainVM,     "GCRetainVM",   false,                                             \
+      "When set we put the segments that should be deleted on a standby list (instead of "     \
+      "releasing them back to the OS) which will be considered to satisfy new segment requests"\
+     " (note that the same thing can be specified via API which is the supported way)")        \
+  BOOL_CONFIG(StressMix,    "GCStressMix",  false,                                             \
+      "Specifies whether the GC mix mode is enabled or not")                                   \
+  BOOL_CONFIG(BreakOnOOM,   "GCBreakOnOOM", false,                                             \
+      "Does a DebugBreak at the soonest time we detect an OOM")                                \
+  BOOL_CONFIG(NoAffinitize, "GCNoAffinitize", false,                                           \
+      "If set, do not affinitize server GC threads")                                           \
+  BOOL_CONFIG(LogEnabled,   "GCLogEnabled", false,                                             \
+      "Specifies if you want to turn on logging in GC")                                        \
+  BOOL_CONFIG(ConfigLogEnabled, "GCConfigLogEnabled", false,                                   \
+      "Specifies the name of the GC config log file")                                          \
+  INT_CONFIG(HeapVerifyLevel, "HeapVerify", HEAPVERIFY_NONE,                                   \
+      "When set verifies the integrity of the managed heap on entry and exit of each GC")      \
+  INT_CONFIG(LOHCompactionMode, "GCLOHCompact", 0, "Specifies the LOH compaction mode")        \
+  INT_CONFIG(BGCSpinCount,  "BGCSpinCount", 140, "Specifies the bgc spin count")               \
+  INT_CONFIG(BGCSpin,       "BGCSpin",      2,   "Specifies the bgc spin time")                \
+  INT_CONFIG(HeapCount,     "GCHeapCount",  0,   "Specifies the number of server GC heaps")    \
+  INT_CONFIG(Gen0Size,      "GCgen0size",   0, "Specifies the smallest gen0 size")             \
+  INT_CONFIG(SegmentSize,   "GCSegmentSize", 0, "Specifies the managed heap segment size")     \
+  INT_CONFIG(LatencyMode,   "GCLatencyMode", -1,                                               \
+      "Specifies the GC latency mode - batch, interactive or low latency (note that the same " \
+      "thing can be specified via API which is the supported way")                             \
+  INT_CONFIG(LogFileSize,   "GCLogFileSize", 0, "Specifies the GC log file size")              \
+  INT_CONFIG(CompactRatio,  "GCCompactRatio", 0,                                               \
+      "Specifies the ratio compacting GCs vs sweeping")                                        \
+  STRING_CONFIG(LogFile,    "GCLogFile",    "Specifies the name of the GC log file")           \
+  STRING_CONFIG(ConfigLogFile, "GCConfigLogFile",                                              \
+      "Specifies the name of the GC config log file")                                          \
+  STRING_CONFIG(MixLogFile, "GCMixLog",                                                        \
+      "Specifies the name of the log file for GC mix statistics")
+
+// This class is responsible for retreiving configuration information
+// for how the GC should operate.
+class GCConfig
+{
+#define BOOL_CONFIG(name, unused_key, unused_default, unused_doc) \
+  public: static bool Get##name();                                \
+  private: static bool s_##name;
+#define INT_CONFIG(name, unused_key, unused_default, unused_doc) \
+  public: static int64_t Get##name();                            \
+  private: static int64_t s_##name;
+#define STRING_CONFIG(name, unused_key, unused_doc) \
+  public: static GCConfigStringHolder Get##name();
+GC_CONFIGURATION_KEYS
+#undef BOOL_CONFIG
+#undef INT_CONFIG
+#undef STRING_CONFIG
+
+public:
+// Flags that may inhabit the number returned for the HeapVerifyLevel config option.
+// Keep this in sync with vm\eeconfig.h if this ever changes.
+enum HeapVerifyFlags {
+    HEAPVERIFY_NONE             = 0,
+    HEAPVERIFY_GC               = 1,   // Verify the heap at beginning and end of GC
+    HEAPVERIFY_BARRIERCHECK     = 2,   // Verify the brick table
+    HEAPVERIFY_SYNCBLK          = 4,   // Verify sync block scanning
+
+    // the following options can be used to mitigate some of the overhead introduced
+    // by heap verification.  some options might cause heap verifiction to be less
+    // effective depending on the scenario.
+
+    HEAPVERIFY_NO_RANGE_CHECKS  = 0x10,   // Excludes checking if an OBJECTREF is within the bounds of the managed heap
+    HEAPVERIFY_NO_MEM_FILL      = 0x20,   // Excludes filling unused segment portions with fill pattern
+    HEAPVERIFY_POST_GC_ONLY     = 0x40,   // Performs heap verification post-GCs only (instead of before and after each GC)
+    HEAPVERIFY_DEEP_ON_COMPACT  = 0x80    // Performs deep object verfication only on compacting GCs.
+};
+
+// Initializes the GCConfig subsystem. Must be called before accessing any
+// configuration information.
+static void Initialize();
+
+};
+
+#endif // __GCCONFIG_H__

--- a/src/Native/gc/gcee.cpp
+++ b/src/Native/gc/gcee.cpp
@@ -467,7 +467,7 @@ void gc_heap::fire_etw_allocation_event (size_t allocation_amount, int gen_numbe
 
     EX_TRY
     {
-        TypeHandle th = GetThread()->GetTHAllocContextObj();
+        TypeHandle th = GCToEEInterface::GetThread()->GetTHAllocContextObj();
 
         if (th != 0)
         {
@@ -533,7 +533,7 @@ uint32_t gc_heap::user_thread_wait (GCEvent *event, BOOL no_mode_change, int tim
     
     if (!no_mode_change)
     {
-        pCurThread = GetThread();
+        pCurThread = GCToEEInterface::GetThread();
         mode = pCurThread ? GCToEEInterface::IsPreemptiveGCDisabled(pCurThread) : false;
         if (mode)
         {

--- a/src/Native/gc/gceesvr.cpp
+++ b/src/Native/gc/gceesvr.cpp
@@ -22,15 +22,4 @@ namespace SVR {
 #include "gcee.cpp"
 }
 
-#if defined(FEATURE_PAL) && !defined(DACCESS_COMPILE)
- 
-// Initializes the SVR DAC table entries
-void DacGlobals::InitializeSVREntries(TADDR baseAddress)
-{
-#define DEFINE_DACVAR_SVR(id_type, size, id, var)   id = PTR_TO_TADDR(&var) - baseAddress;
-#include "dacvars.h"
-}
-
-#endif // FEATURE_PAL && !DACCESS_COMPILE
-
 #endif // FEATURE_SVR_GC

--- a/src/Native/gc/gcenv.ee.standalone.inl
+++ b/src/Native/gc/gcenv.ee.standalone.inl
@@ -241,6 +241,31 @@ ALWAYS_INLINE MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
     assert(g_theGCToCLR != nullptr);
     return g_theGCToCLR->GetFreeObjectMethodTable();
 }
+
+ALWAYS_INLINE bool GCToEEInterface::GetBooleanConfigValue(const char* key, bool* value)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->GetBooleanConfigValue(key, value);
+}
+
+ALWAYS_INLINE bool GCToEEInterface::GetIntConfigValue(const char* key, int64_t* value)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->GetIntConfigValue(key, value);
+}
+
+ALWAYS_INLINE bool GCToEEInterface::GetStringConfigValue(const char* key, const char** value)
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->GetStringConfigValue(key, value);
+}
+
+ALWAYS_INLINE void GCToEEInterface::FreeStringConfigValue(const char* value)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->FreeStringConfigValue(value);
+}
+
 #undef ALWAYS_INLINE
 
 } // anonymous namespace

--- a/src/Native/gc/gcenv.ee.standalone.inl
+++ b/src/Native/gc/gcenv.ee.standalone.inl
@@ -134,6 +134,12 @@ ALWAYS_INLINE void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
     g_theGCToCLR->DisablePreemptiveGC(pThread);
 }
 
+ALWAYS_INLINE bool GCToEEInterface::TrapReturningThreads()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->TrapReturningThreads();
+}
+
 ALWAYS_INLINE gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
 {
     assert(g_theGCToCLR != nullptr);

--- a/src/Native/gc/gcenv.ee.standalone.inl
+++ b/src/Native/gc/gcenv.ee.standalone.inl
@@ -134,6 +134,12 @@ ALWAYS_INLINE void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
     g_theGCToCLR->DisablePreemptiveGC(pThread);
 }
 
+ALWAYS_INLINE Thread* GCToEEInterface::GetThread()
+{
+    assert(g_theGCToCLR != nullptr);
+    return g_theGCToCLR->GetThread();
+}
+
 ALWAYS_INLINE bool GCToEEInterface::TrapReturningThreads()
 {
     assert(g_theGCToCLR != nullptr);

--- a/src/Native/gc/gcenv.ee.standalone.inl
+++ b/src/Native/gc/gcenv.ee.standalone.inl
@@ -5,11 +5,16 @@
 #ifndef __GCTOENV_EE_STANDALONE_INL__
 #define __GCTOENV_EE_STANDALONE_INL__
 
-#include "env/gcenv.ee.h"
+#include "gcinterface.h"
 
 // The singular interface instance. All calls in GCToEEInterface
 // will be fowarded to this interface instance.
 extern IGCToCLR* g_theGCToCLR;
+
+namespace
+{
+
+#include "env/gcenv.ee.h"
 
 // A note about this:
 // In general, we don't want to pretend to be smarter than the compiler
@@ -237,5 +242,7 @@ ALWAYS_INLINE MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
     return g_theGCToCLR->GetFreeObjectMethodTable();
 }
 #undef ALWAYS_INLINE
+
+} // anonymous namespace
 
 #endif // __GCTOENV_EE_STANDALONE_INL__

--- a/src/Native/gc/gchandletable.cpp
+++ b/src/Native/gc/gchandletable.cpp
@@ -56,6 +56,18 @@ OBJECTHANDLE GCHandleStore::CreateDependentHandle(Object* primary, Object* secon
     return handle;
 }
 
+void GCHandleStore::RelocateAsyncPinnedHandles(IGCHandleStore* pTarget)
+{
+    // assumption - the IGCHandleStore is an instance of GCHandleStore
+    GCHandleStore* other = static_cast<GCHandleStore*>(pTarget);
+    ::Ref_RelocateAsyncPinHandles(&_underlyingBucket, &other->_underlyingBucket);
+}
+
+bool GCHandleStore::EnumerateAsyncPinnedHandles(async_pin_enum_fn callback, void* context)
+{
+    return !!::Ref_HandleAsyncPinHandles(callback, context);
+}
+
 GCHandleStore::~GCHandleStore()
 {
     ::Ref_DestroyHandleTableBucket(&_underlyingBucket);

--- a/src/Native/gc/gchandletable.cpp
+++ b/src/Native/gc/gchandletable.cpp
@@ -148,6 +148,16 @@ bool GCHandleManager::StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* obj
     return !!::HndFirstAssignHandle(handle, ObjectToOBJECTREF(object));
 }
 
+void GCHandleManager::SetDependentHandleSecondary(OBJECTHANDLE handle, Object* object)
+{
+    ::SetDependentHandleSecondary(handle, ObjectToOBJECTREF(object));
+}
+
+Object* GCHandleManager::GetDependentHandleSecondary(OBJECTHANDLE handle)
+{
+    return OBJECTREFToObject(::GetDependentHandleSecondary(handle));
+}
+
 Object* GCHandleManager::InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject)
 {
     return (Object*)::HndInterlockedCompareExchangeHandle(handle, ObjectToOBJECTREF(object), ObjectToOBJECTREF(comparandObject));

--- a/src/Native/gc/gchandletableimpl.h
+++ b/src/Native/gc/gchandletableimpl.h
@@ -23,6 +23,10 @@ public:
 
     virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary);
 
+    virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget);
+
+    virtual bool EnumerateAsyncPinnedHandles(async_pin_enum_fn callback, void* context);
+
     virtual ~GCHandleStore();
 
     HandleTableBucket _underlyingBucket;

--- a/src/Native/gc/gchandletableimpl.h
+++ b/src/Native/gc/gchandletableimpl.h
@@ -59,6 +59,10 @@ public:
 
     virtual bool StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* object);
 
+    virtual void SetDependentHandleSecondary(OBJECTHANDLE handle, Object* object);
+
+    virtual Object* GetDependentHandleSecondary(OBJECTHANDLE handle);
+
     virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject);
 };
 

--- a/src/Native/gc/gcimpl.h
+++ b/src/Native/gc/gcimpl.h
@@ -254,7 +254,7 @@ private:
         // to threads returning to cooperative mode is down after gc.
         // In other words, if the sequence in GCHeap::RestartEE changes,
         // the condition here may have to change as well.
-        return g_TrapReturningThreads == 0;
+        return !GCToEEInterface::TrapReturningThreads();
     }
 public:
     //return TRUE if GC actually happens, otherwise FALSE

--- a/src/Native/gc/gcinterface.ee.h
+++ b/src/Native/gc/gcinterface.ee.h
@@ -18,7 +18,7 @@ public:
     // Suspends the EE for the given reason.
     virtual
     void SuspendEE(SUSPEND_REASON reason) = 0;
-    
+
     // Resumes all paused threads, with a boolean indicating
     // if the EE is being restarted because a GC is complete.
     virtual
@@ -166,6 +166,22 @@ public:
     // field to see how many bytes to skip before the next object on a heap segment begins.
     virtual
     MethodTable* GetFreeObjectMethodTable() = 0;
+
+    // Asks the EE for the value of a given configuration key. If the EE does not know or does not
+    // have a value for the requeested config key, false is returned and the value of the passed-in
+    // pointer is undefined. Otherwise, true is returned and the config key's value is written to
+    // the passed-in pointer.
+    virtual
+    bool GetBooleanConfigValue(const char* key, bool* value) = 0;
+
+    virtual
+    bool GetIntConfigValue(const char* key, int64_t* value) = 0;
+
+    virtual
+    bool GetStringConfigValue(const char* key, const char** value) = 0;
+
+    virtual
+    void FreeStringConfigValue(const char* value) = 0;
 };
 
 #endif // _GCINTERFACE_EE_H_

--- a/src/Native/gc/gcinterface.ee.h
+++ b/src/Native/gc/gcinterface.ee.h
@@ -77,6 +77,10 @@ public:
     virtual
     void DisablePreemptiveGC(Thread * pThread) = 0;
 
+    // Returns whether or not a thread suspension is pending.
+    virtual
+    bool TrapReturningThreads() = 0;
+
     // Retrieves the alloc context associated with a given thread.
     virtual
     gc_alloc_context * GetAllocContext(Thread * pThread) = 0;

--- a/src/Native/gc/gcinterface.ee.h
+++ b/src/Native/gc/gcinterface.ee.h
@@ -77,6 +77,11 @@ public:
     virtual
     void DisablePreemptiveGC(Thread * pThread) = 0;
 
+    // Gets the Thread instance for the current thread, or null if no thread
+    // instance is associated with this thread.
+    virtual
+    Thread* GetThread() = 0;
+
     // Returns whether or not a thread suspension is pending.
     virtual
     bool TrapReturningThreads() = 0;

--- a/src/Native/gc/gcinterface.ee.h
+++ b/src/Native/gc/gcinterface.ee.h
@@ -9,9 +9,9 @@
 // of the execution engine. Everything that the GC does that requires the EE
 // to be informed or that requires EE action must go through this interface.
 //
-// When FEATURE_STANDALONE_GC is defined, this class is named IGCToCLR and is
+// When BUILD_AS_STANDALONE is defined, this class is named IGCToCLR and is
 // an abstract class. The EE will provide a class that fulfills this interface,
-// and the GC will dispatch virtually on it to call into the EE. When FEATURE_STANDALONE_GC
+// and the GC will dispatch virtually on it to call into the EE. When BUILD_AS_STANDALONE
 // is not defined, this class is named GCToEEInterface and the GC will dispatch statically on it.
 class IGCToCLR {
 public:

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -185,12 +185,6 @@ typedef bool (*InitializeGarbageCollectorFunction)(
 // to be used as an argument to GetProcAddress.
 #define INITIALIZE_GC_FUNCTION_NAME "InitializeGarbageCollector"
 
-// The runtime needs to know whether we're using workstation or server GC 
-// long before the GCHeap is created. This function sets the type of
-// heap that will be created, before InitializeGarbageCollector is called
-// and the heap is actually created.
-void InitializeHeapType(bool bServerHeap);
-
 #ifdef WRITE_BARRIER_CHECK
 //always defined, but should be 0 in Server GC
 extern uint8_t* g_GCShadow;

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -171,15 +171,24 @@ class Object;
 class IGCHeap;
 class IGCHandleManager;
 
-// Initializes the garbage collector. Should only be called
-// once, during EE startup. Returns true if the initialization
-// was successful, false otherwise.
-bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleManager** gcHandleTable, GcDacVars* gcDacVars);
+// The function that initialzes the garbage collector.
+// Should only be called once: here, during EE startup.
+// Returns true if the initialization was successful, false otherwise.
+typedef bool (*InitializeGarbageCollectorFunction)(
+    /* In  */ IGCToCLR*,
+    /* Out */ IGCHeap**,
+    /* Out */ IGCHandleManager**,
+    /* Out */ GcDacVars*
+);
+
+// The name of the function that initializes the garbage collector,
+// to be used as an argument to GetProcAddress.
+#define INITIALIZE_GC_FUNCTION_NAME "InitializeGarbageCollector"
 
 // The runtime needs to know whether we're using workstation or server GC 
 // long before the GCHeap is created. This function sets the type of
 // heap that will be created, before InitializeGarbageCollector is called
-// and the heap is actually recated.
+// and the heap is actually created.
 void InitializeHeapType(bool bServerHeap);
 
 #ifdef WRITE_BARRIER_CHECK

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -399,6 +399,7 @@ typedef void (* record_surv_fn)(uint8_t* begin, uint8_t* end, ptrdiff_t reloc, v
 typedef void (* fq_walk_fn)(bool, void*);
 typedef void (* fq_scan_fn)(Object** ppObject, ScanContext *pSC, uint32_t dwFlags);
 typedef void (* handle_scan_fn)(Object** pRef, Object* pSec, uint32_t flags, ScanContext* context, bool isDependent);
+typedef bool (* async_pin_enum_fn)(Object* object, void* context);
 
 // Opaque type for tracking object pointers
 #ifndef DACCESS_COMPILE
@@ -425,6 +426,10 @@ public:
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(Object* object, int type, void* pExtraInfo) = 0;
 
     virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary) = 0;
+
+    virtual void RelocateAsyncPinnedHandles(IGCHandleStore* pTarget) = 0;
+
+    virtual bool EnumerateAsyncPinnedHandles(async_pin_enum_fn callback, void* context) = 0;
 
     virtual ~IGCHandleStore() {};
 };

--- a/src/Native/gc/gcinterface.h
+++ b/src/Native/gc/gcinterface.h
@@ -458,6 +458,10 @@ public:
 
     virtual bool StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* object) = 0;
 
+    virtual void SetDependentHandleSecondary(OBJECTHANDLE handle, Object* object) = 0;
+
+    virtual Object* GetDependentHandleSecondary(OBJECTHANDLE handle) = 0;
+
     virtual Object* InterlockedCompareExchangeObjectInHandle(OBJECTHANDLE handle, Object* object, Object* comparandObject) = 0;
 };
 

--- a/src/Native/gc/gcpriv.h
+++ b/src/Native/gc/gcpriv.h
@@ -3002,6 +3002,17 @@ public:
     PER_HEAP_ISOLATED
     size_t min_segment_size;
 
+    // For SOH we always allocate segments of the same
+    // size unless no_gc_region requires larger ones.
+    PER_HEAP_ISOLATED
+    size_t soh_segment_size;
+
+    PER_HEAP_ISOLATED
+    size_t min_loh_segment_size;
+
+    PER_HEAP_ISOLATED
+    size_t segment_info_size;
+
     PER_HEAP
     uint8_t* lowest_address;
 

--- a/src/Native/gc/gcpriv.h
+++ b/src/Native/gc/gcpriv.h
@@ -234,46 +234,6 @@ const int policy_compact = 1;
 const int policy_expand  = 2;
 
 #ifdef TRACE_GC
-
-
-extern int     print_level;
-extern BOOL    trace_gc;
-extern int    gc_trace_fac;
-
-
-class hlet
-{
-    static hlet* bindings;
-    int prev_val;
-    int* pval;
-    hlet* prev_let;
-public:
-    hlet (int& place, int value)
-    {
-        prev_val = place;
-        pval = &place;
-        place = value;
-        prev_let = bindings;
-        bindings = this;
-    }
-    ~hlet ()
-    {
-        *pval = prev_val;
-        bindings = prev_let;
-    }
-};
-
-
-#define let(p,v) hlet __x = hlet (p, v);
-
-#else //TRACE_GC
-
-#define gc_count    -1
-#define let(s,v)
-
-#endif //TRACE_GC
-
-#ifdef TRACE_GC
 #define SEG_REUSE_LOG_0 7
 #define SEG_REUSE_LOG_1 (SEG_REUSE_LOG_0 + 1)
 #define DT_LOG_0 (SEG_REUSE_LOG_1 + 1)
@@ -299,15 +259,12 @@ void GCLog (const char *fmt, ... );
 //#define dprintf(l,x) {if ((l==GTC_LOG) || (l <= 1)) {GCLog x;}}
 //#define dprintf(l,x) {if (trace_gc && ((l <= print_level) || (l==GTC_LOG))) {GCLog x;}}
 //#define dprintf(l,x) {if (l==GTC_LOG) {printf ("\n");printf x ; fflush(stdout);}}
-#else //SIMPLE_DPRINTF
+#else
 
-// The GCTrace output goes to stdout by default but can get sent to the stress log or the logfile if the
-// reg key GCTraceFacility is set.  THe stress log can only take a format string and 4 numbers or
-// string literals.
-#define dprintf(l,x) {if (trace_gc && (l<=print_level)) { \
-      if ( !gc_trace_fac) {printf ("\n");printf x ; fflush(stdout);} \
-      else if ( gc_trace_fac == 2) {LogSpewAlways x;LogSpewAlways ("\n");} \
-      else if ( gc_trace_fac == 1) {STRESS_LOG_VA(x);}}}
+// Nobody used the logging mechanism that used to be here. If we find ourselves
+// wanting to inspect GC logs on unmodified builds, we can use this define here
+// to do so.
+#define dprintf(l, x)
 
 #endif //SIMPLE_DPRINTF
 
@@ -602,7 +559,7 @@ struct GCStatistics
     : public StatisticsBase
 {
     // initialized to the contents of COMPlus_GcMixLog, or NULL, if not present
-    static TCHAR* logFileName;
+    static char* logFileName;
     static FILE*  logFile;
 
     // number of times we executed a background GC, a foreground GC, or a

--- a/src/Native/gc/handletable.cpp
+++ b/src/Native/gc/handletable.cpp
@@ -1293,7 +1293,6 @@ BOOL  Ref_HandleAsyncPinHandles(async_pin_enum_fn asyncPinCallback, void* contex
     {
         NOTHROW;
         GC_NOTRIGGER;
-        if (GetThread()) {MODE_COOPERATIVE;} else {DISABLED(MODE_COOPERATIVE);}
     }
     CONTRACTL_END;
 

--- a/src/Native/gc/handletable.cpp
+++ b/src/Native/gc/handletable.cpp
@@ -1286,9 +1286,9 @@ uint32_t HndCountAllHandles(BOOL fUseLocks)
     return uCount;
 }
 
-#ifndef FEATURE_REDHAWK
-BOOL  Ref_HandleAsyncPinHandles()
+BOOL  Ref_HandleAsyncPinHandles(async_pin_enum_fn asyncPinCallback, void* context)
 {
+#ifndef FEATURE_REDHAWK
     CONTRACTL
     {
         NOTHROW;
@@ -1297,22 +1297,27 @@ BOOL  Ref_HandleAsyncPinHandles()
     }
     CONTRACTL_END;
 
+    AsyncPinCallbackContext callbackCtx(asyncPinCallback, context);
     HandleTableBucket *pBucket = g_HandleTableMap.pBuckets[0];
     BOOL result = FALSE;
     int limit = getNumberOfSlots();
     for (int n = 0; n < limit; n ++ )
     {
-        if (TableHandleAsyncPinHandles(Table(pBucket->pTable[n])))
+        if (TableHandleAsyncPinHandles(Table(pBucket->pTable[n]), callbackCtx))
         {
             result = TRUE;
         }
     }
 
     return result;
+#else
+    return true;
+#endif // !FEATURE_REDHAWK
 }
 
 void  Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget)
 {
+#ifndef FEATURE_REDHAWK
     CONTRACTL
     {
         NOTHROW;
@@ -1325,8 +1330,8 @@ void  Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket 
     {
         TableRelocateAsyncPinHandles(Table(pSource->pTable[n]), Table(pTarget->pTable[n]));
     }
-}
 #endif // !FEATURE_REDHAWK
+}
 
 /*--------------------------------------------------------------------------*/
 

--- a/src/Native/gc/handletablecache.cpp
+++ b/src/Native/gc/handletablecache.cpp
@@ -57,7 +57,7 @@ void SpinUntil(void *pCond, BOOL fNonZero)
 #endif //_DEBUG
 
     // on MP machines, allow ourselves some spin time before sleeping
-    uint32_t uNonSleepSpins = 8 * (g_SystemInfo.dwNumberOfProcessors - 1);
+    static uint32_t uNonSleepSpins = 8 * (GCToOSInterface::GetCurrentProcessCpuCount() - 1);
 
     // spin until the specificed condition is met
     while ((*(uintptr_t *)pCond != 0) != (fNonZero != 0))

--- a/src/Native/gc/handletablecore.cpp
+++ b/src/Native/gc/handletablecore.cpp
@@ -516,14 +516,14 @@ BOOL SegmentInitialize(TableSegment *pSegment, HandleTable *pTable)
 
 #ifndef FEATURE_REDHAWK // todo: implement SafeInt
     // Prefast overflow sanity check the addition
-    if (!ClrSafeInt<uint32_t>::addition(dwCommit, g_SystemInfo.dwPageSize, dwCommit))
+    if (!ClrSafeInt<uint32_t>::addition(dwCommit, OS_PAGE_SIZE, dwCommit))
     {
         return FALSE;
     }
 #endif // !FEATURE_REDHAWK
 
     // Round down to the dwPageSize
-    dwCommit &= ~(g_SystemInfo.dwPageSize - 1);
+    dwCommit &= ~(OS_PAGE_SIZE - 1);
 
     // commit the header
     if (!GCToOSInterface::VirtualCommit(pSegment, dwCommit))
@@ -1443,7 +1443,7 @@ uint32_t SegmentInsertBlockFromFreeListWorker(TableSegment *pSegment, uint32_t u
                 void * pvCommit = pSegment->rgValue + (uCommitLine * HANDLE_HANDLES_PER_BLOCK);
 
                 // we should commit one more page of handles
-                uint32_t dwCommit = g_SystemInfo.dwPageSize;
+                uint32_t dwCommit = OS_PAGE_SIZE;
 
                 // commit the memory
                 if (!GCToOSInterface::VirtualCommit(pvCommit, dwCommit))
@@ -1808,7 +1808,7 @@ BOOL DoesSegmentNeedsToTrimExcessPages(TableSegment *pSegment)
     if (uEmptyLine < uDecommitLine)
     {
         // derive some useful info about the page size
-        uintptr_t dwPageRound = (uintptr_t)g_SystemInfo.dwPageSize - 1;
+        uintptr_t dwPageRound = (uintptr_t)OS_PAGE_SIZE - 1;
         uintptr_t dwPageMask  = ~dwPageRound;
 
         // compute the address corresponding to the empty line
@@ -1852,7 +1852,7 @@ void SegmentTrimExcessPages(TableSegment *pSegment)
     if (uEmptyLine < uDecommitLine)
     {
         // derive some useful info about the page size
-        uintptr_t dwPageRound = (uintptr_t)g_SystemInfo.dwPageSize - 1;
+        uintptr_t dwPageRound = (uintptr_t)OS_PAGE_SIZE - 1;
         uintptr_t dwPageMask  = ~dwPageRound;
 
         // compute the address corresponding to the empty line
@@ -1874,7 +1874,7 @@ void SegmentTrimExcessPages(TableSegment *pSegment)
             pSegment->bCommitLine = (uint8_t)((dwLo - (size_t)pSegment->rgValue) / HANDLE_BYTES_PER_BLOCK);
 
             // compute the address for the new decommit line
-            size_t dwDecommitAddr = dwLo - g_SystemInfo.dwPageSize;
+            size_t dwDecommitAddr = dwLo - OS_PAGE_SIZE;
 
             // assume a decommit line of zero until we know otherwise
             uDecommitLine = 0;

--- a/src/Native/gc/handletablepriv.h
+++ b/src/Native/gc/handletablepriv.h
@@ -341,6 +341,37 @@ struct HandleTypeCache
     int32_t lFreeIndex;
 };
 
+/*
+ * Async pin EE callback context, used to call back tot he EE when enumerating
+ * over async pinned handles.
+ */
+class AsyncPinCallbackContext
+{
+private:
+    async_pin_enum_fn m_callback;
+    void* m_context;
+
+public:
+    /*
+     * Constructs a new AsyncPinCallbackContext from a callback and a context,
+     * which will be passed to the callback as its second parameter every time
+     * it is invoked.
+     */
+    AsyncPinCallbackContext(async_pin_enum_fn callback, void* context)
+        : m_callback(callback), m_context(context)
+    {}
+
+    /*
+     * Invokes the callback with the given argument, returning the callback's
+     * result.'
+     */
+    bool Invoke(Object* argument) const
+    {
+        assert(m_callback != nullptr);
+        return m_callback(argument, m_context);
+    }
+};
+
 
 /*---------------------------------------------------------------------------*/
 
@@ -759,7 +790,7 @@ void SegmentFree(TableSegment *pSegment);
  * Mark ready for all non-pending OverlappedData that get moved to default domain.
  *
  */
-BOOL TableHandleAsyncPinHandles(HandleTable *pTable);
+BOOL TableHandleAsyncPinHandles(HandleTable *pTable, const AsyncPinCallbackContext& callbackCtx);
 
 /*
  * TableRelocateAsyncPinHandles

--- a/src/Native/gc/objecthandle.cpp
+++ b/src/Native/gc/objecthandle.cpp
@@ -563,10 +563,10 @@ int getNumberOfSlots()
         return 1;
 
 #ifdef FEATURE_REDHAWK
-    return g_SystemInfo.dwNumberOfProcessors;
+    return GCToOSInterface::GetCurrentProcessCpuCount();
 #else
     return (CPUGroupInfo::CanEnableGCCPUGroups() ? CPUGroupInfo::GetNumActiveProcessors() :
-                                                   g_SystemInfo.dwNumberOfProcessors);
+                                                   GCToOSInterface::GetCurrentProcessCpuCount());
 #endif
 }
 

--- a/src/Native/gc/objecthandle.cpp
+++ b/src/Native/gc/objecthandle.cpp
@@ -427,7 +427,6 @@ void CALLBACK ScanPointerForProfilerAndETW(_UNCHECKED_OBJECTREF *pObjRef, uintpt
     {
         NOTHROW;
         GC_NOTRIGGER;
-        if (GetThreadNULLOk()) { MODE_COOPERATIVE; } 
     }
     CONTRACTL_END;
 #endif // FEATURE_REDHAWK

--- a/src/Native/gc/objecthandle.h
+++ b/src/Native/gc/objecthandle.h
@@ -87,7 +87,7 @@ bool Ref_Initialize();
 void Ref_Shutdown();
 HandleTableBucket* Ref_CreateHandleTableBucket(void* context);
 bool Ref_InitializeHandleTableBucket(HandleTableBucket* bucket, void* context);
-BOOL Ref_HandleAsyncPinHandles();
+BOOL Ref_HandleAsyncPinHandles(async_pin_enum_fn callback, void* context);
 void Ref_RelocateAsyncPinHandles(HandleTableBucket *pSource, HandleTableBucket *pTarget);
 void Ref_RemoveHandleTableBucket(HandleTableBucket *pBucket);
 void Ref_DestroyHandleTableBucket(HandleTableBucket *pBucket);

--- a/src/Native/gc/sample/CMakeLists.txt
+++ b/src/Native/gc/sample/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(../env)
 set(SOURCES
     GCSample.cpp
     gcenv.ee.cpp
+    ../gcconfig.cpp
     ../gccommon.cpp
     ../gceewks.cpp
     ../gchandletable.cpp

--- a/src/Native/gc/sample/GCSample.cpp
+++ b/src/Native/gc/sample/GCSample.cpp
@@ -107,6 +107,8 @@ void WriteBarrier(Object ** dst, Object * ref)
     ErectWriteBarrier(dst, ref);
 }
 
+extern "C" bool InitializeGarbageCollector(IGCToCLR* clrToGC, IGCHeap** gcHeap, IGCHandleManager** gcHandleManager, GcDacVars* gcDacVars);
+
 int __cdecl main(int argc, char* argv[])
 {
     //

--- a/src/Native/gc/sample/gcenv.ee.cpp
+++ b/src/Native/gc/sample/gcenv.ee.cpp
@@ -286,6 +286,26 @@ bool GCToEEInterface::EagerFinalized(Object* obj)
     return false;
 }
 
+bool GCToEEInterface::GetBooleanConfigValue(const char* key, bool* value)
+{
+    return false;
+}
+
+bool GCToEEInterface::GetIntConfigValue(const char* key, int64_t* value)
+{
+    return false;
+}
+
+bool GCToEEInterface::GetStringConfigValue(const char* key, const char** value)
+{
+    return false;
+}
+
+void GCToEEInterface::FreeStringConfigValue(const char *value)
+{
+
+}
+
 MethodTable* GCToEEInterface::GetFreeObjectMethodTable()
 {
     return g_pFreeObjectMethodTable;
@@ -302,48 +322,3 @@ bool IsGCThread()
     return false;
 }
 
-void SwitchToWriteWatchBarrier()
-{
-}
-
-void SwitchToNonWriteWatchBarrier()
-{
-}
-
-void LogSpewAlways(const char * /*fmt*/, ...)
-{
-}
-
-uint32_t CLRConfig::GetConfigValue(ConfigDWORDInfo eType)
-{
-    switch (eType)
-    {
-    case UNSUPPORTED_BGCSpinCount:
-        return 140;
-
-    case UNSUPPORTED_BGCSpin:
-        return 2;
-
-    case UNSUPPORTED_GCLogEnabled:
-    case UNSUPPORTED_GCLogFile:
-    case UNSUPPORTED_GCLogFileSize:
-    case EXTERNAL_GCStressStart:
-    case INTERNAL_GCStressStartAtJit:
-    case INTERNAL_DbgDACSkipVerifyDlls:
-        return 0;
-
-    case Config_COUNT:
-    default:
-#ifdef _MSC_VER
-#pragma warning(suppress:4127) // Constant conditional expression in ASSERT below
-#endif
-        ASSERT(!"Unknown config value type");
-        return 0;
-    }
-}
-
-HRESULT CLRConfig::GetConfigValue(ConfigStringInfo /*eType*/, TCHAR * * outVal)
-{
-    *outVal = NULL;
-    return 0;
-}

--- a/src/Native/gc/sample/gcenv.ee.cpp
+++ b/src/Native/gc/sample/gcenv.ee.cpp
@@ -190,6 +190,11 @@ void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
     pThread->DisablePreemptiveGC();
 }
 
+Thread* GCToEEInterface::GetThread()
+{
+    return ::GetThread();
+}
+
 bool GCToEEInterface::TrapReturningThreads()
 {
     return !!g_TrapReturningThreads;

--- a/src/Native/gc/sample/gcenv.ee.cpp
+++ b/src/Native/gc/sample/gcenv.ee.cpp
@@ -190,6 +190,11 @@ void GCToEEInterface::DisablePreemptiveGC(Thread * pThread)
     pThread->DisablePreemptiveGC();
 }
 
+bool GCToEEInterface::TrapReturningThreads()
+{
+    return !!g_TrapReturningThreads;
+}
+
 gc_alloc_context * GCToEEInterface::GetAllocContext(Thread * pThread)
 {
     return pThread->GetAllocContext();

--- a/src/Native/gc/sample/gcenv.h
+++ b/src/Native/gc/sample/gcenv.h
@@ -4,9 +4,9 @@
 
 // The sample is to be kept simple, so building the sample
 // in tandem with a standalone GC is currently not supported.
-#ifdef FEATURE_STANDALONE_GC
-#undef FEATURE_STANDALONE_GC
-#endif // FEATURE_STANDALONE_GC
+#ifdef BUILD_AS_STANDALONE
+#undef BUILD_AS_STANDALONE
+#endif // BUILD_AS_STANDALONE
 
 #if defined(_DEBUG)
 #ifndef _DEBUG_IMPL

--- a/src/Native/gc/softwarewritewatch.cpp
+++ b/src/Native/gc/softwarewritewatch.cpp
@@ -10,7 +10,7 @@
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 #ifndef DACCESS_COMPILE
 
-static_assert((static_cast<size_t>(1) << SOFTWARE_WRITE_WATCH_AddressToTableByteIndexShift) == OS_PAGE_SIZE, "Unexpected OS_PAGE_SIZE");
+static_assert((static_cast<size_t>(1) << SOFTWARE_WRITE_WATCH_AddressToTableByteIndexShift) == WRITE_WATCH_UNIT_SIZE, "Unexpected WRITE_WATCH_UNIT_SIZE");
 
 extern "C"
 {
@@ -95,7 +95,7 @@ bool SoftwareWriteWatch::GetDirtyFromBlock(
             block[byteIndex] = 0;
         }
 
-        void *pageAddress = firstPageAddressInBlock + byteIndex * OS_PAGE_SIZE;
+        void *pageAddress = firstPageAddressInBlock + byteIndex * WRITE_WATCH_UNIT_SIZE;
         assert(pageAddress >= GetHeapStartAddress());
         assert(pageAddress < GetHeapEndAddress());
         assert(dirtyPageIndex < dirtyPageCount);
@@ -184,7 +184,7 @@ void SoftwareWriteWatch::GetDirty(
                 break;
             }
             currentBlock += sizeof(size_t);
-            firstPageAddressInCurrentBlock += sizeof(size_t) * OS_PAGE_SIZE;
+            firstPageAddressInCurrentBlock += sizeof(size_t) * WRITE_WATCH_UNIT_SIZE;
         }
 
         while (currentBlock < fullBlockEnd)
@@ -202,7 +202,7 @@ void SoftwareWriteWatch::GetDirty(
                 break;
             }
             currentBlock += sizeof(size_t);
-            firstPageAddressInCurrentBlock += sizeof(size_t) * OS_PAGE_SIZE;
+            firstPageAddressInCurrentBlock += sizeof(size_t) * WRITE_WATCH_UNIT_SIZE;
         }
         if (currentBlock < fullBlockEnd)
         {

--- a/src/Native/gc/softwarewritewatch.h
+++ b/src/Native/gc/softwarewritewatch.h
@@ -8,6 +8,8 @@
 #include "gcinterface.h"
 #include "gc.h"
 
+#define WRITE_WATCH_UNIT_SIZE 0x1000
+
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 #ifndef DACCESS_COMPILE
 
@@ -249,7 +251,7 @@ inline void *SoftwareWriteWatch::GetPageAddress(size_t tableByteIndex)
     void *pageAddress = reinterpret_cast<void *>(tableByteIndex << AddressToTableByteIndexShift);
     assert(pageAddress >= GetHeapStartAddress());
     assert(pageAddress < GetHeapEndAddress());
-    assert(ALIGN_DOWN(pageAddress, OS_PAGE_SIZE) == pageAddress);
+    assert(ALIGN_DOWN(pageAddress, WRITE_WATCH_UNIT_SIZE) == pageAddress);
     return pageAddress;
 }
 

--- a/src/Native/gc/unix/gcenv.unix.cpp
+++ b/src/Native/gc/unix/gcenv.unix.cpp
@@ -32,10 +32,6 @@ static_assert(sizeof(uint64_t) == 8, "unsigned long isn't 8 bytes");
 #include "gcenv.base.h"
 #include "gcenv.os.h"
 
-#ifndef BUILD_AS_STANDALONE
- #error "A GC-private implementation of GCToOSInterface should only be used with BUILD_AS_STANDALONE"
-#endif // BUILD_AS_STANDALONE
-
 #if HAVE_SYS_TIME_H
  #include <sys/time.h>
 #else

--- a/src/Native/gc/unix/gcenv.unix.cpp
+++ b/src/Native/gc/unix/gcenv.unix.cpp
@@ -32,9 +32,9 @@ static_assert(sizeof(uint64_t) == 8, "unsigned long isn't 8 bytes");
 #include "gcenv.base.h"
 #include "gcenv.os.h"
 
-#ifndef FEATURE_STANDALONE_GC
- #error "A GC-private implementation of GCToOSInterface should only be used with FEATURE_STANDALONE_GC"
-#endif // FEATURE_STANDALONE_GC
+#ifndef BUILD_AS_STANDALONE
+ #error "A GC-private implementation of GCToOSInterface should only be used with BUILD_AS_STANDALONE"
+#endif // BUILD_AS_STANDALONE
 
 #if HAVE_SYS_TIME_H
  #include <sys/time.h>

--- a/src/Native/gc/unix/gcenv.unix.cpp
+++ b/src/Native/gc/unix/gcenv.unix.cpp
@@ -704,6 +704,18 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
     return (st == 0);
 }
 
+// Gets the total number of processors on the machine, not taking
+// into account current process affinity.
+// Return:
+//  Number of processors on the machine
+uint32_t GCToOSInterface::GetTotalProcessorCount()
+{
+    // Calculated in GCToOSInterface::Initialize using
+    // sysconf(_SC_NPROCESSORS_ONLN)
+    return g_logicalCpuCount;
+}
+
+
 // Initialize the critical section
 void CLRCriticalSection::Initialize()
 {

--- a/src/Native/gc/windows/gcenv.windows.cpp
+++ b/src/Native/gc/windows/gcenv.windows.cpp
@@ -603,6 +603,15 @@ bool GCToOSInterface::CreateThread(GCThreadFunction function, void* param, GCThr
     return true;
 }
 
+// Gets the total number of processors on the machine, not taking
+// into account current process affinity.
+// Return:
+//  Number of processors on the machine
+uint32_t GCToOSInterface::GetTotalProcessorCount()
+{
+    return g_SystemInfo.dwNumberOfProcessors;
+}
+
 // Initialize the critical section
 void CLRCriticalSection::Initialize()
 {


### PR DESCRIPTION
This port continues https://github.com/dotnet/corert/pull/7383
Porting strategy: extracting patches via `format-patch` from coreclr, adjusting paths, then `am` them on corert.

**Glossary:**
- already merged: change already exists in corert
- gc only port: change only affected the gc directory and patch applied with no conflicts
- manual port: change applied with custom changes
- omitted changes: contains changes to files that do not exists in corert and were discarded

**Changes since [last commit](https://github.com/dotnet/coreclr/commit/ee454e11d0c73820dde10ab710f9d6eccd4471f1):**
- https://github.com/dotnet/coreclr/commit/984f6719a3c4b0ad35cba6b9d819a33935bc0b3e (gc only port)
- https://github.com/dotnet/coreclr/commit/1a183684b1ecf63ece8a2fd80173f083c0deea52 (gc only port, omitted changes)
- https://github.com/dotnet/coreclr/commit/5529df988f80e7fe67ec46f9f6cbd169fdf7edd5 (gc only port)
- https://github.com/dotnet/coreclr/commit/0f66b465dbe7774ff7514d4f2e160f0616b4085a (gc only port, omitted changes)
- https://github.com/dotnet/coreclr/commit/eb12b78102f2b54dc082caabcd1b59b42166509b (gc only port, omitted changes)
- https://github.com/dotnet/coreclr/commit/0834425813497593ceda8bb0ae12dcc463011d7c (manual port, omitted changes)
- https://github.com/dotnet/coreclr/commit/77eb339752afa774655d88121f4d8f5de05f6d0a (manual port, omitted changes)
- https://github.com/dotnet/coreclr/commit/0597a34b570d359d34a03c74e1007025c43ae7e8 (gc only port)
- https://github.com/dotnet/coreclr/commit/bab2cc30b1516cd257aba763c7a1c06497219ede (manual port)
- https://github.com/dotnet/coreclr/commit/f1d81d24932391c0f087364cd91a66ac2c758e35 (manual port)
- https://github.com/dotnet/coreclr/commit/4af0f91b0f3b9a99b8cb9bc3551576494b058732 (gc only port)
- https://github.com/dotnet/coreclr/commit/1e11b32ca720f886adfa0cc2a6a46829feba78d0 (gc only port, omitted changes)

**Points of interest**:
In https://github.com/dotnet/coreclr/commit/0834425813497593ceda8bb0ae12dcc463011d7c methods were added to the GCToEEInterface, that were using the CLRConfig system to acquire more information.
As that doesn't seem to be available in CoreRT, i've directed them to go against `g_pConfig` where possible.