### PR TITLE
Clean publish test output folders before run

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -422,6 +422,9 @@ goto :eof
     set __SourceFolder=%~1
     set __SourceFileName=%2
 
+    if exist "!__SourceFolder!\bin" rmdir /s /q !__SourceFolder!\bin
+    if exist "!__SourceFolder!\obj" rmdir /s /q !__SourceFolder!\obj
+
     :: Compute publish RID
     if /i "%CoreRT_BuildArch%" == "x86" (
         set Publish_Rid=win-x86


### PR DESCRIPTION
Incremental build was hiding failures in our local enlistments that only CI would catch due to it always starting with a fresh enlistment.