### PR TITLE
SuperIlc fixes for building the entire Pri#1 suite

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/Buckets.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/Buckets.cs
@@ -55,7 +55,7 @@ namespace ReadyToRun.SuperIlc
             IEnumerable<KeyValuePair<string, List<ProcessInfo>>> orderedBuckets = _bucketMap.OrderByDescending(bucket => bucket.Value.Count);
             foreach (KeyValuePair<string, List<ProcessInfo>> bucketKvp in orderedBuckets)
             {
-                bucketKvp.Value.Sort((a, b) => a.InputFileName.CompareTo(b.InputFileName));
+                bucketKvp.Value.Sort((a, b) => a.Parameters.InputFileName.CompareTo(b.Parameters.InputFileName));
                 output.WriteLine($@"    [{bucketKvp.Value.Count} failures] {bucketKvp.Key}");
             }
 
@@ -70,7 +70,7 @@ namespace ReadyToRun.SuperIlc
 
                 foreach (ProcessInfo failure in bucketKvp.Value)
                 {
-                    output.WriteLine($@"   {failure.InputFileName}");
+                    output.WriteLine($@"   {failure.Parameters.InputFileName}");
                 }
 
                 if (detailed)
@@ -80,14 +80,14 @@ namespace ReadyToRun.SuperIlc
 
                     foreach (ProcessInfo failure in bucketKvp.Value)
                     {
-                        output.WriteLine($@"Test: {failure.InputFileName}");
+                        output.WriteLine($@"Test: {failure.Parameters.InputFileName}");
                         try
                         {
-                            output.WriteLine(File.ReadAllText(failure.LogPath));
+                            output.WriteLine(File.ReadAllText(failure.Parameters.LogPath));
                         }
                         catch (Exception ex)
                         {
-                            output.WriteLine($"Error reading file {failure.LogPath}: {ex.Message}");
+                            output.WriteLine($"Error reading file {failure.Parameters.LogPath}: {ex.Message}");
                         }
                         output.WriteLine();
                     }
@@ -104,7 +104,7 @@ namespace ReadyToRun.SuperIlc
                     return "Timed out";
                 }
 
-                string[] lines = File.ReadAllLines(process.LogPath);
+                string[] lines = File.ReadAllLines(process.Parameters.LogPath);
 
                 for (int lineIndex = 2; lineIndex < lines.Length; lineIndex++)
                 {
@@ -138,7 +138,7 @@ namespace ReadyToRun.SuperIlc
                     return "Timed out";
                 }
 
-                string[] lines = File.ReadAllLines(process.LogPath);
+                string[] lines = File.ReadAllLines(process.Parameters.LogPath);
 
                 for (int lineIndex = 0; lineIndex < lines.Length; lineIndex++)
                 {
@@ -165,7 +165,7 @@ namespace ReadyToRun.SuperIlc
                     }
                 }
 
-                return $"Exit code: {process.ExitCode} = 0x{process.ExitCode:X8}, expected {process.ExpectedExitCode}";
+                return $"Exit code: {process.ExitCode} = 0x{process.ExitCode:X8}, expected {process.Parameters.ExpectedExitCode}";
             }
             catch (Exception ex)
             {

--- a/tests/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
@@ -51,7 +51,7 @@ namespace ReadyToRun.SuperIlc
                 ProcessInfo[] fileCompilations = new ProcessInfo[(int)CompilerIndex.Count];
                 foreach (CompilerRunner runner in compilerRunners)
                 {
-                    ProcessInfo compilationProcess = runner.CompilationProcess(_outputFolder, file);
+                    ProcessInfo compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, _outputFolder, file));
                     fileCompilations[(int)runner.Index] = compilationProcess;
                 }
                 _compilations.Add(fileCompilations);
@@ -78,7 +78,7 @@ namespace ReadyToRun.SuperIlc
                         folders.Add(Path.GetDirectoryName(script));
                         folders.UnionWith(runner.ReferenceFolders);
 
-                        scriptExecutions[(int)runner.Index] = runner.ScriptExecutionProcess(_outputFolder, script, modules, folders);
+                        scriptExecutions[(int)runner.Index] = new ProcessInfo(new ScriptExecutionProcessConstructor(runner, _outputFolder, script, modules, folders));
                     }
                 }
 
@@ -106,7 +106,7 @@ namespace ReadyToRun.SuperIlc
                             folders.Add(Path.GetDirectoryName(mainExe));
                             folders.UnionWith(runner.ReferenceFolders);
 
-                            appExecutions[(int)runner.Index] = runner.AppExecutionProcess(_outputFolder, mainExe, modules, folders);
+                            appExecutions[(int)runner.Index] = new ProcessInfo(new AppExecutionProcessConstructor(runner, _outputFolder, mainExe, modules, folders));
                         }
                     }
                 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/BuildFolder.cs
@@ -4,9 +4,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace ReadyToRun.SuperIlc
 {
@@ -120,6 +120,8 @@ namespace ReadyToRun.SuperIlc
             List<string> mainExecutables = new List<string>();
             List<string> executionScripts = new List<string>();
 
+            string scriptExtension = (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".cmd" : ".sh");
+
             // Copy unmanaged files (runtime, native dependencies, resources, etc)
             foreach (string file in Directory.EnumerateFiles(inputDirectory))
             {
@@ -137,7 +139,7 @@ namespace ReadyToRun.SuperIlc
                 {
                     mainExecutables.Add(file);
                 }
-                else if (ext.Equals(".cmd", StringComparison.OrdinalIgnoreCase))
+                else if (ext.Equals(scriptExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     executionScripts.Add(file);
                 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -99,7 +99,7 @@ namespace ReadyToRun.SuperIlc
                 }
             }
 
-            ParallelRunner.Run(compilationsToRun);
+            ParallelRunner.Run(compilationsToRun, _options.DegreeOfParallelism);
             
             bool success = true;
             List<KeyValuePair<string, string>> failedCompilationsPerBuilder = new List<KeyValuePair<string, string>>();
@@ -190,7 +190,7 @@ namespace ReadyToRun.SuperIlc
                 }
             }
 
-            ParallelRunner.Run(compilationsToRun);
+            ParallelRunner.Run(compilationsToRun, _options.DegreeOfParallelism);
 
             HashSet<string> skipCopying = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             int[] failedCompilationsPerBuilder = new int[(int)CompilerIndex.Count];
@@ -252,7 +252,7 @@ namespace ReadyToRun.SuperIlc
                 AddBuildFolderExecutions(executionsToRun, folder, stopwatch);
             }
 
-            ParallelRunner.Run(executionsToRun, degreeOfParallelism: _options.Sequential ? 1 : Environment.ProcessorCount);
+            ParallelRunner.Run(executionsToRun, degreeOfParallelism: _options.Sequential ? 1 : 0);
 
             List<KeyValuePair<string, string>> failedExecutionsPerBuilder = new List<KeyValuePair<string, string>>();
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -99,8 +99,6 @@ namespace ReadyToRun.SuperIlc
                 }
             }
 
-            compilationsToRun.Sort((a, b) => b.CompilationCostHeuristic.CompareTo(a.CompilationCostHeuristic));
-
             ParallelRunner.Run(compilationsToRun);
             
             bool success = true;
@@ -121,15 +119,15 @@ namespace ReadyToRun.SuperIlc
                             _compilationFailureBuckets.AddCompilation(runnerProcess);
                             try
                             {
-                                File.Copy(runnerProcess.InputFileName, runnerProcess.OutputFileName);
+                                File.Copy(runnerProcess.Parameters.InputFileName, runnerProcess.Parameters.OutputFileName);
                             }
                             catch (Exception ex)
                             {
-                                Console.Error.WriteLine("Error copying {0} to {1}: {2}", runnerProcess.InputFileName, runnerProcess.OutputFileName, ex.Message);
+                                Console.Error.WriteLine("Error copying {0} to {1}: {2}", runnerProcess.Parameters.InputFileName, runnerProcess.Parameters.OutputFileName, ex.Message);
                             }
                             if (file == null)
                             {
-                                file = runnerProcess.InputFileName;
+                                file = runnerProcess.Parameters.InputFileName;
                                 failedBuilders = runner.CompilerName;
                             }
                             else
@@ -186,7 +184,7 @@ namespace ReadyToRun.SuperIlc
                 compilationsPerRunner.Add(new KeyValuePair<string, ProcessInfo[]>(frameworkDll, processes));
                 foreach (CompilerRunner runner in frameworkRunners)
                 {
-                    ProcessInfo compilationProcess = runner.CompilationProcess(_options.CoreRootDirectory.FullName, frameworkDll);
+                    ProcessInfo compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, _options.CoreRootDirectory.FullName, frameworkDll));
                     compilationsToRun.Add(compilationProcess);
                     processes[(int)runner.Index] = compilationProcess;
                 }
@@ -206,7 +204,7 @@ namespace ReadyToRun.SuperIlc
                     ProcessInfo compilationProcess = kvp.Value[(int)runner.Index];
                     if (compilationProcess.Succeeded)
                     {
-                        skipCopying.Add(compilationProcess.InputFileName);
+                        skipCopying.Add(compilationProcess.Parameters.InputFileName);
                     }
                     else
                     {
@@ -276,7 +274,7 @@ namespace ReadyToRun.SuperIlc
 
                             if (file == null)
                             {
-                                file = runnerProcess.InputFileName;
+                                file = runnerProcess.Parameters.InputFileName;
                                 failedBuilders = runner.CompilerName;
                             }
                             else
@@ -346,6 +344,11 @@ namespace ReadyToRun.SuperIlc
                         {
                             executionsToRun.Add(executionProcess);
                         }
+                        else
+                        {
+                            // Forget the execution process when compilation failed
+                            execution[(int)runner.Index] = null;
+                        }
                     }
                 }
             }
@@ -371,7 +374,7 @@ namespace ReadyToRun.SuperIlc
 
             foreach (ProcessInfo processInfo in selection)
             {
-                logWriter.WriteLine($"{processInfo.DurationMilliseconds,10} | {processInfo.InputFileName}");
+                logWriter.WriteLine($"{processInfo.DurationMilliseconds,10} | {processInfo.Parameters.InputFileName}");
             }
         }
 
@@ -716,7 +719,7 @@ namespace ReadyToRun.SuperIlc
                             ProcessInfo compilationProcess = compilation[(int)runner.Index];
                             if (compilationProcess != null)
                             {
-                                string log = $"\nCOMPILE {runner.CompilerName}:{compilationProcess.InputFileName}\n" + File.ReadAllText(compilationProcess.LogPath);
+                                string log = $"\nCOMPILE {runner.CompilerName}:{compilationProcess.Parameters.InputFileName}\n" + File.ReadAllText(compilationProcess.Parameters.LogPath);
                                 perRunnerLog[(int)runner.Index].Write(log);
                                 combinedLog.Write(log);
                                 if (!compilationProcess.Succeeded)
@@ -735,10 +738,10 @@ namespace ReadyToRun.SuperIlc
                                 ProcessInfo executionProcess = execution[(int)runner.Index];
                                 if (executionProcess != null)
                                 {
-                                    string log = $"\nEXECUTE {runner.CompilerName}:{executionProcess.InputFileName}\n";
+                                    string log = $"\nEXECUTE {runner.CompilerName}:{executionProcess.Parameters.InputFileName}\n";
                                     try
                                     {
-                                        log += File.ReadAllText(executionProcess.LogPath);
+                                        log += File.ReadAllText(executionProcess.Parameters.LogPath);
                                     }
                                     catch (Exception ex)
                                     {

--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -41,6 +41,8 @@ namespace ReadyToRun.SuperIlc
                         LargeBubble(),
                         ReferencePath(),
                         IssuesPath(),
+                        CompilationTimeoutMinutes(),
+                        ExecutionTimeoutMinutes(),
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileDirectoryCommand.CompileDirectory));
 
@@ -64,6 +66,8 @@ namespace ReadyToRun.SuperIlc
                         LargeBubble(),
                         ReferencePath(),
                         IssuesPath(),
+                        CompilationTimeoutMinutes(),
+                        ExecutionTimeoutMinutes(),
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileSubtreeCommand.CompileSubtree));
 
@@ -76,7 +80,9 @@ namespace ReadyToRun.SuperIlc
                         CoreRootDirectory(),
                         Crossgen(),
                         CpaotDirectory(),
-                        NoCleanup()
+                        NoCleanup(),
+                        CompilationTimeoutMinutes(),
+                        ExecutionTimeoutMinutes(),
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileNugetCommand.CompileNuget));
 
@@ -129,6 +135,12 @@ namespace ReadyToRun.SuperIlc
 
             Option IssuesPath() =>
                 new Option(new[] { "--issues-path", "-ip" }, "Path to issues.targets", new Argument<FileInfo[]>() { Arity = ArgumentArity.ZeroOrMore });
+
+            Option CompilationTimeoutMinutes() =>
+                new Option(new[] { "--compilation-timeout-minutes", "-ct" }, "Compilation timeout (minutes)", new Argument<int>());
+
+            Option ExecutionTimeoutMinutes() =>
+                new Option(new[] { "--execution-timeout-minutes", "-et" }, "Execution timeout (minutes)", new Argument<int>());
 
             //
             // compile-nuget specific options

--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -34,6 +34,7 @@ namespace ReadyToRun.SuperIlc
                         NoExe(),
                         NoEtw(),
                         NoCleanup(),
+                        DegreeOfParallelism(),
                         Sequential(),
                         Framework(),
                         UseFramework(),
@@ -59,6 +60,7 @@ namespace ReadyToRun.SuperIlc
                         NoExe(),
                         NoEtw(),
                         NoCleanup(),
+                        DegreeOfParallelism(),
                         Sequential(),
                         Framework(),
                         UseFramework(),
@@ -81,6 +83,7 @@ namespace ReadyToRun.SuperIlc
                         Crossgen(),
                         CpaotDirectory(),
                         NoCleanup(),
+                        DegreeOfParallelism(),
                         CompilationTimeoutMinutes(),
                         ExecutionTimeoutMinutes(),
                     },
@@ -117,6 +120,9 @@ namespace ReadyToRun.SuperIlc
 
             Option NoCleanup() =>
                 new Option(new[] { "--nocleanup" }, "Don't clean up compilation artifacts after test runs", new Argument<bool>());
+
+            Option DegreeOfParallelism() =>
+                new Option(new[] { "--degree-of-parallelism", "-dop" }, "Override default compilation / execution DOP (default = logical processor count)", new Argument<int>());
 
             Option Sequential() =>
                 new Option(new[] { "--sequential" }, "Run tests sequentially", new Argument<bool>());

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileDirectoryCommand.cs
@@ -33,7 +33,7 @@ namespace ReadyToRun.SuperIlc
 
             IEnumerable<CompilerRunner> runners = options.CompilerRunners(isFramework: false);
 
-            PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, recursive: false);
+            PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
 
             BuildFolder folder = BuildFolder.FromDirectory(options.InputDirectory.FullName, runners, options.OutputDirectory.FullName, options);
             if (folder == null)
@@ -47,7 +47,7 @@ namespace ReadyToRun.SuperIlc
 
             if (!options.NoCleanup)
             {
-                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, recursive: false);
+                PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
             }
 
             return success ? 0 : 1;

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileNugetCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileNugetCommand.cs
@@ -34,7 +34,7 @@ namespace ReadyToRun.SuperIlc
             IEnumerable<string> referencePaths = options.ReferencePaths();
             IEnumerable<CompilerRunner> runners = options.CompilerRunners(false);
 
-            PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, recursive: false);
+            PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
 
             string nugetOutputFolder = Path.Combine(options.OutputDirectory.FullName, "nuget.out");
             Directory.CreateDirectory(nugetOutputFolder);
@@ -88,7 +88,7 @@ namespace ReadyToRun.SuperIlc
 
                 if (!options.NoCleanup)
                 {
-                    PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, recursive: false);
+                    PathExtensions.DeleteOutputFolders(options.OutputDirectory.FullName, options.CoreRootDirectory.FullName, recursive: false);
                 }
 
                 return success ? 0 : 1;

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompileSubtreeCommand.cs
@@ -44,7 +44,12 @@ namespace ReadyToRun.SuperIlc
                 .ToArray();
 
             ConcurrentBag<BuildFolder> folders = new ConcurrentBag<BuildFolder>();
-            int relativePathOffset = options.InputDirectory.FullName.Length + 1;
+            int relativePathOffset = options.InputDirectory.FullName.Length;
+            if (relativePathOffset > 0 && options.InputDirectory.FullName[relativePathOffset - 1] != Path.DirectorySeparatorChar)
+            {
+                relativePathOffset++;
+            }
+
             int folderCount = 0;
             int compilationCount = 0;
             int executionCount = 0;

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -47,8 +47,8 @@ namespace ReadyToRun.SuperIlc
         {
             int errno = chmod(path,
                 ((byte)Permissions.ReadWriteExecute << (int)PermissionGroupShift.Owner) |
-                ((byte)Permissions.ReadExecute << (int)PermissionGroupShift.Owner) |
-                ((byte)Permissions.ReadExecute << (int)PermissionGroupShift.Owner));
+                ((byte)Permissions.ReadExecute << (int)PermissionGroupShift.Group) |
+                ((byte)Permissions.ReadExecute << (int)PermissionGroupShift.Other));
 
             if (errno != 0)
             {

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -19,44 +19,6 @@ namespace ReadyToRun.SuperIlc
         Count
     }
 
-    internal static class Linux
-    {
-        [Flags]
-        private enum Permissions : byte
-        {
-            Read = 1,
-            Write = 2,
-            Execute = 4,
-
-            ReadExecute = Read | Execute,
-
-            ReadWriteExecute = Read | Write | Execute,
-        }
-
-        private enum PermissionGroupShift : int
-        {
-            Owner = 6,
-            Group = 3,
-            Other = 0,
-        }
-
-        [DllImport("libc", SetLastError = true)]
-        private static extern int chmod(string path, int flags);
-
-        public static void MakeExecutable(string path)
-        {
-            int errno = chmod(path,
-                ((byte)Permissions.ReadWriteExecute << (int)PermissionGroupShift.Owner) |
-                ((byte)Permissions.ReadExecute << (int)PermissionGroupShift.Group) |
-                ((byte)Permissions.ReadExecute << (int)PermissionGroupShift.Other));
-
-            if (errno != 0)
-            {
-                throw new Exception($@"Failed to set permissions on {path}: error code {errno}");
-            }
-        }
-    }
-
     public abstract class CompilerRunner
     {
         protected readonly BuildOptions _options;

--- a/tests/src/tools/ReadyToRun.SuperIlc/ComputeManagedAssemblies.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ComputeManagedAssemblies.cs
@@ -64,10 +64,7 @@ class ComputeManagedAssemblies
             isManaged = false;
         }
 
-        lock (_isManagedCache)
-        {
-            _isManagedCache[file] = isManaged;
-        }
+        _isManagedCache[file] = isManaged;
 
         return isManaged;
     }

--- a/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -17,7 +17,7 @@ namespace ReadyToRun.SuperIlc
     {
         public override CompilerIndex Index => CompilerIndex.CPAOT;
 
-        protected override string CompilerFileName => "ilc.exe";
+        protected override string CompilerFileName => "ilc".OSExeSuffix();
 
         private List<string> _resolvedReferences;
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CpaotRunner.cs
@@ -19,15 +19,17 @@ namespace ReadyToRun.SuperIlc
 
         protected override string CompilerFileName => "ilc.exe";
 
+        private List<string> _resolvedReferences;
+
         public CpaotRunner(BuildOptions options, IEnumerable<string> referencePaths)
             : base(options, options.CpaotDirectory.FullName, referencePaths)
         { }
 
-        protected override ProcessInfo ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
+        protected override ProcessParameters ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
         {
-            ProcessInfo processInfo = base.ExecutionProcess(modules, folders, noEtw);
-            processInfo.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "1";
-            return processInfo;
+            ProcessParameters processParameters = base.ExecutionProcess(modules, folders, noEtw);
+            processParameters.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "1";
+            return processParameters;
         }
 
         protected override IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName)
@@ -62,13 +64,28 @@ namespace ReadyToRun.SuperIlc
                 yield return $"-r:{reference}";
             }
 
+            if (_resolvedReferences == null)
+            {
+                _resolvedReferences = ResolveReferences();
+            }
+
+            foreach (string asmRef in _resolvedReferences)
+            {
+                yield return asmRef;
+            }
+        }
+
+        private List<string> ResolveReferences()
+        {
+            List<string> references = new List<string>();
             foreach (var referenceFolder in _referenceFolders)
             {
                 foreach (var reference in ComputeManagedAssemblies.GetManagedAssembliesInFolder(referenceFolder))
                 {
-                    yield return $"-r:{reference}";
+                    references.Add($"-r:{reference}");
                 }
             }
+            return references;
         }
     }
 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -22,11 +22,11 @@ namespace ReadyToRun.SuperIlc
         public CrossgenRunner(BuildOptions options, IEnumerable<string> referencePaths)
             : base(options, options.CoreRootDirectory.FullName, referencePaths) { }
 
-        protected override ProcessInfo ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
+        protected override ProcessParameters ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
         {
-            ProcessInfo processInfo = base.ExecutionProcess(modules, folders, noEtw);
-            processInfo.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "1";
-            return processInfo;
+            ProcessParameters processParameters = base.ExecutionProcess(modules, folders, noEtw);
+            processParameters.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "1";
+            return processParameters;
         }
 
         protected override IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName)

--- a/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -17,7 +17,7 @@ namespace ReadyToRun.SuperIlc
     {
         public override CompilerIndex Index => CompilerIndex.Crossgen;
 
-        protected override string CompilerFileName => "crossgen.exe";
+        protected override string CompilerFileName => "crossgen".OSExeSuffix();
 
         public CrossgenRunner(BuildOptions options, IEnumerable<string> referencePaths)
             : base(options, options.CoreRootDirectory.FullName, referencePaths) { }

--- a/tests/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/JitRunner.cs
@@ -25,17 +25,17 @@ namespace ReadyToRun.SuperIlc
         /// JIT runner has no compilation process as it doesn't transform the source IL code in any manner.
         /// </summary>
         /// <returns></returns>
-        public override ProcessInfo CompilationProcess(string outputRoot, string assemblyFileName)
+        public override ProcessParameters CompilationProcess(string outputRoot, string assemblyFileName)
         {
             File.Copy(assemblyFileName, GetOutputFileName(outputRoot, assemblyFileName), overwrite: true);
             return null;
         }
 
-        protected override ProcessInfo ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
+        protected override ProcessParameters ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
         {
-            ProcessInfo processInfo = base.ExecutionProcess(modules, folders, noEtw);
-            processInfo.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "0";
-            return processInfo;
+            ProcessParameters processParameters = base.ExecutionProcess(modules, folders, noEtw);
+            processParameters.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "0";
+            return processParameters;
         }
 
         protected override IEnumerable<string> BuildCommandLineArguments(string assemblyFileName, string outputFileName)

--- a/tests/src/tools/ReadyToRun.SuperIlc/Linux.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/Linux.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace ReadyToRun.SuperIlc
+{
+    internal static class Linux
+    {
+        [Flags]
+        private enum Permissions : byte
+        {
+            Read = 1,
+            Write = 2,
+            Execute = 4,
+
+            ReadExecute = Read | Execute,
+
+            ReadWriteExecute = Read | Write | Execute,
+        }
+
+        private enum PermissionGroupShift : int
+        {
+            Owner = 6,
+            Group = 3,
+            Other = 0,
+        }
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int chmod(string path, int flags);
+
+        public static void MakeExecutable(string path)
+        {
+            int errno = chmod(path,
+                ((byte)Permissions.ReadWriteExecute << (int)PermissionGroupShift.Owner) |
+                ((byte)Permissions.ReadExecute << (int)PermissionGroupShift.Group) |
+                ((byte)Permissions.ReadExecute << (int)PermissionGroupShift.Other));
+
+            if (errno != 0)
+            {
+                throw new Exception($@"Failed to set permissions on {path}: error code {errno}");
+            }
+        }
+    }
+
+}

--- a/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
@@ -89,23 +89,18 @@ public sealed class ParallelRunner
     }
 
     /// <summary>
-    /// Execute a given set of mutually independent build commands with the default
-    /// degree of parallelism.
-    /// </summary>
-    /// <param name="processesToRun">Processes to execute in parallel</param>
-    public static void Run(IEnumerable<ProcessInfo> processesToRun)
-    {
-        Run(processesToRun, degreeOfParallelism: Environment.ProcessorCount);
-    }
-
-    /// <summary>
     /// Execute a given set of mutually independent build commands with given degree of
     /// parallelism.
     /// </summary>
     /// <param name="processesToRun">Processes to execute in parallel</param>
-    /// <param name="degreeOfParallelism">Maximum number of processes to execute in parallel</param>
-    public static void Run(IEnumerable<ProcessInfo> processesToRun, int degreeOfParallelism)
+    /// <param name="degreeOfParallelism">Maximum number of processes to execute in parallel, 0 = logical processor count</param>
+    public static void Run(IEnumerable<ProcessInfo> processesToRun, int degreeOfParallelism = 0)
     {
+        if (degreeOfParallelism == 0)
+        {
+            degreeOfParallelism = Environment.ProcessorCount;
+        }
+
         List<ProcessInfo> processList = new List<ProcessInfo>();
         bool collectEtwTraces = false;
         foreach (ProcessInfo process in processesToRun)

--- a/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ParallelRunner.cs
@@ -67,7 +67,7 @@ public sealed class ParallelRunner
         public void Launch(ProcessInfo processInfo, ReadyToRunJittedMethods jittedMethods, int processIndex, int processCount, int progressIndex)
         {
             Debug.Assert(_processRunner == null);
-            Console.WriteLine($"{processIndex} / {processCount} ({(progressIndex * 100 / processCount)}%): launching: {processInfo.ProcessPath} {processInfo.Arguments}");
+            Console.WriteLine($"{processIndex} / {processCount} ({(progressIndex * 100 / processCount)}%): launching: {processInfo.Parameters.ProcessPath} {processInfo.Parameters.Arguments}");
 
             _processRunner = new ProcessRunner(processInfo, processIndex, processCount, jittedMethods, _processExitEvent);
         }
@@ -106,14 +106,23 @@ public sealed class ParallelRunner
     /// <param name="degreeOfParallelism">Maximum number of processes to execute in parallel</param>
     public static void Run(IEnumerable<ProcessInfo> processesToRun, int degreeOfParallelism)
     {
-        int processCount = processesToRun.Count();
+        List<ProcessInfo> processList = new List<ProcessInfo>();
+        bool collectEtwTraces = false;
+        foreach (ProcessInfo process in processesToRun)
+        {
+            process.Construct();
+            processList.Add(process);
+            collectEtwTraces |= process.Parameters.CollectJittedMethods;
+        }
+
+        processList.Sort((a, b) => b.Parameters.CompilationCostHeuristic.CompareTo(a.Parameters.CompilationCostHeuristic));
+
+        int processCount = processList.Count;
         if (processCount < degreeOfParallelism)
         {
             // We never need a higher DOP than the number of process to execute
             degreeOfParallelism = processCount;
         }
-
-        bool collectEtwTraces = processesToRun.Any(processInfo => processInfo.CollectJittedMethods);
 
         if (collectEtwTraces)
         {
@@ -121,33 +130,34 @@ public sealed class ParallelRunner
             // the process objects alive for the entire duration of the parallel execution, otherwise PID's
             // may get recycled by the OS and we can no longer back-translate PIDs in events to the logical
             // process executions. Without parallelization, we simply run the processes one by one.
-            int etwCollectionBatching = (degreeOfParallelism == 1 ? 1 : 100);
+            int etwCollectionBatching = (degreeOfParallelism == 1 ? 1 : 10);
 
             for (int batchStartIndex = 0; batchStartIndex < processCount; batchStartIndex += etwCollectionBatching)
             {
                 BuildEtwProcesses(
                     startIndex: batchStartIndex,
-                    processCount: processCount,
-                    processesToRun.Skip(batchStartIndex).Take(etwCollectionBatching),
+                    endIndex: Math.Min(batchStartIndex + etwCollectionBatching, processCount),
+                    totalCount: processCount,
+                    processList,
                     degreeOfParallelism);
             }
         }
         else
         {
-            BuildProjects(startIndex: 0, processCount, processesToRun, null, degreeOfParallelism);
+            BuildProjects(startIndex: 0, endIndex: processCount, totalCount: processCount, processList, null, degreeOfParallelism);
         }
     }
 
-    private static void BuildEtwProcesses(int startIndex, int processCount, IEnumerable<ProcessInfo> processesToRun, int degreeOfParallelism)
+    private static void BuildEtwProcesses(int startIndex, int endIndex, int totalCount, List<ProcessInfo> processList, int degreeOfParallelism)
     {
         using (TraceEventSession traceEventSession = new TraceEventSession("ReadyToRunTestSession"))
         {
             traceEventSession.EnableProvider(ClrTraceEventParser.ProviderGuid, TraceEventLevel.Verbose, (ulong)(ClrTraceEventParser.Keywords.Jit | ClrTraceEventParser.Keywords.Loader));
-            using (ReadyToRunJittedMethods jittedMethods = new ReadyToRunJittedMethods(traceEventSession, processesToRun))
+            using (ReadyToRunJittedMethods jittedMethods = new ReadyToRunJittedMethods(traceEventSession, processList, startIndex, endIndex))
             {
                 Task.Run(() =>
                 {
-                    BuildProjects(startIndex, processCount, processesToRun, jittedMethods, degreeOfParallelism);
+                    BuildProjects(startIndex, endIndex, totalCount, processList, jittedMethods, degreeOfParallelism);
                     traceEventSession.Stop();
                 });
             }
@@ -155,11 +165,12 @@ public sealed class ParallelRunner
         }
 
         // Append jitted method info to the logs
-        foreach (ProcessInfo processInfo in processesToRun)
+        for (int index = startIndex; index < endIndex; index++)
         {
-            if (processInfo.CollectJittedMethods)
+            ProcessInfo processInfo = processList[index];
+            if (processInfo.Parameters.CollectJittedMethods)
             {
-                using (StreamWriter processLogWriter = new StreamWriter(processInfo.LogPath, append: true))
+                using (StreamWriter processLogWriter = new StreamWriter(processInfo.Parameters.LogPath, append: true))
                 {
                     if (processInfo.JittedMethods != null)
                     {
@@ -181,7 +192,7 @@ public sealed class ParallelRunner
         }
     }
 
-    private static void BuildProjects(int startIndex, int processCount, IEnumerable<ProcessInfo> processesToRun, ReadyToRunJittedMethods jittedMethods, int degreeOfParallelism)
+    private static void BuildProjects(int startIndex, int endIndex, int totalCount, List<ProcessInfo> processList, ReadyToRunJittedMethods jittedMethods, int degreeOfParallelism)
     {
         using (AutoResetEvent processExitEvent = new AutoResetEvent(initialState: false))
         {
@@ -192,8 +203,10 @@ public sealed class ParallelRunner
             }
 
             int progressIndex = startIndex;
-            foreach (ProcessInfo processInfo in processesToRun)
+            for (int index = startIndex; index < endIndex; index++)
             {
+                ProcessInfo processInfo = processList[index];
+
                 // Allocate a process slot, potentially waiting on the exit event
                 // when all slots are busy (running)
                 ProcessSlot freeSlot = null;
@@ -215,7 +228,7 @@ public sealed class ParallelRunner
                 }
                 while (freeSlot == null);
 
-                freeSlot.Launch(processInfo, jittedMethods, startIndex++, processCount, progressIndex);
+                freeSlot.Launch(processInfo, jittedMethods, index, totalCount, progressIndex);
             }
 
             // We have launched all the commands, now wait for all processes to finish

--- a/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,6 +28,8 @@ static class PathExtensions
     /// when the directory is opened in the file explorer, the propagation typically takes 2 seconds.
     /// </summary>
     const int DirectoryDeletionBackoffMilliseconds = 500;
+
+    internal static string OSExeSuffix(this string path) => (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? path + ".exe" : path);
 
     internal static string ToAbsolutePath(this string argValue) => Path.GetFullPath(argValue);
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRunJittedMethods.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ReadyToRunJittedMethods.cs
@@ -32,19 +32,20 @@ public class ReadyToRunJittedMethods : IDisposable
     private Dictionary<long, string> _testModuleIdToName = new Dictionary<long, string>();
     private Dictionary<string, HashSet<string>> _methodsJitted = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
-    public ReadyToRunJittedMethods(TraceEventSession session, IEnumerable<ProcessInfo> processes)
+    public ReadyToRunJittedMethods(TraceEventSession session, List<ProcessInfo> processList, int startIndex, int endIndex)
     {
         _etwProcesses = new List<Process>();
         _pidToProcess = new Dictionary<int, ProcessInfo>();
         _testModuleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         _testFolderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (ProcessInfo process in processes)
+        for (int index = startIndex; index < endIndex; index++)
         {
-            if (process.CollectJittedMethods)
+            ProcessInfo process = processList[index];
+            if (process.Parameters.CollectJittedMethods)
             {
-                _testFolderNames.UnionWith(process.MonitorFolders);
-                _testModuleNames.UnionWith(process.MonitorModules);
+                _testFolderNames.UnionWith(process.Parameters.MonitorFolders);
+                _testModuleNames.UnionWith(process.Parameters.MonitorModules);
             }
         }
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
@@ -32,6 +32,8 @@ namespace ReadyToRun.SuperIlc
         public bool UseFramework { get; set; }
         public bool Release { get; set; }
         public bool LargeBubble { get; set; }
+        public int CompilationTimeoutMinutes { get; set; }
+        public int ExecutionTimeoutMinutes { get; set; }
         public DirectoryInfo[] ReferencePath { get; set; }
         public FileInfo[] IssuesPath { get; set; }
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
@@ -104,10 +104,12 @@ namespace ReadyToRun.SuperIlc
 
         public string CoreRunPath(CompilerIndex index, bool isFramework)
         {
-            string coreRunPath = Path.Combine(CoreRootOutputPath(index, isFramework), "CoreRun.exe");
+            string coreRunDir = CoreRootOutputPath(index, isFramework);
+            string coreRunExe = "corerun".OSExeSuffix();
+            string coreRunPath = Path.Combine(coreRunDir, coreRunExe);
             if (!File.Exists(coreRunPath))
             {
-                Console.Error.WriteLine("CoreRun.exe not found in CORE_ROOT, explicit exe launches won't work");
+                Console.Error.WriteLine($@"{coreRunExe} not found in {coreRunDir}, explicit exe launches won't work");
             }
             return coreRunPath;
         }

--- a/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
@@ -27,6 +27,7 @@ namespace ReadyToRun.SuperIlc
         public bool NoEtw { get; set; }
         public bool NoCleanup { get; set; }
         public FileInfo PackageList { get; set; }
+        public int DegreeOfParallelism { get; set; }
         public bool Sequential { get; set; }
         public bool Framework { get; set; }
         public bool UseFramework { get; set; }

--- a/tests/src/tools/ReadyToRun.SuperIlc/TestExclusion.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/TestExclusion.cs
@@ -5,10 +5,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
+using System.Runtime.InteropServices;
 using System.Xml.Linq;
-using System.Xml.XPath;
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
@@ -166,7 +164,8 @@ namespace ReadyToRun.SuperIlc
                 Project project = new Project();
                 project.SetGlobalProperty("XunitTestBinBase", "*");
                 project.SetGlobalProperty("BuildArch", "amd64");
-                project.SetGlobalProperty("TargetsWindows", "true");
+                // TODO: cross-OS CPAOT
+                project.SetGlobalProperty("TargetsWindows", (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "true" : "false"));
                 project.SetGlobalProperty("AltJitArch", "amd64");
                 project.SetGlobalProperty("RunTestViaIlLink", "false");
 


### PR DESCRIPTION
After adding support for the issues.targets file I became
able to run the entire Pri# 1 test suite using SuperIlc.
This change fixes issues uncovered by this more extensive
testing.

1) We need to slightly special-case the Core_Root folder
as it technically lies under the CoreCLR\bin\tests\(cfg)
folder; when building this entire folder, SuperIlc used to
pick it up as one of the folders to compile and was
subsequently racing between the build of this folder and
of the tests that refer to it in CPAOT framework mode.

2) BuildFolder construction was collecting test references
too early i.e. before the framework was built. I came to
the conclusion that this is a general problem stemming from
the fact that ProcessInfo was an arbitrary mixture of the
process parameters and the state machine used during the
actual build. I have cleaned this up by separating the
parameter file into a new class ProcessParameters; this let
me add logic for constructing the actual paramterers later.

3) I have added new options to specify explicit compilation
and execution timeouts to add at least minimum support for
long-building and long-running tests.

4) I have parallelized folder deletion and subtree lookup
to improve their performance.

5) I have added caching to the check for managed assemblies.
Previously, in the Pri# 1 tests we used to open framework
assemblies about 3 million times just for the purpose of
this lookup.

6) I have reduced the batch size for running ETW processes
from 100 to 10 as the larger number of events collected
within a single session was apparently slowing down test
execution.

Thanks

Tomas