### PR TITLE
Initial script changes to enable CPAOT on Linux

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -39,7 +39,8 @@ See the LICENSE file in the project root for more information.
     <NativeObjectExt Condition="'$(TargetOS)' == 'Windows_NT'">.obj</NativeObjectExt>
     <NativeObjectExt Condition="'$(TargetOS)' != 'Windows_NT'">.o</NativeObjectExt>
     <NativeObjectExt Condition="'$(NativeCodeGen)' == 'wasm'">.bc</NativeObjectExt>
-    <NativeObjectExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe'">.exe</NativeObjectExt>
+    <NativeObjectExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe' and '$(TargetOS)' == 'Windows_NT'">.exe</NativeObjectExt>
+    <NativeObjectExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe' and '$(TargetOS)' != 'Windows_NT'"></NativeObjectExt>
     <NativeObjectExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' != 'Exe'">.dll</NativeObjectExt>
 
     <LibFileExt Condition="'$(TargetOS)' == 'Windows_NT'">.lib</LibFileExt>
@@ -59,7 +60,9 @@ See the LICENSE file in the project root for more information.
     <NativeBinaryExt Condition="'$(IsNativeExecutable)' != 'true' and '$(TargetOS)' == 'Windows_NT' and $(NativeLib) == 'Static'">.lib</NativeBinaryExt>
     <NativeBinaryExt Condition="'$(IsNativeExecutable)' != 'true' and '$(TargetOS)' != 'Windows_NT' and $(NativeLib) == 'Static'">.a</NativeBinaryExt>
     <NativeBinaryExt Condition="'$(NativeCodeGen)' == 'wasm'">.html</NativeBinaryExt>
-    <NativeBinaryExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe'">.exe</NativeBinaryExt>
+
+    <NativeBinaryExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe' and '$(TargetOS)' == 'Windows_NT'">.exe</NativeBinaryExt>
+    <NativeBinaryExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe' and '$(TargetOS)' != 'Windows_NT'"></NativeBinaryExt>
     <NativeBinaryExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' != 'Exe'">.dll</NativeBinaryExt>
 
     <ExportsFileExt Condition="'$(OutputType)' !=  'Exe' and '$(TargetOS)' == 'Windows_NT' and '$(NativeLib)' == 'Shared'">.def</ExportsFileExt>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -39,8 +39,7 @@ See the LICENSE file in the project root for more information.
     <NativeObjectExt Condition="'$(TargetOS)' == 'Windows_NT'">.obj</NativeObjectExt>
     <NativeObjectExt Condition="'$(TargetOS)' != 'Windows_NT'">.o</NativeObjectExt>
     <NativeObjectExt Condition="'$(NativeCodeGen)' == 'wasm'">.bc</NativeObjectExt>
-    <NativeObjectExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe' and '$(TargetOS)' == 'Windows_NT'">.exe</NativeObjectExt>
-    <NativeObjectExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe' and '$(TargetOS)' != 'Windows_NT'"></NativeObjectExt>
+    <NativeObjectExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe'">.exe</NativeObjectExt>
     <NativeObjectExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' != 'Exe'">.dll</NativeObjectExt>
 
     <LibFileExt Condition="'$(TargetOS)' == 'Windows_NT'">.lib</LibFileExt>
@@ -60,9 +59,7 @@ See the LICENSE file in the project root for more information.
     <NativeBinaryExt Condition="'$(IsNativeExecutable)' != 'true' and '$(TargetOS)' == 'Windows_NT' and $(NativeLib) == 'Static'">.lib</NativeBinaryExt>
     <NativeBinaryExt Condition="'$(IsNativeExecutable)' != 'true' and '$(TargetOS)' != 'Windows_NT' and $(NativeLib) == 'Static'">.a</NativeBinaryExt>
     <NativeBinaryExt Condition="'$(NativeCodeGen)' == 'wasm'">.html</NativeBinaryExt>
-
-    <NativeBinaryExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe' and '$(TargetOS)' == 'Windows_NT'">.exe</NativeBinaryExt>
-    <NativeBinaryExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe' and '$(TargetOS)' != 'Windows_NT'"></NativeBinaryExt>
+    <NativeBinaryExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' == 'Exe'">.exe</NativeBinaryExt>
     <NativeBinaryExt Condition="'$(NativeCodeGen)' == 'readytorun' and '$(OutputType)' != 'Exe'">.dll</NativeBinaryExt>
 
     <ExportsFileExt Condition="'$(OutputType)' !=  'Exe' and '$(TargetOS)' == 'Windows_NT' and '$(NativeLib)' == 'Shared'">.def</ExportsFileExt>

--- a/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
@@ -6,19 +6,14 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using System.Runtime.InteropServices;
 
-using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysis.ReadyToRun;
 using ILCompiler.DependencyAnalysisFramework;
 using ILCompiler.PEWriter;
 using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
 
-using Internal.Metadata.NativeFormat;
-using Internal.TypeSystem.Ecma;
+using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -73,25 +68,30 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         /// <summary>
-        /// Determine OS override for the active hosting OS.
-        /// TODO: This will need changing once we enable cross-OS build
-        /// (logically this represents the target OS, not the host OS).
+        /// Determine OS machine override for the target operating system.
         /// </summary>
-        private static MachineOSOverride GetMachineOSOverride()
+        private MachineOSOverride GetMachineOSOverride()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            switch (_nodeFactory.Target.OperatingSystem)
             {
-                return MachineOSOverride.Windows;
+                case TargetOS.Windows:
+                    return MachineOSOverride.Windows;
+
+                case TargetOS.Linux:
+                    return MachineOSOverride.Linux;
+
+                case TargetOS.OSX:
+                    return MachineOSOverride.Apple;
+
+                case TargetOS.FreeBSD:
+                    return MachineOSOverride.FreeBSD;
+
+                case TargetOS.NetBSD:
+                    return MachineOSOverride.NetBSD;
+
+                default:
+                    throw new NotImplementedException(_nodeFactory.Target.OperatingSystem.ToString());
             }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return MachineOSOverride.Linux;
-            }
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return MachineOSOverride.Apple;
-            }
-            throw new NotImplementedException();
         }
 
         public void EmitPortableExecutable()

--- a/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
 
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysis.ReadyToRun;
@@ -21,6 +22,19 @@ using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.DependencyAnalysis
 {
+    /// <summary>
+    /// Per-OS machine overrides. Corresponds to CoreCLR constants
+    /// IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE.
+    /// </summary>
+    public enum MachineOSOverride : ushort
+    {
+        Windows = 0,
+        Linux = 0x7B79,
+        Apple = 0x4644,
+        FreeBSD = 0xADC4,
+        NetBSD = 0x1993,        
+    }
+
     /// <summary>
     /// Object writer using R2RPEReader to directly emit Windows Portable Executable binaries
     /// </summary>
@@ -56,6 +70,28 @@ namespace ILCompiler.DependencyAnalysis
             _nodes = nodes;
             _nodeFactory = factory;
             _inputPeReader = inputPeReader;
+        }
+
+        /// <summary>
+        /// Determine OS override for the active hosting OS.
+        /// TODO: This will need changing once we enable cross-OS build
+        /// (logically this represents the target OS, not the host OS).
+        /// </summary>
+        private static MachineOSOverride GetMachineOSOverride()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return MachineOSOverride.Windows;
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return MachineOSOverride.Linux;
+            }
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return MachineOSOverride.Apple;
+            }
+            throw new NotImplementedException();
         }
 
         public void EmitPortableExecutable()
@@ -135,6 +171,20 @@ namespace ILCompiler.DependencyAnalysis
                 using (var peStream = File.Create(_objectFilePath))
                 {
                     r2rPeBuilder.Write(peStream);
+
+                    // TODO: System.Reflection.Metadata doesn't currently support
+                    // OS machine overrides. We cannot directly pass the xor-ed
+                    // target machine to PEHeaderBuilder because it may incorrectly
+                    // detect 32-bitness and emit wrong OptionalHeader.Magic.
+                    const int DosHeaderSize = 0x80;
+                    const int PESignatureSize = sizeof(uint);
+
+                    byte[] patchedTargetMachine = BitConverter.GetBytes(
+                        (ushort)unchecked((ushort)targetMachine ^ (ushort)GetMachineOSOverride()));
+                    Debug.Assert(patchedTargetMachine.Length == sizeof(ushort));
+
+                    peStream.Seek(DosHeaderSize + PESignatureSize, SeekOrigin.Begin);
+                    peStream.Write(patchedTargetMachine, 0, patchedTargetMachine.Length);
                 }
 
                 mapFile.WriteLine($@"R2R object emission finished: {DateTime.Now}, {stopwatch.ElapsedMilliseconds} msecs");

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -511,7 +511,7 @@ do
         fi
     fi
     if [ "${CoreRT_TestCompileMode}" = "readytorun" ] || [ "${CoreRT_TestCompileMode}" = "" ]; then
-        if [ -e `dirname ${csproj}`/readytorun ]; then
+        if [ -e `dirname ${csproj}`/readytorun_ ]; then
             run_test_dir ${csproj} "ReadyToRun"
         fi
     fi

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -47,6 +47,9 @@ run_test_dir()
     if [ "${__mode}" = "Wasm" ]; then
         __extra_args="${__extra_args} /p:NativeCodeGen=wasm"
     fi
+    if [ "${__mode}" = "ReadyToRun" ]; then
+        __extra_args="${__extra_args} /p:NativeCodeGen=readytorun"
+    fi
     if [ -n "${__extra_cxxflags}" ]; then
         __extra_cxxflags="/p:AdditionalCppCompilerFlags=\"${__extra_cxxflags}\""
         __extra_flags+=("${__extra_cxxflags}")
@@ -310,6 +313,9 @@ CoreRT_CrossBuild=0
 CoreRT_EnableCoreDumps=0
 CoreRT_TestName=*
 CoreRT_SingleThreaded=
+CoreRT_CoreCLRRuntimeDir=${CoreRT_TestRoot}/../bin/obj/Linux.${CoreRT_BuildArch}.${CoreRT_BuildType}/CoreClrRuntime
+
+export CoreRT_CoreCLRRuntimeDir
 
 while [ "$1" != "" ]; do
         lowerI="$(echo $1 | awk '{print tolower($0)}')"
@@ -502,6 +508,11 @@ do
     if [ "${CoreRT_TestCompileMode}" = "cpp" ] || [ "${CoreRT_TestCompileMode}" = "" ]; then
         if [ ! -e `dirname ${csproj}`/no_cpp ]; then
             run_test_dir ${csproj} "Cpp" "$CoreRT_ExtraCXXFlags" "$CoreRT_ExtraLinkFlags"
+        fi
+    fi
+    if [ "${CoreRT_TestCompileMode}" = "readytorun" ] || [ "${CoreRT_TestCompileMode}" = "" ]; then
+        if [ -e `dirname ${csproj}`/readytorun ]; then
+            run_test_dir ${csproj} "ReadyToRun"
         fi
     fi
     if [ "${CoreRT_TestCompileMode}" = "wasm" ]; then

--- a/tests/src/Simple/ReadyToRunUnit/Program.cs
+++ b/tests/src/Simple/ReadyToRunUnit/Program.cs
@@ -23,7 +23,7 @@ internal class Program
     const int LineCountInitialValue = 0x12345678;
 
     [ThreadStatic]
-    private static string TextFileName = @"samplefile.txt";
+    private static string TextFileName;
 
     [ThreadStatic]
     private static int LineCount = LineCountInitialValue;
@@ -251,25 +251,6 @@ internal class Program
         {
             return p2;
         }
-    }
-
-    private static bool WriteTextFile()
-    {
-        Console.WriteLine($@"Writing file: {TextFileName}");
-        const int CharCountToWrite = 1000;
-        using (StreamWriter writer = new StreamWriter(TextFileName))
-        {
-            for (int i = 0; i < CharCountToWrite; i++)
-            {
-                writer.Write(i % 10);
-                if ((i + 1) % 80 == 0)
-                {
-                    writer.WriteLine();
-                }
-            }
-        }
-        return File.Exists(TextFileName) &&
-            new FileInfo(TextFileName).Length >= CharCountToWrite;
     }
 
     private static bool ReadAllText()
@@ -1060,15 +1041,19 @@ internal class Program
         return success;
     }
 
+    private static string EmitTextFileForTesting()
+    {
+        string file = Path.GetTempFileName();
+        File.WriteAllText(file, "Input for a test\nA small cog in the machine\nTurning endlessly\n");
+        return file;
+    }
+
     public static int Main(string[] args)
     {
-        if (args.Length > 0)
-        {
-            TextFileName = args[0];
-        }
-
         _passedTests = new List<string>();
         _failedTests = new List<string>();
+
+        TextFileName = EmitTextFileForTesting();
 
         RunTest("NewString", NewString());
         RunTest("WriteLine", WriteLine());
@@ -1080,7 +1065,6 @@ internal class Program
         RunTest("BoxUnbox", BoxUnbox());
         RunTest("TypeHandle", TypeHandle());
         RunTest("RuntimeTypeHandle", RuntimeTypeHandle());
-        RunTest("WriteTextFile", WriteTextFile());
         RunTest("ReadAllText", ReadAllText());
         RunTest("StreamReaderReadLine", StreamReaderReadLine());
         RunTest("SimpleDelegateTest", SimpleDelegateTest());
@@ -1117,12 +1101,14 @@ internal class Program
         RunTest("GVMTest", GVMTest());
         RunTest("RuntimeMethodHandle", RuntimeMethodHandle());
 
+        File.Delete(TextFileName);
+
         Console.WriteLine($@"{_passedTests.Count} tests pass:");
         foreach (string testName in _passedTests)
         {
             Console.WriteLine($@"    {testName}");
         }
-
+        
         if (_failedTests.Count == 0)
         {
             Console.WriteLine($@"All {_passedTests.Count} tests pass!");

--- a/tests/src/Simple/ReadyToRunUnit/Program.cs
+++ b/tests/src/Simple/ReadyToRunUnit/Program.cs
@@ -23,7 +23,7 @@ internal class Program
     const int LineCountInitialValue = 0x12345678;
 
     [ThreadStatic]
-    private static string TextFileName = @"C:\Windows\Microsoft.NET\Framework\v4.0.30319\clientexclusionlist.xml";
+    private static string TextFileName = @"samplefile.txt";
 
     [ThreadStatic]
     private static int LineCount = LineCountInitialValue;
@@ -251,6 +251,25 @@ internal class Program
         {
             return p2;
         }
+    }
+
+    private static bool WriteTextFile()
+    {
+        Console.WriteLine($@"Writing file: {TextFileName}");
+        const int CharCountToWrite = 1000;
+        using (StreamWriter writer = new StreamWriter(TextFileName))
+        {
+            for (int i = 0; i < CharCountToWrite; i++)
+            {
+                writer.Write(i % 10);
+                if ((i + 1) % 80 == 0)
+                {
+                    writer.WriteLine();
+                }
+            }
+        }
+        return File.Exists(TextFileName) &&
+            new FileInfo(TextFileName).Length >= CharCountToWrite;
     }
 
     private static bool ReadAllText()
@@ -1061,6 +1080,7 @@ internal class Program
         RunTest("BoxUnbox", BoxUnbox());
         RunTest("TypeHandle", TypeHandle());
         RunTest("RuntimeTypeHandle", RuntimeTypeHandle());
+        RunTest("WriteTextFile", WriteTextFile());
         RunTest("ReadAllText", ReadAllText());
         RunTest("StreamReaderReadLine", StreamReaderReadLine());
         RunTest("SimpleDelegateTest", SimpleDelegateTest());

--- a/tests/src/Simple/ReadyToRunUnit/ReadyToRunUnit.cmd
+++ b/tests/src/Simple/ReadyToRunUnit/ReadyToRunUnit.cmd
@@ -3,8 +3,8 @@ setlocal
 
 REM The arguments to invoke a ready-to-run test with ETW logging of jitted methods look like
 REM dotnet run --project --corerun tests\src\tools\ReadyToRun.TestHarness bin\obj\<Build>\CoreCLRRuntime\CoreRun.exe --in bin\<cfg>\<arch>\native\<test>.exe --whitelist methodWhiteList.txt
-echo %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt --testargs %~dp0TestTextFile.txt
-call %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt --testargs %~dp0TestTextFile.txt
+echo %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt
+call %3 %4 --corerun %5 --in "%1\%2" --whitelist %~dp0methodWhiteList.txt
 
 IF "%errorlevel%"=="100" (
     echo %~n0: Pass

--- a/tests/src/Simple/ReadyToRunUnit/ReadyToRunUnit.sh
+++ b/tests/src/Simple/ReadyToRunUnit/ReadyToRunUnit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-${CoreRT_CoreCLRRuntimeDir}/corerun $1/$2
+${CoreRT_CoreCLRRuntimeDir}/corerun $1/$2.exe
 if [ $? == 100 ]; then
     echo pass
     exit 0

--- a/tests/src/Simple/ReadyToRunUnit/ReadyToRunUnit.sh
+++ b/tests/src/Simple/ReadyToRunUnit/ReadyToRunUnit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+${CoreRT_CoreCLRRuntimeDir}/corerun $1/$2
+if [ $? == 100 ]; then
+    echo pass
+    exit 0
+else
+    echo fail
+    exit 1
+fi

--- a/tests/src/Simple/ReadyToRunUnit/TestTextFile.txt
+++ b/tests/src/Simple/ReadyToRunUnit/TestTextFile.txt
@@ -1,3 +1,0 @@
-Input for a test
-A small cog in the machine
-Turning endlessly

--- a/tests/src/Simple/SimpleTest.targets
+++ b/tests/src/Simple/SimpleTest.targets
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <!-- For Ready To Run testing, use the CoreCLR framework assemblies instead of the AOT ones -->
-    <IlcReference Condition="'$(NativeCodeGen)' == 'readytorun'" Include="$(CoreRT_CoreCLRRuntimeDir)\*.dll" />
+    <IlcReference Condition="'$(NativeCodeGen)' == 'readytorun'" Include="$(CoreRT_CoreCLRRuntimeDir)/*.dll" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
This is a small set of script changes I made to enable
CPAOT build on Linux. I have basically added the new
option to runtest.sh and fixed a few trivial issues
I hit in my local testing. I haven't yet figured out
how to cleanly pull down the CoreClrRuntime folder,
for now I'm copying it over manually from a live CoreCLR
build on my DTL VM.

With these changes (and after manually copying the Core_Root
folder from CoreCLR to bin/obj/Linux.x64.Debug/CoreClrRuntme)
I'm able to build the ReadyToRunUnit test. Sadly it doesn't
run yet, corerun claims that "coreclr_initialize failed:
0x80070057"; I have however found out that I'm receiving
exactly the same error when trying to run the same test
compiled with Crossgen so I guess it's rather a problem
with my local enlistment and / or build. I'm looking into
this right now.

Thanks

Tomas