### PR TITLE
Updating MicrosoftNetCompilersToolsetVersion to 3.2.0-beta2-19272-03

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -272,7 +272,7 @@
 
   <PropertyGroup>
     <!-- Also update init-tools.cmd and init-tools.sh -->
-    <RoslynVersion>3.2.0-beta1-19229-02</RoslynVersion>
+    <RoslynVersion>3.2.0-beta2-19272-03</RoslynVersion>
     <RoslynPackageName>Microsoft.Net.Compilers.Toolset</RoslynPackageName>
     <RoslynPackageDir>$(PackagesDir)/$(RoslynPackageName.ToLower())/$(RoslynVersion)/</RoslynPackageDir>
     <RoslynPropsFile>$(RoslynPackageDir)build/$(RoslynPackageName).props</RoslynPropsFile>

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -11,7 +11,7 @@ set /P BUILDTOOLS_VERSION=< "%~dp0BuildToolsVersion.txt"
 set BUILD_TOOLS_PATH=%PACKAGES_DIR%\Microsoft.DotNet.BuildTools\%BUILDTOOLS_VERSION%\lib
 set INIT_TOOLS_RESTORE_PROJECT=%~dp0init-tools.msbuild
 set BUILD_TOOLS_SEMAPHORE_DIR=%TOOLRUNTIME_DIR%\%BUILDTOOLS_VERSION%
-set BUILD_TOOLS_SEMAPHORE=%BUILD_TOOLS_SEMAPHORE_DIR%\init-tools.completed_4
+set BUILD_TOOLS_SEMAPHORE=%BUILD_TOOLS_SEMAPHORE_DIR%\init-tools.completed_5
 
 :: if force option is specified then clean the tool runtime and build tools package directory to force it to get recreated
 if [%1]==[force] (
@@ -84,7 +84,7 @@ if not [%INIT_TOOLS_ERRORLEVEL%]==[0] (
 :: Restore a custom RoslynToolset since we can't trivially update the BuildTools dependency in CoreRT
 echo Configurating RoslynToolset...
 :: Also update BUILD_TOOLS_SEMAPHORE, init-tools.sh, and dir.props
-set ROSLYNCOMPILERS_VERSION=3.2.0-beta1-19229-02
+set ROSLYNCOMPILERS_VERSION=3.2.0-beta2-19272-03
 set DEFAULT_RESTORE_ARGS=--no-cache --packages "%PACKAGES_DIR%"
 set INIT_TOOLS_RESTORE_ARGS=%DEFAULT_RESTORE_ARGS% --source https://dotnet.myget.org/F/roslyn/api/v3/index.json --source https://api.nuget.org/v3/index.json %INIT_TOOLS_RESTORE_ARGS%
 set MSBUILD_PROJECT_CONTENT= ^

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -18,7 +18,7 @@ __DOTNET_TOOLS_VERSION=$(cat $__scriptpath/DotnetCLIVersion.txt)
 __BUILD_TOOLS_PATH=$__PACKAGES_DIR/microsoft.dotnet.buildtools/$__BUILD_TOOLS_PACKAGE_VERSION/lib
 __INIT_TOOLS_RESTORE_PROJECT=$__scriptpath/init-tools.msbuild
 __INIT_TOOLS_DONE_MARKER_DIR=$__TOOLRUNTIME_DIR/$__BUILD_TOOLS_PACKAGE_VERSION
-__INIT_TOOLS_DONE_MARKER=$__INIT_TOOLS_DONE_MARKER_DIR/done_4
+__INIT_TOOLS_DONE_MARKER=$__INIT_TOOLS_DONE_MARKER_DIR/done_5
 
 if [ -z "$__DOTNET_PKG" ]; then
     OSName=$(uname -s)
@@ -143,7 +143,7 @@ if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
         # Restore a custom RoslynToolset since we can't trivially update the BuildTools dependency in CoreRT
         echo "Configuring RoslynToolset..."
         # Also update __INIT_TOOLS_DONE_MARKER, init-tools.cmd, and dir.props
-        __ROSLYNCOMPILER_VERSION=3.2.0-beta1-19229-02
+        __ROSLYNCOMPILER_VERSION=3.2.0-beta2-19272-03
         __DEFAULT_RESTORE_ARGS="--no-cache --packages \"${__PACKAGES_DIR}\""
         __INIT_TOOLS_RESTORE_ARGS="${__DEFAULT_RESTORE_ARGS} --source https://dotnet.myget.org/F/roslyn/api/v3/index.json --source https://api.nuget.org/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
         __PORTABLETARGETS_PROJECT_CONTENT="


### PR DESCRIPTION
CC. @jaredpar, @agocke, @dotnet/nullablefc

CoreRT side for https://github.com/dotnet/arcade/pull/2856 and https://github.com/dotnet/buildtools/pull/2256