### PR TITLE
CPAOT large version bubble bugfixes

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ManifestMetadataTableNode.cs
@@ -156,9 +156,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             foreach (AssemblyName assemblyName in _manifestAssemblies)
             {
                 AssemblyFlags assemblyFlags = 0;
+                byte[] publicKeyOrToken;
                 if ((assemblyName.Flags & AssemblyNameFlags.PublicKey) != 0)
                 {
                     assemblyFlags |= AssemblyFlags.PublicKey;
+                    publicKeyOrToken = assemblyName.GetPublicKey();
+                }
+                else
+                {
+                    publicKeyOrToken = assemblyName.GetPublicKeyToken();
                 }
                 if ((assemblyName.Flags & AssemblyNameFlags.Retargetable) != 0)
                 {
@@ -169,7 +175,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     name: metadataBuilder.GetOrAddString(assemblyName.Name),
                     version: assemblyName.Version,
                     culture: metadataBuilder.GetOrAddString(assemblyName.CultureName),
-                    publicKeyOrToken: metadataBuilder.GetOrAddBlob(assemblyName.GetPublicKeyToken()),
+                    publicKeyOrToken: metadataBuilder.GetOrAddBlob(publicKeyOrToken),
                     flags: assemblyFlags,
                     hashValue: default(BlobHandle) /* TODO */);
             }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/NewArrayFixupSignature.cs
@@ -6,6 +6,7 @@ using System;
 
 using Internal.Text;
 using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
@@ -28,8 +29,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ObjectDataSignatureBuilder dataBuilder = new ObjectDataSignatureBuilder();
             dataBuilder.AddSymbol(this);
 
-            dataBuilder.EmitByte((byte)ReadyToRunFixupKind.READYTORUN_FIXUP_NewArray);
-            dataBuilder.EmitTypeSignature(_arrayType, _signatureContext);
+            EcmaModule targetModule = _signatureContext.GetTargetModule(_arrayType);
+            SignatureContext innerContext = dataBuilder.EmitFixup(r2rFactory, ReadyToRunFixupKind.READYTORUN_FIXUP_NewArray, targetModule, _signatureContext);
+            dataBuilder.EmitTypeSignature(_arrayType, innerContext);
 
             return dataBuilder.ToObjectData();
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureContext.cs
@@ -66,7 +66,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public EcmaModule GetTargetModule(FieldDesc field)
         {
-            return GetTargetModule(field.OwningType);
+            return GetModuleTokenForField(field).Module;
         }
 
         public ModuleToken GetModuleTokenForType(EcmaType type, bool throwIfNotFound = true)

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
+using Internal.IL;
 using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -630,9 +631,17 @@ namespace Internal.JitInterface
             return false;
         }
 
+        private EcmaModule HandleToModule(CORINFO_MODULE_STRUCT_* module)
+        {
+            MethodIL methodIL = (MethodIL)HandleToObject((IntPtr)module);
+            EcmaMethod method = (EcmaMethod)methodIL.OwningMethod.GetTypicalMethodDefinition();
+            return method.Module;
+        }
+
         private InfoAccessType constructStringLiteral(CORINFO_MODULE_STRUCT_* module, mdToken metaTok, ref void* ppValue)
         {
-            ISymbolNode stringObject = _compilation.SymbolNodeFactory.StringLiteral(new ModuleToken(_tokenContext, metaTok), GetSignatureContext());
+            ISymbolNode stringObject = _compilation.SymbolNodeFactory.StringLiteral(
+                new ModuleToken(HandleToModule(module), metaTok), GetSignatureContext());
             ppValue = (void*)ObjectToHandle(stringObject);
             return InfoAccessType.IAT_PPVALUE;
         }

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -425,7 +425,7 @@ namespace ILCompiler
                                 EcmaModule module = typeSystemContext.GetModuleFromPath(referenceFile);
                                 versionBubbleModules.Add(module);
                             }
-                            catch (BadImageFormatException ex)
+                            catch (TypeSystemException.BadImageFormatException ex)
                             {
                                 Console.WriteLine("Warning: cannot open reference assembly '{0}': {1}", referenceFile, ex.Message);
                             }


### PR DESCRIPTION
I have finally identified the reason for various recent inconsistencies
we were recently hitting in large version bubble testing. As the
R2R major version number was recently bumped to 3 in CoreCLR, it
got out of sync with the value 2 we have in CoreClrRuntime used
for CPAOT testing in the CoreRT repo. For this reason all recent
testing performed against the CoreCLR version of Core_Root was
silently switching over to JIT; this included my recent local
large version bubble testing - while R2RDump was dumping the R2R
file content correctly and let me fix most issues, some problems
naturally remained and only popped up at runtime:

1) NewArrayFixupSignature wasn't properly switching over to the
inner signature context when emitting the array type signature.

2) SignatureBuilder was emitting incorrect signature for fields
on instantiated types (this only popped up after inlining parts
of CoreLib into the unit test).

3) In SignatureContext, we should call the token resolution logic
when determining field tokens as for fields encoded using refs
the reference module is the module containing the ref, not
necessarily the reference module for its owning type.

4) In CorInfoImpl.ReadyToRun, the logic for encoding string literals
was incorrect in large version bubble mode in the presence of
inlining - we need to use the context module passed along with the
string token, not the input module.

5) ManifestMetadataTableNode was incorrectly encoding public key
tokens for the AssemblyRefs.

6) I previously overlooked the fact that the BadImageFormatException
thrown for native assemblies is a variation of the type local
to TypeSystemException.

Thanks

Tomas

P.S. With this change the CoreCLR JIT test suite has about 93% pass
rate. I suspect I understand some of the remaining failures but
I wanted to send this our early as I'm going to be mostly OOF
for the rest of this week.
