### PR TITLE
Update CoreCLR and framework for R2R tests

### DIFF
--- a/src/Common/src/Internal/Runtime/ModuleHeaders.cs
+++ b/src/Common/src/Internal/Runtime/ModuleHeaders.cs
@@ -15,8 +15,8 @@ namespace Internal.Runtime
     {
         public const uint Signature = 0x00525452; // 'RTR'
 
-        public const ushort CurrentMajorVersion = 2;
-        public const ushort CurrentMinorVersion = 1;
+        public const ushort CurrentMajorVersion = 3;
+        public const ushort CurrentMinorVersion = 0;
     }
 
 #pragma warning disable 0169

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/HeaderNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/HeaderNode.cs
@@ -14,8 +14,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     {
         public const uint Signature = 0x00525452; // 'RTR'
 
-        public const ushort CurrentMajorVersion = 2;
-        public const ushort CurrentMinorVersion = 1;
+        public const ushort CurrentMajorVersion = 3;
+        public const ushort CurrentMinorVersion = 0;
     }
 
     public abstract class HeaderTableNode : ObjectNode, ISymbolDefinitionNode

--- a/src/Native/Runtime/inc/ModuleHeaders.h
+++ b/src/Native/Runtime/inc/ModuleHeaders.h
@@ -11,8 +11,8 @@ struct ReadyToRunHeaderConstants
 {
     static const uint32_t Signature = 0x00525452; // 'RTR'
 
-    static const uint32_t CurrentMajorVersion = 2;
-    static const uint32_t CurrentMinorVersion = 1;
+    static const uint32_t CurrentMajorVersion = 3;
+    static const uint32_t CurrentMinorVersion = 0;
 };
 
 struct ReadyToRunHeader

--- a/tests/external/runtime/runtime.depproj
+++ b/tests/external/runtime/runtime.depproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App">
-      <Version>3.0.0-preview4-27428-13</Version>
+      <Version>3.0.0-preview5-27626-15</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.TestHost">
       <Version>2.0.8</Version>


### PR DESCRIPTION
In Preview5, the R2R format version was bumped to 3.0. Roll forward to 3.0 and test against a more recent runtime that supports 3.0 ready-to-run image format.