### PR TITLE
Restore CoreCLRRuntime on Linux

### DIFF
--- a/buildscripts/build-tests.sh
+++ b/buildscripts/build-tests.sh
@@ -10,6 +10,24 @@ if [ "$BUILDVARS_DONE" != 1 ]; then
     . $scriptRoot/buildvars-setup.sh $*
 fi
 
+# Restore CoreCLR for ReadyToRun testing
+${__dotnetclipath}/dotnet msbuild ${__ProjectRoot}/tests/dirs.proj /nologo /t:Restore "/flp:v=normal;LogFile=$__TestBuildLog" /p:NuPkgRid=$__NugetRuntimeId /maxcpucount /p:OSGroup=$__BuildOS /p:Configuration=$__BuildType /p:Platform=$__BuildArch $__ExtraMsBuildArgs
+
+echo Commencing build of test components for $__BuildOS.$__BuildArch.$__BuildType
+echo
+
+${__dotnetclipath}/dotnet msbuild ${__ProjectRoot}/tests/dirs.proj /nologo "/flp:v=normal;LogFile=$__TestBuildLog" /p:NuPkgRid=$__NugetRuntimeId /maxcpucount /p:OSGroup=$__BuildOS /p:Configuration=$__BuildType /p:Platform=$__BuildArch $__ExtraMsBuildArgs "/p:RepoPath=$__ProjectRoot"  "/p:RepoLocalBuild=true"
+export BUILDERRORLEVEL=$?
+if [ $BUILDERRORLEVEL != 0 ]; then
+    echo Test build failed with exit code $BUILDERRORLEVEL. Refer to $__TestBuildLog for details.
+    exit $BUILDERRORLEVEL
+fi
+
+# No run. Only build >:|
+if [ -n "$__BuildTests" ]; then
+    exit 0
+fi
+
 pushd ${__ProjectRoot}/tests
 source ${__ProjectRoot}/tests/runtest.sh $__BuildOS $__BuildArch $__BuildType -cross $__CrossBuild -dotnetclipath $__dotnetclipath
 TESTERRORLEVEL=$?

--- a/buildscripts/build-tests.sh
+++ b/buildscripts/build-tests.sh
@@ -16,7 +16,8 @@ ${__dotnetclipath}/dotnet msbuild ${__ProjectRoot}/tests/dirs.proj /nologo /t:Re
 echo Commencing build of test components for $__BuildOS.$__BuildArch.$__BuildType
 echo
 
-${__dotnetclipath}/dotnet msbuild ${__ProjectRoot}/tests/dirs.proj /nologo "/flp:v=normal;LogFile=$__TestBuildLog" /p:NuPkgRid=$__NugetRuntimeId /maxcpucount /p:OSGroup=$__BuildOS /p:Configuration=$__BuildType /p:Platform=$__BuildArch $__ExtraMsBuildArgs "/p:RepoPath=$__ProjectRoot"  "/p:RepoLocalBuild=true"
+
+${__dotnetclipath}/dotnet msbuild ${__ProjectRoot}/tests/dirs.proj /nologo "/flp:v=normal;LogFile=$__TestBuildLog" /p:NuPkgRid=$__NugetRuntimeId /maxcpucount /p:OSGroup=$__BuildOS /p:Configuration=$__BuildType /p:Platform=$__BuildArch $__ExtraMsBuildArgs "/p:RepoPath=$__ProjectRoot"  "/p:RepoLocalBuild=true" /nodeReuse:false
 export BUILDERRORLEVEL=$?
 if [ $BUILDERRORLEVEL != 0 ]; then
     echo Test build failed with exit code $BUILDERRORLEVEL. Refer to $__TestBuildLog for details.

--- a/buildscripts/buildvars-setup.sh
+++ b/buildscripts/buildvars-setup.sh
@@ -136,6 +136,9 @@ while [ "$1" != "" ]; do
         skiptests)
             export __SkipTests=true
             ;;
+        buildtests)
+            export __BuildTests=1
+            ;;
         x86|x64|arm|arm64|armel|wasm)
             __BuildArch=$lowerI
             ;;
@@ -225,6 +228,9 @@ export __ProductBinDir="$__rootbinpath/$__BuildOS.$__BuildArch.$__BuildType"
 if [ $__CrossBuild = 1 ]; then
     export __ProductHostBinDir="$__rootbinpath/$__BuildOS.$__HostArch.$__BuildType"
 fi
+
+export __LogsDir="$__rootbinpath/Logs"
+export __TestBuildLog="$__LogsDir/tests_$__BuildOS.$__BuildArch.$__BuildType.log"
 
 # CI_SPECIFIC - On CI machines, $HOME may not be set. In such a case, create a subfolder and set the variable to set.
 # This is needed by CLI to function.

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -313,9 +313,6 @@ CoreRT_CrossBuild=0
 CoreRT_EnableCoreDumps=0
 CoreRT_TestName=*
 CoreRT_SingleThreaded=
-CoreRT_CoreCLRRuntimeDir=${CoreRT_TestRoot}/../bin/obj/Linux.${CoreRT_BuildArch}.${CoreRT_BuildType}/CoreClrRuntime
-
-export CoreRT_CoreCLRRuntimeDir
 
 while [ "$1" != "" ]; do
         lowerI="$(echo $1 | awk '{print tolower($0)}')"
@@ -444,6 +441,21 @@ if [ ${CoreRT_CrossBuild} != 0 ]; then
     esac
     CoreRT_ExtraCXXFlags="$CoreRT_ExtraCXXFlags $CoreRT_CrossCXXFlags"
     CoreRT_ExtraLinkFlags="$CoreRT_ExtraLinkFlags $CoreRT_CrossLinkerFlags"
+fi
+
+CoreRT_CoreCLRRuntimeDir=${CoreRT_TestRoot}/../bin/obj/Linux.${CoreRT_BuildArch}.${CoreRT_BuildType}/CoreClrRuntime
+
+export CoreRT_CoreCLRRuntimeDir
+
+if [ ! -d ${CoreRT_CoreCLRRuntimeDir} ]; then
+    # The test build handles restoring external dependencies such as CoreCLR runtime and its test host
+    # Trigger the test build so it will build but not run tests before we run them here
+    ${CoreRT_TestRoot}/../buildscripts/build-tests.sh buildtests
+    RestoreExitCode=$?
+    if [ ${RestoreExitCode} != 0 ]; then
+        echo Test build failed with code ${RestoreExitCode}
+        exit ${RestoreExitCode}
+    fi
 fi
 
 source "$CoreRT_TestRoot/testenv.sh"


### PR DESCRIPTION
When running tests, invoke the test build to restore the runtime / corefx / corerun to a well known folder needed to run Ready-to-run tests against.

The actual running of R2R tests is not enabled yet since we need to fix an issue with PE section virtual address offsets