### PR TITLE
[Intepreter] Method Call

### DIFF
--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -2470,7 +2470,7 @@ setvar:
                 switch (argumentType.Category)
                 {
                     case TypeFlags.Boolean:
-                        localVariableSet.SetVar<bool>(i, stackItem.AsInt32() > 0);
+                        localVariableSet.SetVar<bool>(i, stackItem.AsInt32() != 0);
                         break;
                     case TypeFlags.Char:
                         localVariableSet.SetVar<char>(i, (char)stackItem.AsInt32());
@@ -2544,12 +2544,16 @@ getvar:
                     callInfo.ReturnValue = StackItem.FromInt32(localVariableSet.GetVar<char>(0));
                     break;
                 case TypeFlags.SByte:
-                case TypeFlags.Byte:
                     callInfo.ReturnValue = StackItem.FromInt32(localVariableSet.GetVar<sbyte>(0));
                     break;
+                case TypeFlags.Byte:
+                    callInfo.ReturnValue = StackItem.FromInt32(localVariableSet.GetVar<byte>(0));
+                    break;
                 case TypeFlags.Int16:
-                case TypeFlags.UInt16:
                     callInfo.ReturnValue = StackItem.FromInt32(localVariableSet.GetVar<short>(0));
+                    break;
+                case TypeFlags.UInt16:
+                    callInfo.ReturnValue = StackItem.FromInt32(localVariableSet.GetVar<ushort>(0));
                     break;
                 case TypeFlags.Int32:
                 case TypeFlags.UInt32:
@@ -2602,6 +2606,12 @@ getvar:
             int delta = (signature.IsStatic ? 1 : 2);
 
             LocalVariableType[] localVariableTypes = new LocalVariableType[signature.Length + delta];
+            if (returnType.IsByRef)
+            {
+                // TODO: Unwrap ref types
+                throw new NotImplementedException();
+            }
+
             localVariableTypes[0] = new LocalVariableType(returnType.GetRuntimeTypeHandle(), false, returnType.IsByRef);
 
             if (!signature.IsStatic)
@@ -2610,6 +2620,12 @@ getvar:
             for (int i = 0; i < signature.Length; i++)
             {
                 var argument = signature[i];
+                if (argument.IsByRef)
+                {
+                    // TODO: Unwrap ref types
+                    throw new NotImplementedException();
+                }
+
                 localVariableTypes[i + delta] = new LocalVariableType(argument.GetRuntimeTypeHandle(), false, argument.IsByRef);
             }
 

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -2503,8 +2503,7 @@ setvar:
                         break;
                     case TypeFlags.ValueType:
                     case TypeFlags.Nullable:
-                        localVariableSet.SetVar<ValueType>(i, stackItem.AsValueType());
-                        break;
+                        throw new NotImplementedException();
                     case TypeFlags.Enum:
                         argumentType = argumentType.UnderlyingType;
                         goto setvar;
@@ -2512,7 +2511,6 @@ setvar:
                     case TypeFlags.Interface:
                     case TypeFlags.Array:
                     case TypeFlags.SzArray:
-                        callInfo.ReturnValue = StackItem.FromObjectRef(localVariableSet.GetVar<object>(0));
                         localVariableSet.SetVar<object>(i, stackItem.AsObjectRef());
                         break;
                     default:

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.MethodAddress.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.MethodAddress.cs
@@ -39,7 +39,7 @@ namespace Internal.Runtime.TypeLoader
         /// <param name="methodAddress">Resolved method address</param>
         /// <param name="unboxingStubAddress">Resolved unboxing stub address</param>
         /// <returns>true when the resolution succeeded, false when not</returns>
-        internal static bool TryGetMethodAddressFromMethodDesc(
+        public static bool TryGetMethodAddressFromMethodDesc(
             MethodDesc method,
             out IntPtr methodAddress,
             out IntPtr unboxingStubAddress,


### PR DESCRIPTION
This WIP PR calling static or non-virtual instance methods. It adds support for the following opcode:

* `call`

which should allow methods like the following to be interpreted:

```csharp
public static void CallMethod()
{
    Console.WriteLine("Hello World Intepreted");
}
```

~At this time it doesn't actually work, it doesn't throw an error either nor does the program return a non-zero exit code. I need help figuring out what is wrong.~

cc @jkotas @MichalStrehovsky 