### PR TITLE
CPAOT fixes for Linux

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/ILCompiler.ReadyToRun/src/CodeGen/ReadyToRunObjectWriter.cs
@@ -18,19 +18,6 @@ using Internal.TypeSystem;
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
-    /// Per-OS machine overrides. Corresponds to CoreCLR constants
-    /// IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE.
-    /// </summary>
-    public enum MachineOSOverride : ushort
-    {
-        Windows = 0,
-        Linux = 0x7B79,
-        Apple = 0x4644,
-        FreeBSD = 0xADC4,
-        NetBSD = 0x1993,        
-    }
-
-    /// <summary>
     /// Object writer using R2RPEReader to directly emit Windows Portable Executable binaries
     /// </summary>
     internal class ReadyToRunObjectWriter

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -103,6 +103,7 @@
     <Compile Include="ObjectWriter\SectionBuilder.cs" />
     <Compile Include="ObjectWriter\R2RPEBuilder.cs" />
     <Compile Include="ObjectWriter\RelocationHelper.cs" />
+    <Compile Include="ObjectWriter\TargetExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/TargetExtensions.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/TargetExtensions.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection.PortableExecutable;
+
+using Internal.TypeSystem;
+
+namespace ILCompiler.PEWriter
+{
+    /// <summary>
+    /// Per-OS machine overrides. Corresponds to CoreCLR constants
+    /// IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE.
+    /// </summary>
+    public enum MachineOSOverride : ushort
+    {
+        Windows = 0,
+        Linux = 0x7B79,
+        Apple = 0x4644,
+        FreeBSD = 0xADC4,
+        NetBSD = 0x1993,
+    }
+
+    public static class TargetExtensions
+    {
+        /// <summary>
+        /// Calculate machine ID based on compilation target architecture.
+        /// </summary>
+        /// <param name="target">Compilation target environment specification</param>
+        /// <returns></returns>
+        public static Machine MachineFromTarget(this TargetDetails target)
+        {
+            switch (target.Architecture)
+            {
+                case Internal.TypeSystem.TargetArchitecture.X64:
+                    return Machine.Amd64;
+
+                case Internal.TypeSystem.TargetArchitecture.X86:
+                    return Machine.I386;
+
+                default:
+                    throw new NotImplementedException(target.Architecture.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Determine OS machine override for the target operating system.
+        /// </summary>
+        public static MachineOSOverride MachineOSOverrideFromTarget(this TargetDetails target)
+        {
+            switch (target.OperatingSystem)
+            {
+                case TargetOS.Windows:
+                    return MachineOSOverride.Windows;
+
+                case TargetOS.Linux:
+                    return MachineOSOverride.Linux;
+
+                case TargetOS.OSX:
+                    return MachineOSOverride.Apple;
+
+                case TargetOS.FreeBSD:
+                    return MachineOSOverride.FreeBSD;
+
+                case TargetOS.NetBSD:
+                    return MachineOSOverride.NetBSD;
+
+                default:
+                    throw new NotImplementedException(target.OperatingSystem.ToString());
+            }
+        }
+    }
+}

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -450,7 +450,7 @@ export CoreRT_CoreCLRRuntimeDir
 if [ ! -d ${CoreRT_CoreCLRRuntimeDir} ]; then
     # The test build handles restoring external dependencies such as CoreCLR runtime and its test host
     # Trigger the test build so it will build but not run tests before we run them here
-    ${CoreRT_TestRoot}/../buildscripts/build-tests.sh buildtests
+    ${CoreRT_TestRoot}/../buildscripts/build-tests.sh ${CoreRT_BuildArch} ${CoreRT_BuildType} buildtests
     RestoreExitCode=$?
     if [ ${RestoreExitCode} != 0 ]; then
         echo Test build failed with code ${RestoreExitCode}
@@ -525,7 +525,7 @@ do
         fi
     fi
     if [ "${CoreRT_TestCompileMode}" = "readytorun" ] || [ "${CoreRT_TestCompileMode}" = "" ]; then
-        if [ -e `dirname ${csproj}`/readytorun_ ]; then
+        if [ -e `dirname ${csproj}`/readytorun ]; then
             run_test_dir ${csproj} "ReadyToRun"
         fi
     fi

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -443,7 +443,9 @@ if [ ${CoreRT_CrossBuild} != 0 ]; then
     CoreRT_ExtraLinkFlags="$CoreRT_ExtraLinkFlags $CoreRT_CrossLinkerFlags"
 fi
 
-CoreRT_CoreCLRRuntimeDir=${CoreRT_TestRoot}/../bin/obj/Linux.${CoreRT_BuildArch}.${CoreRT_BuildType}/CoreClrRuntime
+source "$CoreRT_TestRoot/testenv.sh"
+
+CoreRT_CoreCLRRuntimeDir=${CoreRT_TestRoot}/../bin/obj/${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}/CoreClrRuntime
 
 export CoreRT_CoreCLRRuntimeDir
 
@@ -457,8 +459,6 @@ if [ ! -d ${CoreRT_CoreCLRRuntimeDir} ]; then
         exit ${RestoreExitCode}
     fi
 fi
-
-source "$CoreRT_TestRoot/testenv.sh"
 
 __BuildStr=${CoreRT_BuildOS}.${CoreRT_BuildArch}.${CoreRT_BuildType}
 __CoreRTTestBinDir=${CoreRT_TestRoot}/../bin/tests

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -499,6 +499,8 @@ __JitTotalTests=0
 __JitPassedTests=0
 __WasmTotalTests=0
 __WasmPassedTests=0
+__ReadyToRunTotalTests=0
+__ReadyToRunPassedTests=0
 
 if [ ! -d ${__CoreRTTestBinDir} ]; then
     mkdir -p ${__CoreRTTestBinDir}
@@ -523,7 +525,7 @@ do
         fi
     fi
     if [ "${CoreRT_TestCompileMode}" = "readytorun" ] || [ "${CoreRT_TestCompileMode}" = "" ]; then
-        if [ -e `dirname ${csproj}`/readytorun_ ]; then
+        if [ -e `dirname ${csproj}`/readytorun ]; then
             run_test_dir ${csproj} "ReadyToRun"
         fi
     fi
@@ -534,8 +536,8 @@ do
     fi
 done
 
-__TotalTests=$((${__JitTotalTests} + ${__CppTotalTests} + ${__WasmTotalTests}))
-__PassedTests=$((${__JitPassedTests} + ${__CppPassedTests} + ${__WasmPassedTests}))
+__TotalTests=$((${__JitTotalTests} + ${__CppTotalTests} + ${__WasmTotalTests} + ${__ReadyToRunTotalTests}))
+__PassedTests=$((${__JitPassedTests} + ${__CppPassedTests} + ${__WasmPassedTests} + ${__ReadyToRunPassedTests}))
 __FailedTests=$((${__TotalTests} - ${__PassedTests}))
 
 if [ "$CoreRT_MultiFileConfiguration" = "MultiModule" ]; then
@@ -559,6 +561,7 @@ echo "</assemblies>"  >> ${__TestResultsLog}
 echo "JIT - TOTAL: ${__JitTotalTests} PASSED: ${__JitPassedTests}"
 echo "CPP - TOTAL: ${__CppTotalTests} PASSED: ${__CppPassedTests}"
 echo "WASM - TOTAL: ${__WasmTotalTests} PASSED: ${__WasmPassedTests}"
+echo "R2R - TOTAL: ${__ReadyToRunTotalTests} PASSED: ${__ReadyToRunPassedTests}"
 
 if [ ${__JitTotalTests} == 0 ] && [ "${CoreRT_TestCompileMode}" != "wasm" ]; then
     exit 1
@@ -566,18 +569,13 @@ fi
 if [ ${__CppTotalTests} == 0 ] && [ "${CoreRT_TestCompileMode}" != "wasm" ]; then
     exit 1
 fi
-if [ ${__WasmTotalTests} == 0 ] && [ "${CoreRT_TestCompileMode}" = "wasm" ]; then
+if [ ${__WasmTotalTests} == 0 ] && [ "${CoreRT_TestCompileMode}" == "wasm" ]; then
     exit 1
 fi 
-
-if [ ${__JitTotalTests} -gt ${__JitPassedTests} ]; then
+if [ $(__ReadyToRunTotalTests) == 0 ] && [ "${CoreRT_TestCompileMode}" == "readytorun" ]; then
     exit 1
 fi
-if [ ${__CppTotalTests} -gt ${__CppPassedTests} ]; then
+if [ ${__FailedTests} -gt 0 ]; then
     exit 1
 fi
-if [ ${__WasmTotalTests} -gt ${__WasmPassedTests} ]; then
-    exit 1
-fi
-
 exit 0

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -572,7 +572,7 @@ fi
 if [ ${__WasmTotalTests} == 0 ] && [ "${CoreRT_TestCompileMode}" == "wasm" ]; then
     exit 1
 fi 
-if [ $(__ReadyToRunTotalTests) == 0 ] && [ "${CoreRT_TestCompileMode}" == "readytorun" ]; then
+if [ ${__ReadyToRunTotalTests} == 0 ] && [ "${CoreRT_TestCompileMode}" == "readytorun" ]; then
     exit 1
 fi
 if [ ${__FailedTests} -gt 0 ]; then

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -525,7 +525,7 @@ do
         fi
     fi
     if [ "${CoreRT_TestCompileMode}" = "readytorun" ] || [ "${CoreRT_TestCompileMode}" = "" ]; then
-        if [ -e `dirname ${csproj}`/readytorun ]; then
+        if [ -e `dirname ${csproj}`/readytorun_ ]; then
             run_test_dir ${csproj} "ReadyToRun"
         fi
     fi


### PR DESCRIPTION
I found out that the R2R I was producing with CPAOT
was crashing in CoreCLR PAL during memory mapping and
it silently switched over to runtime JIT without any
indications of doing so.

The problem is that the relative offset of all section
start RVA's within a page must match the corresponding
file offsets. As PEBuilder doesn't support this logic,
I ended up copying a bunch of enumerations from the
related CoreFX code and I added logic to patch the
section headers manually. At some point we might want
to flow some of these changes back to the CoreFX repo.

I have also moved the machine OS override logic to
R2RPEBuilder for better encapsulation. As a side effect
of the TargetBuilder propagatioin I have fixed code
padding to select the proper instruction on all
architectures.

Thanks

Tomas