### PR TITLE
Enable devirtualization/stackalloc optimization with RyuJIT

### DIFF
--- a/src/Common/src/TypeSystem/Canon/MethodDelegator.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/MethodDelegator.Canon.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class MethodDelegator
+    {
+        public override bool IsCanonicalMethod(CanonicalFormKind policy)
+        {
+            return _wrappedMethod.IsCanonicalMethod(policy);
+        }
+
+        // For this method, delegating to the wrapped MethodDesc would likely be the wrong thing.
+        public abstract override MethodDesc GetCanonMethodTarget(CanonicalFormKind kind);
+    }
+}

--- a/src/Common/src/TypeSystem/CodeGen/MethodDelegator.CodeGen.cs
+++ b/src/Common/src/TypeSystem/CodeGen/MethodDelegator.CodeGen.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class MethodDelegator
+    {
+        public override bool IsIntrinsic
+        {
+            get
+            {
+                return _wrappedMethod.IsIntrinsic;
+            }
+        }
+
+        public override bool IsNoInlining
+        {
+            get
+            {
+                return _wrappedMethod.IsNoInlining;
+            }
+        }
+
+        public override bool IsAggressiveInlining
+        {
+            get
+            {
+                return _wrappedMethod.IsAggressiveInlining;
+            }
+        }
+
+        public override bool IsAggressiveOptimization
+        {
+            get
+            {
+                return _wrappedMethod.IsAggressiveOptimization;
+            }
+        }
+
+        public override bool IsNoOptimization
+        {
+            get
+            {
+                return _wrappedMethod.IsNoOptimization;
+            }
+        }
+
+        public override bool IsRuntimeImplemented
+        {
+            get
+            {
+                return _wrappedMethod.IsRuntimeImplemented;
+            }
+        }
+
+        public override bool IsInternalCall
+        {
+            get
+            {
+                return _wrappedMethod.IsInternalCall;
+            }
+        }
+
+        public override bool IsSynchronized
+        {
+            get
+            {
+                return _wrappedMethod.IsSynchronized;
+            }
+        }
+
+        public override bool IsNativeCallable
+        {
+            get
+            {
+                return _wrappedMethod.IsNativeCallable;
+            }
+        }
+
+        public override bool IsRuntimeExport
+        {
+            get
+            {
+                return _wrappedMethod.IsRuntimeExport;
+            }
+        }
+
+        public override bool IsSpecialName
+        {
+            get
+            {
+                return _wrappedMethod.IsSpecialName;
+            }
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/Common/MethodDelegator.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDelegator.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    /// <summary>
+    /// Wraps a <see cref="MethodDesc"/> object and delegates methods to that <see cref="MethodDesc"/>.
+    /// </summary>
+    public abstract partial class MethodDelegator : MethodDesc
+    {
+        protected readonly MethodDesc _wrappedMethod;
+
+        public MethodDelegator(MethodDesc wrappedMethod)
+        {
+            _wrappedMethod = wrappedMethod;
+        }
+
+        public override TypeSystemContext Context => _wrappedMethod.Context;
+
+        public override TypeDesc OwningType => _wrappedMethod.OwningType;
+
+        public override MethodSignature Signature => _wrappedMethod.Signature;
+
+        public override Instantiation Instantiation => _wrappedMethod.Instantiation;
+
+        public override bool IsDefaultConstructor => _wrappedMethod.IsDefaultConstructor;
+
+        public override string Name => _wrappedMethod.Name;
+
+        public override bool IsVirtual => _wrappedMethod.IsVirtual;
+
+        public override bool IsNewSlot => _wrappedMethod.IsNewSlot;
+
+        public override bool IsAbstract => _wrappedMethod.IsAbstract;
+
+        public override bool IsFinal => _wrappedMethod.IsFinal;
+
+        public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
+        {
+            return _wrappedMethod.HasCustomAttribute(attributeNamespace, attributeName);
+        }
+
+        // For this method, delegating to the wrapped MethodDesc would likely be the wrong thing.
+        public abstract override MethodDesc GetMethodDefinition();
+
+        // For this method, delegating to the wrapped MethodDesc would likely be the wrong thing.
+        public abstract override MethodDesc GetTypicalMethodDefinition();
+
+        // For this method, delegating to the wrapped MethodDesc would likely be the wrong thing.
+        public abstract override MethodDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation);
+    }
+}

--- a/src/Common/src/TypeSystem/Interop/MethodDelegator.Interop.cs
+++ b/src/Common/src/TypeSystem/Interop/MethodDelegator.Interop.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Internal.TypeSystem
+{
+    partial class MethodDelegator
+    {
+        public override bool IsPInvoke => _wrappedMethod.IsPInvoke;
+
+        public override PInvokeMetadata GetPInvokeMethodMetadata()
+        {
+            return _wrappedMethod.GetPInvokeMethodMetadata();
+        }
+
+        public override ParameterMetadata[] GetParameterMetadata()
+        {
+            return _wrappedMethod.GetParameterMetadata();
+        }
+    }
+}

--- a/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
+++ b/src/ILCompiler.ReadyToRun/src/ILCompiler.ReadyToRun.csproj
@@ -136,6 +136,9 @@
     <Compile Include="..\..\JitInterface\src\MemoryHelper.cs">
       <Link>JitInterface\MemoryHelper.cs</Link>
     </Compile>
+    <Compile Include="..\..\JitInterface\src\UnboxingMethodDesc.cs">
+      <Link>JitInterface\UnboxingMethodDesc.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" Condition="'$(IsProjectNLibrary)' != 'true'" />

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1200,11 +1200,18 @@ namespace Internal.JitInterface
                         if (pResult->thisTransform != CORINFO_THIS_TRANSFORM.CORINFO_NO_THIS_TRANSFORM)
                             pConstrainedResolvedToken = null;
 
+                        MethodDesc nonUnboxingMethod = methodToCall;
+                        bool isUnboxingStub = methodToCall.IsUnboxingThunk();
+                        if (isUnboxingStub)
+                        {
+                            nonUnboxingMethod = methodToCall.GetUnboxedMethod();
+                        }
+
                         // READYTORUN: FUTURE: Direct calls if possible
                         pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
-                            _compilation.NodeFactory.ImportedMethodNode(methodToCall, constrainedType, originalMethod,
+                            _compilation.NodeFactory.ImportedMethodNode(nonUnboxingMethod, constrainedType, originalMethod,
                             new ModuleToken(callerModule, pResolvedToken.token),
-                            isUnboxingStub: false,
+                            isUnboxingStub,
                             isInstantiatingStub: useInstantiatingStub,
                             GetSignatureContext()));
                     }

--- a/src/ILCompiler.RyuJit/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -36,6 +36,10 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
+            // MethodDesc that represents an unboxing thunk is a thing that is internal to the JitInterface.
+            // It should not leak out of JitInterface.
+            Debug.Assert(!Internal.JitInterface.UnboxingMethodDescExtensions.IsUnboxingThunk(method));
+
             if (CompilationModuleGroup.ContainsMethodBody(method, false))
             {
                 return new MethodCodeNode(method);

--- a/src/ILCompiler.RyuJit/src/ILCompiler.RyuJit.csproj
+++ b/src/ILCompiler.RyuJit/src/ILCompiler.RyuJit.csproj
@@ -70,6 +70,9 @@
     <Compile Include="..\..\JitInterface\src\MemoryHelper.cs">
       <Link>JitInterface\MemoryHelper.cs</Link>
     </Compile>
+    <Compile Include="..\..\JitInterface\src\UnboxingMethodDesc.cs">
+      <Link>JitInterface\UnboxingMethodDesc.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" Condition="'$(IsProjectNLibrary)' != 'true'" />

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -959,6 +959,16 @@ namespace Internal.JitInterface
             return CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_VC;
         }
 
+        private IMethodNode GetMethodEntrypoint(MethodDesc method)
+        {
+            bool isUnboxingThunk = method.IsUnboxingThunk();
+            if (isUnboxingThunk)
+            {
+                method = method.GetUnboxedMethod();
+            }
+            return _compilation.NodeFactory.MethodEntrypoint(method, isUnboxingThunk);
+        }
+
         private void getCallInfo(ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_RESOLVED_TOKEN* pConstrainedResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_CALLINFO_FLAGS flags, CORINFO_CALL_INFO* pResult)
         {
 #if DEBUG
@@ -1166,7 +1176,7 @@ namespace Internal.JitInterface
 
                     Debug.Assert(!forceUseRuntimeLookup);
                     pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
-                        _compilation.NodeFactory.MethodEntrypoint(targetMethod)
+                        GetMethodEntrypoint(targetMethod)
                         );
                 }
                 else
@@ -1189,7 +1199,7 @@ namespace Internal.JitInterface
                     }
 
                     pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
-                        _compilation.NodeFactory.MethodEntrypoint(targetMethod)
+                        GetMethodEntrypoint(targetMethod)
                         );
                 }
 

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -55,6 +55,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Canon\MetadataType.Canon.cs">
       <Link>TypeSystem\Canon\MetadataType.Canon.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Canon\MethodDelegator.Canon.cs">
+      <Link>TypeSystem\Canon\MethodDelegator.Canon.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Canon\MethodDesc.Canon.cs">
       <Link>TypeSystem\Canon\MethodDesc.Canon.cs</Link>
     </Compile>
@@ -78,6 +81,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\CodeGen\FieldDesc.CodeGen.cs">
       <Link>TypeSystem\CodeGen\FieldDesc.CodeGen.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\CodeGen\MethodDelegator.CodeGen.cs">
+      <Link>TypeSystem\CodeGen\MethodDelegator.CodeGen.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\CodeGen\MethodDesc.CodeGen.cs">
       <Link>TypeSystem\CodeGen\MethodDesc.CodeGen.cs</Link>
@@ -261,6 +267,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\VirtualMethodAlgorithm.cs">
       <Link>TypeSystem\Common\VirtualMethodAlgorithm.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDelegator.cs">
+      <Link>TypeSystem\Common\MethodDelegator.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDesc.cs">
       <Link>TypeSystem\Common\MethodDesc.cs</Link>
@@ -582,6 +591,9 @@
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Interop\MetadataType.Interop.cs">
       <Link>TypeSystem\Interop\MetadataType.Interop.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Interop\MethodDelegator.Interop.cs">
+      <Link>TypeSystem\Interop\MethodDelegator.Interop.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Interop\MethodDesc.Interop.cs">
       <Link>TypeSystem\Interop\MethodDesc.Interop.cs</Link>

--- a/src/JitInterface/src/UnboxingMethodDesc.cs
+++ b/src/JitInterface/src/UnboxingMethodDesc.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Internal.TypeSystem;
+
+namespace Internal.JitInterface
+{
+    /// <summary>
+    /// Represents the unboxing entrypoint of a valuetype instance method.
+    /// This class is for internal purposes within the JitInterface. It's not expected
+    /// for it to escape the JitInterface.
+    /// </summary>
+    internal class UnboxingMethodDesc : MethodDelegator
+    {
+        private readonly UnboxingMethodDescFactory _factory;
+
+        public MethodDesc Target => _wrappedMethod;
+
+        public UnboxingMethodDesc(MethodDesc wrappedMethod, UnboxingMethodDescFactory factory)
+            : base(wrappedMethod)
+        {
+            Debug.Assert(wrappedMethod.OwningType.IsValueType);
+            Debug.Assert(!wrappedMethod.Signature.IsStatic);
+            _factory = factory;
+        }
+
+        public override MethodDesc GetCanonMethodTarget(CanonicalFormKind kind)
+        {
+            MethodDesc realCanonTarget = _wrappedMethod.GetCanonMethodTarget(kind);
+            if (realCanonTarget != _wrappedMethod)
+                return _factory.GetUnboxingMethod(realCanonTarget);
+
+            return this;
+        }
+
+        public override MethodDesc GetMethodDefinition()
+        {
+            MethodDesc realMethodDefinition = _wrappedMethod.GetMethodDefinition();
+            if (realMethodDefinition != _wrappedMethod)
+                return _factory.GetUnboxingMethod(realMethodDefinition);
+
+            return this;
+        }
+
+        public override MethodDesc GetTypicalMethodDefinition()
+        {
+            MethodDesc realTypicalMethodDefinition = _wrappedMethod.GetTypicalMethodDefinition();
+            if (realTypicalMethodDefinition != _wrappedMethod)
+                return _factory.GetUnboxingMethod(realTypicalMethodDefinition);
+
+            return this;
+        }
+
+        public override MethodDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
+        {
+            MethodDesc realInstantiateSignature = _wrappedMethod.InstantiateSignature(typeInstantiation, methodInstantiation);
+            if (realInstantiateSignature != _wrappedMethod)
+                return _factory.GetUnboxingMethod(realInstantiateSignature);
+
+            return this;
+        }
+
+        public override string ToString()
+        {
+            return "Unboxing MethodDesc: " + _wrappedMethod.ToString();
+        }
+
+#if !SUPPORT_JIT
+        protected override int ClassCode => throw new NotImplementedException();
+
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        {
+            throw new NotImplementedException();
+        }
+#endif
+    }
+
+    internal class UnboxingMethodDescFactory : Dictionary<MethodDesc, UnboxingMethodDesc>
+    {
+        public UnboxingMethodDesc GetUnboxingMethod(MethodDesc method)
+        {
+            if (!TryGetValue(method, out UnboxingMethodDesc result))
+            {
+                result = new UnboxingMethodDesc(method, this);
+                Add(method, result);
+            }
+
+            return result;
+        }
+    }
+
+    internal static class UnboxingMethodDescExtensions
+    {
+        public static bool IsUnboxingThunk(this MethodDesc method)
+        {
+            return method is UnboxingMethodDesc;
+        }
+
+        public static MethodDesc GetUnboxedMethod(this MethodDesc method)
+        {
+            return ((UnboxingMethodDesc)method).Target;
+        }
+    }
+}

--- a/src/System.Private.Jit/src/System.Private.Jit.csproj
+++ b/src/System.Private.Jit/src/System.Private.Jit.csproj
@@ -152,6 +152,7 @@
     <Compile Include="$(JitInterfaceBasePath)\JitConfigProvider.cs" />
     <Compile Include="$(JitInterfaceBasePath)\MemoryHelper.cs" />
     <Compile Include="$(JitInterfaceBasePath)\TypeString.cs" />
+    <Compile Include="$(JitInterfaceBasePath)\UnboxingMethodDesc.cs" />
     <Compile Include="$(TypeLoaderBasePath)\Internal\TypeSystem\PInvokeTargetNativeMethod.Runtime.cs" />
     <Compile Include="Internal\Runtime\JitSupport\RyuJitExecutionStrategy.cs" />
     <Compile Include="Internal\Runtime\JitSupport\VirtualMethodSlotHelper.cs" />

--- a/src/System.Private.TypeLoader/src/Internal/TypeSystem/MethodDelegator.Runtime.cs
+++ b/src/System.Private.TypeLoader/src/Internal/TypeSystem/MethodDelegator.Runtime.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.Runtime.CompilerServices;
+
+namespace Internal.TypeSystem
+{
+    partial class MethodDelegator
+    {
+        public override MethodNameAndSignature NameAndSignature => _wrappedMethod.NameAndSignature;
+
+        public override bool IsNonSharableMethod => _wrappedMethod.IsNonSharableMethod;
+
+        public override bool UnboxingStub => _wrappedMethod.UnboxingStub;
+    }
+}

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -56,9 +56,14 @@
     <NativeFormatCommonPath>..\..\Common\src\Internal\NativeFormat</NativeFormatCommonPath>
   </PropertyGroup>
   <ItemGroup Condition="'$(DynamicCodeSupport)' == 'true'">
+    <Compile Include="Internal\TypeSystem\MethodDelegator.Runtime.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Common\MethodDelegator.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Canon\MethodDelegator.Canon.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\CodeGen\TypeDesc.CodeGen.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\CodeGen\FieldDesc.CodeGen.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\CodeGen\MethodDelegator.CodeGen.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\Ecma\EcmaField.CodeGen.cs" />
+    <Compile Include="..\..\Common\src\TypeSystem\Interop\MethodDelegator.Interop.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\NativeFormat\NativeFormatField.CodeGen.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ArrayType.RuntimeDetermined.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\RuntimeDetermined\ByRefType.RuntimeDetermined.cs" />


### PR DESCRIPTION
(Implementation for both CPAOT and full AOT, since the non-shared parts are just a couple lines)

We've had a TODO for a while that disabled devirtualization on valuetype methods because we didn't have a representation of unboxing thunks in the type system (the result of a devirtualization that lands on a valuetype method is an unboxing thunk).

With this, I'm adding an unboxing thunk `MethodDesc` _within the JitInterface only_. Unboxing thunks are weird enough that we don't want them to roam around the whole system, but if they're just something we hand to RyuJIT when needed and convert them back to the real thing when we're done, it's less of a trouble. I'm fully expecting that we're going to see these escaping into the dependency system from time to time, causing bugs. But that's life.

* Most of the commit is a general purpose `MethodDelegator` class that delegates calls to a different `MethodDesc`.
* We use the `MethodDelegator` within the JitInterface to create a wrapper for non-unboxing methods to represent an unboxing thunk.
* We make it so that the unboxing wrapper is returned from `resolveVirtualMethod` when the result of resolution is a valuetype method.
* We then make it possible for RyuJIT to unwrap it with `getUnboxedEntry`
* We also unwrap it in `getCallInfo` so that it doesn't get into the dependency system.

Fixes #7463.