### PR TITLE
Emit all symbols as global on Windows

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -862,9 +862,12 @@ namespace ILCompiler.DependencyAnalysis
                     AppendExternCPrefix(_sb);
                     name.AppendMangledName(_nodeFactory.NameMangler, _sb);
 
+                    // Emit all symbols as global on Windows because they matter only for the PDB.
                     // Emit all symbols as global in multifile builds so that object files can
                     // link against each other.
-                    EmitSymbolDef(_sb, global: !_isSingleFileCompilation);
+                    bool isGlobal = _nodeFactory.Target.IsWindows || !_isSingleFileCompilation;
+
+                    EmitSymbolDef(_sb, isGlobal);
 
                     string alternateName = _nodeFactory.GetSymbolAlternateName(name);
                     if (alternateName != null)


### PR DESCRIPTION
Symbols don't end up in the PDB otherwise and the only things with symbols are methods with debug information and things that have a non-null `_nodeFactory.GetSymbolAlternateName`.

This regressed in #7249.