### PR TITLE
CPAOT: token context cleanup in JIT interface

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -20,13 +20,6 @@ namespace ILCompiler
     public sealed class ReadyToRunCodegenCompilation : Compilation
     {
         /// <summary>
-        /// Map from method modules to the appropriate CorInfoImpl instantiations
-        /// used to propagate the module back to managed code as context for
-        /// reference token resolution.
-        /// </summary>
-        private readonly Dictionary<EcmaModule, CorInfoImpl> _corInfo;
-
-        /// <summary>
         /// JIT configuration provider.
         /// </summary>
         private readonly JitConfigProvider _jitConfigProvider;
@@ -35,6 +28,11 @@ namespace ILCompiler
         /// Name of the compilation input MSIL file.
         /// </summary>
         private readonly string _inputFilePath;
+
+        /// <summary>
+        /// JIT interface implementation.
+        /// </summary>
+        private readonly CorInfoImpl _corInfo;
 
         public new ReadyToRunCodegenNodeFactory NodeFactory { get; }
 
@@ -55,10 +53,10 @@ namespace ILCompiler
         {
             NodeFactory = nodeFactory;
             SymbolNodeFactory = new ReadyToRunSymbolNodeFactory(nodeFactory);
-            _corInfo = new Dictionary<EcmaModule, CorInfoImpl>();
             _jitConfigProvider = configProvider;
 
             _inputFilePath = inputFilePath;
+            _corInfo = new CorInfoImpl(this, _jitConfigProvider);
         }
 
         private static IEnumerable<ICompilationRootProvider> GetCompilationRoots(IEnumerable<ICompilationRootProvider> existingRoots, NodeFactory factory)
@@ -124,16 +122,7 @@ namespace ILCompiler
 
                 try
                 {
-                    EcmaModule module = ((EcmaMethod)method.GetTypicalMethodDefinition()).Module;
-
-                    CorInfoImpl perModuleCorInfo;
-                    if (!_corInfo.TryGetValue(module, out perModuleCorInfo))
-                    {
-                        perModuleCorInfo = new CorInfoImpl(this, module, _jitConfigProvider);
-                        _corInfo.Add(module, perModuleCorInfo);
-                    }
-
-                    perModuleCorInfo.CompileMethod(methodCodeNodeNeedingCode);
+                    _corInfo.CompileMethod(methodCodeNodeNeedingCode);
                 }
                 catch (TypeSystemException ex)
                 {


### PR DESCRIPTION
One of the remaining debts in CPAOT I noticed during my recent
investigations was the notion of input module token context. This
is just wrong in the presence of inlining as we may never presume
that a token originated in the input module. This simple change
changes token resolution to resolve token context modules based on
the token scope instead.

With this change we no longer need to create a dictionary of
per-module CorInfoImpl instances so that we can get by with just
a singleton; this is the gist of the additional cleanup in
ReadyToRunCodegenCompilation.

Thanks

Tomas