### PR TITLE
Avoid custom attributes when resolving lazy pinvokes

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -284,7 +284,10 @@ namespace Internal.Runtime.CompilerHelpers
                 // TODO: this should not actually throw yet: AssemblyLoadContext.ResolvingUnmanagedDll is
                 // a last chance callback we should call before giving up.
                 hModule = NativeLibrary.LoadLibraryByName(
-                    moduleName, callingAssembly, hasDllImportSearchPath ? (DllImportSearchPath?)dllImportSearchPath : null, true);
+                    moduleName,
+                    callingAssembly,
+                    hasDllImportSearchPath ? (DllImportSearchPath?)dllImportSearchPath : NativeLibrary.DefaultDllImportSearchPath,
+                    throwOnError: true);
             }
 
             Debug.Assert(hModule != IntPtr.Zero);

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.CoreRT.cs
@@ -40,21 +40,23 @@ namespace System.Runtime.InteropServices
             return ret;
         }
 
+        internal const DllImportSearchPath DefaultDllImportSearchPath = DllImportSearchPath.AssemblyDirectory;
+
         // TODO: make this into a reflection callback so that we can make this work when reflection is disabled.
         private static void GetDllImportSearchPathFlags(Assembly callingAssembly, out int searchPathFlags, out bool searchAssemblyDirectory)
         {
-            searchAssemblyDirectory = true;
-            searchPathFlags = 0;
+            DllImportSearchPath searchPath = DefaultDllImportSearchPath;
 
             foreach (CustomAttributeData cad in callingAssembly.CustomAttributes)
             {
                 if (cad.AttributeType == typeof(DefaultDllImportSearchPathsAttribute))
                 {
-                    var attributeValue = (DllImportSearchPath)cad.ConstructorArguments[0].Value;
-                    searchPathFlags = (int)(attributeValue & ~DllImportSearchPath.AssemblyDirectory);
-                    searchAssemblyDirectory = (attributeValue & DllImportSearchPath.AssemblyDirectory) != 0;
+                    searchPath = (DllImportSearchPath)cad.ConstructorArguments[0].Value;
                 }
             }
+
+            searchPathFlags = (int)(searchPath & ~DllImportSearchPath.AssemblyDirectory);
+            searchAssemblyDirectory = (searchPath & DllImportSearchPath.AssemblyDirectory) != 0;
         }
 
         private static IntPtr LoadLibraryModuleBySearch(Assembly callingAssembly, bool searchAssemblyDirectory, int dllImportSearchPathFlags, ref LoadLibErrorTracker errorTracker, string libraryName)


### PR DESCRIPTION
We already know the DllImportSearchPath wasn't specified in the assembly - no point in looking for the custom attribute.

The custom attribute lookup was failing when reflection is disabled.