### PR TITLE
Preparatory change for constrained call changes pt.1: MethodEntrypoint

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -96,7 +96,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public bool IsValueType() { if (_isByRef) return false; return _type.IsValueType; }
         public bool IsPointerType() { if (_isByRef) return false; return _type.IsPointer; }
 
-        public bool HasIndeterminateSize() { return IsValueType() && _type.GetElementSize().IsIndeterminate; }
+        public bool HasIndeterminateSize() { return IsValueType() && ((DefType)_type).InstanceFieldSize.IsIndeterminate; }
 
         public int PointerSize => _type.Context.Target.PointerSize;
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -96,6 +96,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public bool IsValueType() { if (_isByRef) return false; return _type.IsValueType; }
         public bool IsPointerType() { if (_isByRef) return false; return _type.IsPointer; }
 
+        public bool HasIndeterminateSize() { return IsValueType() && _type.GetElementSize().IsIndeterminate; }
+
         public int PointerSize => _type.Context.Target.PointerSize;
 
         public int GetSize()
@@ -538,6 +540,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private bool[] _forcedByRefParams;
         private bool _skipFirstArg;
         private bool _extraObjectFirstArg;
+        private bool _hasIndeterminateSize;
         private CallingConventions _interpreterCallingConvention;
 
         public bool HasThis => _hasThis;
@@ -644,6 +647,19 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
 
             return (int)size;
+        }
+
+        /// <summary>
+        /// Returns true when the signature contains runtime-dependent constructs like Vector of T.
+        /// </summary>
+        /// <returns>true = signature depends on runtime processor extensions, false = can be evaluated at compile time</returns>
+        public bool HasIndeterminateSize()
+        {
+            if (!_SIZE_OF_ARG_STACK_COMPUTED)
+            {
+                ForceSigWalk();
+            }
+            return _hasIndeterminateSize;
         }
 
         //------------------------------------------------------------------------
@@ -922,7 +938,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 _ITERATION_STARTED = true;
             }
 
-            if (_argNum >= NumFixedArgs)
+            if (_argNum >= NumFixedArgs || _hasIndeterminateSize)
                 return TransitionBlock.InvalidOffset;
 
             CorElementType argType = GetArgumentType(_argNum, out _argTypeHandle, out _argForceByRef);
@@ -930,6 +946,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _argTypeHandleOfByRefParam = (argType == CorElementType.ELEMENT_TYPE_BYREF ? _argData.GetByRefArgumentType(_argNum) : default(TypeHandle));
 
             _argNum++;
+
+            if (_argTypeHandle.HasIndeterminateSize())
+            {
+                _hasIndeterminateSize = true;
+                return TransitionBlock.InvalidOffset;
+            }
 
             int argSize = TypeHandle.GetElemSize(argType, _argTypeHandle);
 
@@ -1397,11 +1419,21 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     TypeHandle thArgType;
                     bool argForcedToBeByref;
                     CorElementType type = GetArgumentType(i, out thArgType, out argForcedToBeByref);
+                    if (thArgType.HasIndeterminateSize())
+                    {
+                        _hasIndeterminateSize = true;
+                        break;
+                    }
                     if (argForcedToBeByref)
                         type = CorElementType.ELEMENT_TYPE_BYREF;
 
                     if (!_transitionBlock.IsArgumentInRegister(ref numRegistersUsed, type, thArgType))
                     {
+                        if (thArgType.HasIndeterminateSize())
+                        {
+                            _hasIndeterminateSize = true;
+                            break;
+                        }
                         int structSize = TypeHandle.GetElemSize(type, thArgType);
 
                         nSizeOfArgStack += _transitionBlock.StackElemSize(structSize);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
@@ -68,7 +68,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 // Require compilation of the canonical version for instantiating stubs
                 MethodDesc canonMethod = _method.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
                 ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
-                ISymbolNode canonMethodNode = r2rFactory.ImportedMethodNode(
+                ISymbolNode canonMethodNode = r2rFactory.MethodEntrypoint(
                     canonMethod,
                     constrainedType: null,
                     originalMethod: canonMethod,

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -96,6 +96,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 skipFirstArg,
                 extraObjectFirstArg);
 
+            if (argit.HasIndeterminateSize())
+            {
+                // Flush an empty GC ref map block so that the list of methods remains in sync with the list of GC ref map records
+                Flush();
+                return;
+            }
+
             int nStackBytes = argit.SizeOfFrameArgumentArray();
 
             // Allocate a fake stack

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -75,7 +75,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             method = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
 
             if (_compilationModuleGroup.VersionsWithMethodBody(method) &&
-                method is EcmaMethod ecmaMethod)
+                method.GetTypicalMethodDefinition() is EcmaMethod ecmaMethod)
             {
                 return new ModuleToken(ecmaMethod.Module, ecmaMethod.Handle);
             }

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1206,7 +1206,7 @@ namespace Internal.JitInterface
 
                         // READYTORUN: FUTURE: Direct calls if possible
                         pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
-                            _compilation.NodeFactory.ImportedMethodNode(nonUnboxingMethod, constrainedType, originalMethod,
+                            _compilation.NodeFactory.MethodEntrypoint(nonUnboxingMethod, constrainedType, originalMethod,
                             new ModuleToken(callerModule, pResolvedToken.token),
                             isUnboxingStub,
                             isInstantiatingStub: useInstantiatingStub,


### PR DESCRIPTION
This is one of the problems I uncovered during the constrained call
work and I believe it merits separate treatment. Historically
the implementation of MethodEntrypoint was naturally one of the
oldest CPAOT bits and we had to iterate on its exact functionality.

The pre-existing version prior to this change had one strange aspect -
somewhat ambiguous blurring of functionality between MethodEntrypoint
and ImportedMethodNode. This led to various weird situations including
unintended direct method calls, infinite recursion when conditions
in two methods didn't exactly match and similar fun.

I have cleaned this mess up by basically moving the pre-existing
functionality of ImportedMethodNode to MethodEntrypoint that has become
the only API dealing with creation of import cells used for calling
methods. The two flavors of import cells being created are
ExternalMethodImport and LocalMethodImport where the only difference
between them is that LocalMethodImport brings in the dependency to the
MethodWithGCInfo for the method and triggers its JIT compilation
(which may fail when the method requires runtime JIT).

I have added graceful handling for indeterminate signatures to
ArgIterator because the code graph changes triggered this in one
of the ASP.NET assemblies and it's nice to have in general.

Thanks

Tomas