### PR TITLE
Add support for GetManifestResourceInfo

### DIFF
--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.ManifestResources.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.ManifestResources.cs
@@ -23,7 +23,15 @@ namespace Internal.Reflection.Execution
     {
         public sealed override ManifestResourceInfo GetManifestResourceInfo(Assembly assembly, String resourceName)
         {
-            throw new PlatformNotSupportedException();
+            LowLevelList<ResourceInfo> resourceInfos = GetExtractedResources(assembly);
+            for (int i = 0; i < resourceInfos.Count; i++)
+            {
+                if (resourceName == resourceInfos[i].Name)
+                {
+                    return new ManifestResourceInfo(assembly, resourceName, ResourceLocation.Embedded);
+                }
+            }
+            return null;
         }
 
         public sealed override String[] GetManifestResourceNames(Assembly assembly)


### PR DESCRIPTION
This just adds an implementation for `Assembly.GetManifestResourceInfo` along the lines of its sibling methods, which will allow https://github.com/aspnet/Extensions/blob/master/src/FileProviders/Embedded/src/EmbeddedFileProvider.cs from [Microsoft.Extensions.FileProviders.Embedded](https://www.nuget.org/packages/Microsoft.Extensions.FileProviders.Embedded) to work.

Some questions:

- This always returns a `ResourceLocation.Embedded` - is this always true?
- The file makes mention of `WinRTInterop`, and includes ifdefs for WinRT support, however: https://github.com/dotnet/corert/issues/823#issuecomment-315557621 , wut?
- I attempted to add a test case for Embedded Resources as a whole, however it seems the way the test projects invoke the toolchain causes them to not link embedded resources, however it works when following the steps in https://github.com/dotnet/corert/blob/master/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md - any way to make this work?