### PR TITLE
Constrained calls pt. 2 - actually add constrained type to MethodWithToken

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
@@ -69,9 +69,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 MethodDesc canonMethod = _method.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
                 ReadyToRunCodegenNodeFactory r2rFactory = (ReadyToRunCodegenNodeFactory)factory;
                 ISymbolNode canonMethodNode = r2rFactory.MethodEntrypoint(
-                    canonMethod,
-                    constrainedType: null,
-                    methodToken: _method.Token,
+                    new MethodWithToken(canonMethod, _method.Token, constrainedType: null),
                     isUnboxingStub: false,
                     isInstantiatingStub: false,
                     signatureContext: _signatureContext);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
@@ -71,7 +71,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 ISymbolNode canonMethodNode = r2rFactory.MethodEntrypoint(
                     canonMethod,
                     constrainedType: null,
-                    originalMethod: canonMethod,
                     methodToken: _method.Token,
                     isUnboxingStub: false,
                     isInstantiatingStub: false,

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 
 using Internal.TypeSystem;
 
+using Internal.JitInterface;
 using Internal.Text;
 using ILCompiler.DependencyAnalysisFramework;
 
@@ -47,9 +48,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 SignatureContext innerContext = builder.EmitFixup(r2rFactory, ReadyToRunFixupKind.READYTORUN_FIXUP_DelegateCtor, _methodToken.Module, _signatureContext);
 
                 builder.EmitMethodSignature(
-                    _targetMethod.Method, 
-                    constrainedType: null,
-                    methodToken: _methodToken,
+                    new MethodWithToken(_targetMethod.Method, _methodToken, constrainedType: null),
                     enforceDefEncoding: false,
                     innerContext,
                     isUnboxingStub: false,

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ExternalMethodImport.cs
@@ -3,24 +3,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using Internal.Text;
+using Internal.JitInterface;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     public class ExternalMethodImport : DelayLoadHelperImport, IMethodNode
     {
-        private readonly MethodDesc _methodDesc;
+        private readonly MethodWithToken _method;
 
         private readonly SignatureContext _signatureContext;
 
         public ExternalMethodImport(
             ReadyToRunCodegenNodeFactory factory,
             ReadyToRunFixupKind fixupKind,
-            MethodDesc methodDesc,
-            TypeDesc constrainedType,
-            ModuleToken methodToken,
+            MethodWithToken method,
             bool isUnboxingStub,
             bool isInstantiatingStub,
             SignatureContext signatureContext)
@@ -30,18 +27,16 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                   ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_MethodCall,
                   factory.MethodSignature(
                       fixupKind,
-                      methodDesc,
-                      constrainedType,
-                      methodToken,
+                      method,
                       isUnboxingStub,
                       isInstantiatingStub,
                       signatureContext))
         {
-            _methodDesc = methodDesc;
+            _method = method;
             _signatureContext = signatureContext;
         }
 
-        public MethodDesc Method => _methodDesc;
+        public MethodDesc Method => _method.Method;
 
         public override int ClassCode => 458823351;
     }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -112,9 +112,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (_methodArgument != null)
             {
                 dataBuilder.EmitMethodSignature(
-                    method: _methodArgument.Method,
-                    constrainedType: _typeArgument,
-                    methodToken: _methodArgument.Token,
+                    _methodArgument,
                     enforceDefEncoding: false,
                     context: innerContext,
                     isUnboxingStub: false,

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection.Metadata.Ecma335;
 
+using Internal.JitInterface;
 using Internal.NativeFormat;
 using Internal.Runtime;
 using Internal.Text;
@@ -61,9 +62,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                     ArraySignatureBuilder signatureBuilder = new ArraySignatureBuilder();
                     signatureBuilder.EmitMethodSignature(
-                        method.Method, 
-                        constrainedType: null,
-                        moduleToken,
+                        new MethodWithToken(method.Method, moduleToken, constrainedType: null),
                         enforceDefEncoding: true,
                         method.SignatureContext,
                         isUnboxingStub: false, 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/LocalMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/LocalMethodImport.cs
@@ -31,9 +31,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                   ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_MethodCall,
                   factory.MethodSignature(
                       fixupKind,
-                      method.Method,
-                      constrainedType: null,
-                      methodToken: method.Token,
+                      method,
                       isUnboxingStub,
                       isInstantiatingStub,
                       signatureContext))

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -110,30 +110,28 @@ namespace ILCompiler.DependencyAnalysis
             bool isInstantiatingStub,
             SignatureContext signatureContext)
         {
-            bool isLocalMethod = CompilationModuleGroup.ContainsMethodBody(method.Method, false);
-
             IMethodNode methodImport;
             TypeAndMethod key = new TypeAndMethod(method.ConstrainedType, method, isUnboxingStub, isInstantiatingStub);
             if (!_importMethods.TryGetValue(key, out methodImport))
             {
-                if (!isLocalMethod)
-                {
-                    // First time we see a given external method - emit indirection cell and the import entry
-                    methodImport = new ExternalMethodImport(
-                        this,
-                        ReadyToRunFixupKind.READYTORUN_FIXUP_MethodEntry,
-                        method,
-                        isUnboxingStub,
-                        isInstantiatingStub,
-                        signatureContext);
-                }
-                else
+                if (CompilationModuleGroup.ContainsMethodBody(method.Method, false))
                 {
                     methodImport = new LocalMethodImport(
                         this,
                         ReadyToRunFixupKind.READYTORUN_FIXUP_MethodEntry,
                         method,
                         CreateMethodEntrypointNode(method, isUnboxingStub, isInstantiatingStub, signatureContext),
+                        isUnboxingStub,
+                        isInstantiatingStub,
+                        signatureContext);
+                }
+                else
+                {
+                    // First time we see a given external method - emit indirection cell and the import entry
+                    methodImport = new ExternalMethodImport(
+                        this,
+                        ReadyToRunFixupKind.READYTORUN_FIXUP_MethodEntry,
+                        method,
                         isUnboxingStub,
                         isInstantiatingStub,
                         signatureContext);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/TypeAndMethod.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/TypeAndMethod.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+
+using Internal.JitInterface;
 using Internal.TypeSystem;
 
 using ILCompiler.DependencyAnalysis.ReadyToRun;
@@ -12,16 +14,14 @@ namespace ILCompiler.DependencyAnalysis
     internal struct TypeAndMethod : IEquatable<TypeAndMethod>
     {
         public readonly TypeDesc Type;
-        public readonly MethodDesc Method;
-        public readonly ModuleToken MethodToken;
+        public readonly MethodWithToken Method;
         public readonly bool IsUnboxingStub;
         public readonly bool IsInstantiatingStub;
 
-        public TypeAndMethod(TypeDesc type, MethodDesc method, ModuleToken methodToken, bool isUnboxingStub, bool isInstantiatingStub)
+        public TypeAndMethod(TypeDesc type, MethodWithToken method, bool isUnboxingStub, bool isInstantiatingStub)
         {
             Type = type;
             Method = method;
-            MethodToken = methodToken;
             IsUnboxingStub = isUnboxingStub;
             IsInstantiatingStub = isInstantiatingStub;
         }
@@ -29,8 +29,7 @@ namespace ILCompiler.DependencyAnalysis
         public bool Equals(TypeAndMethod other)
         {
             return Type == other.Type &&
-                   Method == other.Method &&
-                   MethodToken.Equals(other.MethodToken) &&
+                   Method.Equals(other.Method) &&
                    IsUnboxingStub == other.IsUnboxingStub &&
                    IsInstantiatingStub == other.IsInstantiatingStub;
         }
@@ -43,7 +42,7 @@ namespace ILCompiler.DependencyAnalysis
         public override int GetHashCode()
         {
             return (Type?.GetHashCode() ?? 0) ^ 
-                unchecked(Method.GetHashCode() * 31  + MethodToken.GetHashCode() * 97) ^ 
+                unchecked(Method.GetHashCode() * 31) ^ 
                 (IsUnboxingStub ? -0x80000000 : 0) ^ 
                 (IsInstantiatingStub ? 0x40000000 : 0);
         }

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -295,12 +295,12 @@ namespace Internal.JitInterface
                 MemoryHelper.FillMemory((byte*)tmp, 0xcc, sizeof(CORINFO_LOOKUP));
 #endif
 
-            MethodDesc targetMethod = HandleToObject(pTargetMethod.hMethod);
             TypeDesc delegateTypeDesc = HandleToObject(delegateType);
+            MethodWithToken targetMethod = new MethodWithToken(HandleToObject(pTargetMethod.hMethod), HandleToModuleToken(ref pTargetMethod), constrainedType: null);
 
             pLookup.lookupKind.needsRuntimeLookup = false;
             pLookup.constLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.DelegateCtor(
-                    delegateTypeDesc, targetMethod, HandleToModuleToken(ref pTargetMethod), GetSignatureContext()));
+                    delegateTypeDesc, targetMethod, GetSignatureContext()));
         }
 
         private ISymbolNode GetHelperFtnUncached(CorInfoHelpFunc ftnNum)
@@ -1219,11 +1219,11 @@ namespace Internal.JitInterface
 
                         // READYTORUN: FUTURE: Direct calls if possible
                         pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
-                            _compilation.NodeFactory.MethodEntrypoint(nonUnboxingMethod, constrainedType,
-                            HandleToModuleToken(ref pResolvedToken),
-                            isUnboxingStub,
-                            isInstantiatingStub: useInstantiatingStub,
-                            GetSignatureContext()));
+                            _compilation.NodeFactory.MethodEntrypoint(
+                                new MethodWithToken(nonUnboxingMethod, HandleToModuleToken(ref pResolvedToken), constrainedType),
+                                isUnboxingStub,
+                                isInstantiatingStub: useInstantiatingStub,
+                                GetSignatureContext()));
                     }
                     break;
 


### PR DESCRIPTION
This change modifies MethodWithToken to optionally include the constrained type information and changes most places in the CPAOT compiler that were previously passing the separated triplet of MethodDesc / ModuleToken / TypeDesc to use the newly beefed up MethodWithToken.

As additional changes of note I removed the "originalMethod" parameter to MethodEntrypoint as it was almost unused and I deleted an orphaned method MethodGenericDictionary. I have decided to keep this change mostly mechanical to make git history cleaner.

Thanks

Tomas
