### PR TITLE
Unify GC sources and implement GetGCMemoryInfo

### DIFF
--- a/src/Native/Runtime/GCHelpers.cpp
+++ b/src/Native/Runtime/GCHelpers.cpp
@@ -213,3 +213,10 @@ COOP_PINVOKE_HELPER(Int64, RhGetAllocatedBytesForCurrentThread, ())
     Int64 currentAllocated = ac->alloc_bytes + ac->alloc_bytes_loh - (ac->alloc_limit - ac->alloc_ptr);
     return currentAllocated;
 }
+
+COOP_PINVOKE_HELPER(void, RhGetMemoryInfo, (UInt32* highMemLoadThreshold, UInt64* totalPhysicalMem, UInt32* lastRecordedMemLoad, size_t* lastRecordedHeapSize, size_t* lastRecordedFragmentation))
+{
+    return GCHeapUtilities::GetGCHeap()->GetMemoryInfo(highMemLoadThreshold, totalPhysicalMem,
+                                                       lastRecordedMemLoad,
+                                                       lastRecordedHeapSize, lastRecordedFragmentation);
+}

--- a/src/Native/gc/gc.cpp
+++ b/src/Native/gc/gc.cpp
@@ -3096,15 +3096,15 @@ void gc_heap::fire_pevents()
     settings.record (&gc_data_global);
     gc_data_global.print();
 
-    FIRE_EVENT(GCGlobalHeapHistory_V2,
-        gc_data_global.final_youngest_desired,
-        gc_data_global.num_heaps,
-        gc_data_global.condemned_generation,
-        gc_data_global.gen0_reduction_count,
-        gc_data_global.reason,
-        gc_data_global.global_mechanisms_p,
-        gc_data_global.pause_mode,
-        gc_data_global.mem_pressure);
+    FIRE_EVENT(GCGlobalHeapHistory_V2, 
+               gc_data_global.final_youngest_desired, 
+               gc_data_global.num_heaps, 
+               gc_data_global.condemned_generation, 
+               gc_data_global.gen0_reduction_count, 
+               gc_data_global.reason, 
+               gc_data_global.global_mechanisms_p, 
+               gc_data_global.pause_mode, 
+               gc_data_global.mem_pressure);
 
 #ifdef MULTIPLE_HEAPS
     for (int i = 0; i < gc_heap::n_heaps; i++)
@@ -5039,32 +5039,14 @@ extern "C" uint64_t __rdtsc();
 #else // _MSC_VER
     extern "C" ptrdiff_t get_cycle_count(void);
 #endif // _MSC_VER
-#elif defined(_TARGET_ARM_)
+#else
     static ptrdiff_t get_cycle_count()
     {
-        // @ARMTODO: cycle counter is not exposed to user mode by CoreARM. For now (until we can show this
-        // makes a difference on the ARM configurations on which we'll run) just return 0. This will result in
-        // all buffer access times being reported as equal in access_time().
-        return 0;
-    }
-#elif defined(_TARGET_ARM64_)
-    static ptrdiff_t get_cycle_count()
-    {
-        // @ARM64TODO: cycle counter is not exposed to user mode by CoreARM. For now (until we can show this
-        // makes a difference on the ARM configurations on which we'll run) just return 0. This will result in
-        // all buffer access times being reported as equal in access_time().
-        return 0;
-    }
-#elif defined(_TARGET_WASM_)
-    static ptrdiff_t get_cycle_count()
-    {
-        // @WASMTODO: cycle counter is not exposed to user mode by WebAssembly. For now (until we can show this
+        // @ARMTODO, @ARM64TODO, @WASMTODO: cycle counter is not exposed to user mode. For now (until we can show this
         // makes a difference on the configurations on which we'll run) just return 0. This will result in
         // all buffer access times being reported as equal in access_time().
         return 0;
     }
-#else
-#error NYI platform: get_cycle_count
 #endif //_TARGET_X86_
 
 class heap_select
@@ -16279,7 +16261,7 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
     }
 
     int soh_align_const = get_alignment_constant (TRUE);
-    size_t max_soh_allocated = (soh_segment_size - segment_info_size - eph_gen_starts_size);
+    size_t max_soh_allocated = soh_segment_size - segment_info_size - eph_gen_starts_size;
     size_t size_per_heap = 0;
     const double scale_factor = 1.05;
 
@@ -35224,11 +35206,11 @@ GCHeap::GetContainingObject (void *pInteriorPtr, bool fCollectedGenOnly)
     gc_heap* hp = gc_heap::heap_of (o);
 
     uint8_t* lowest = (fCollectedGenOnly ? hp->gc_low : hp->lowest_address);
-    uint8_t * highest = (fCollectedGenOnly ? hp->gc_high : hp->highest_address);
+    uint8_t* highest = (fCollectedGenOnly ? hp->gc_high : hp->highest_address);
 
     if (o >= lowest && o < highest)
     {
-        o = hp->find_object(o, lowest);
+        o = hp->find_object (o, lowest);
     }
     else
     {

--- a/src/Native/gc/gcinterface.dac.h
+++ b/src/Native/gc/gcinterface.dac.h
@@ -11,7 +11,6 @@
 //      GC-internal type's fields, while still maintaining the same layout.
 // This interface is strictly versioned, see gcinterface.dacvars.def for more information.
 
-#define HEAP_SEGMENT_FLAGS_READONLY     1
 #define NUM_GC_DATA_POINTS              9
 #define MAX_COMPACT_REASONS_COUNT       11
 #define MAX_EXPAND_MECHANISMS_COUNT     6

--- a/src/Native/gc/sample/GCSample.vcxproj
+++ b/src/Native/gc/sample/GCSample.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">

--- a/src/Native/gc/sample/GCSample.vcxproj.filters
+++ b/src/Native/gc/sample/GCSample.vcxproj.filters
@@ -1,4 +1,5 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
       <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>

--- a/src/System.Private.CoreLib/src/System/GC.cs
+++ b/src/System.Private.CoreLib/src/System/GC.cs
@@ -640,8 +640,17 @@ namespace System
 
         public static GCMemoryInfo GetGCMemoryInfo()
         {
-            // TODO: https://github.com/dotnet/corert/issues/5680
-            return default;
+            RuntimeImports.RhGetMemoryInfo(out uint highMemLoadThreshold,
+                                           out ulong totalPhysicalMem,
+                                           out uint lastRecordedMemLoad,
+                                           out UIntPtr lastRecordedHeapSize,
+                                           out UIntPtr lastRecordedFragmentation);
+
+            return new GCMemoryInfo((long)((double)highMemLoadThreshold / 100 * totalPhysicalMem),
+                                    (long)((double)lastRecordedMemLoad / 100 * totalPhysicalMem),
+                                    (long)totalPhysicalMem,
+                                    (long)(ulong)lastRecordedHeapSize,
+                                    (long)(ulong)lastRecordedFragmentation);
         }
 
         internal static ulong GetSegmentSize()

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -197,6 +197,15 @@ namespace System.Runtime
         internal static extern long RhGetAllocatedBytesForCurrentThread();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhGetMemoryInfo")]
+        internal static extern void RhGetMemoryInfo(out uint highMemLoadThreshold,
+                                                    out ulong totalPhysicalMem,
+                                                    out uint lastRecordedMemLoad,
+                                                    // The next two are size_t
+                                                    out UIntPtr lastRecordedHeapSize,
+                                                    out UIntPtr lastRecordedFragmentation);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhCompareObjectContentsAndPadding")]
         internal extern static bool RhCompareObjectContentsAndPadding(object obj1, object obj2);
 


### PR DESCRIPTION
The first commit copies everything from coreclr (mainly formatting differences).

The second commit implements `GC.GetGCMemoryInfo` for #5680.
I don't know how to test it though, the simple tests in corert yield
> 'GC' does not contain a definition for 'GetGCMemoryInfo'

and the [instructions](https://github.com/dotnet/corert/blob/master/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md#compiling-source-to-native-code-using-the-ilcompiler-you-built) are failing for me because
> error MSB4064: The "DotNetAppHostExecutableName" parameter is not supported by the "ComputeManagedAssemblies" task. Verify the parameter exists on the task, and it is a settable public instance property