### PR TITLE
Fix build with clang on Alpine Linux

### DIFF
--- a/src/Native/gen-buildsys-clang.sh
+++ b/src/Native/gen-buildsys-clang.sh
@@ -15,15 +15,15 @@ then
 fi
 
 # Set up the environment to be used for building with clang.
-if command -v "clang-$2.$3" > /dev/null 2>&1
+if command -v "clang-$2.$3" > /dev/null 2>&1 && command -v "clang++-$2.$3" > /dev/null 2>&1
     then
         export CC="$(command -v clang-$2.$3)"
         export CXX="$(command -v clang++-$2.$3)"
-elif command -v "clang$2$3" > /dev/null 2>&1
+elif command -v "clang$2$3" > /dev/null 2>&1 && command -v "clang++$2$3" > /dev/null 2>&1
     then
         export CC="$(command -v clang$2$3)"
         export CXX="$(command -v clang++$2$3)"
-elif command -v clang > /dev/null 2>&1
+elif command -v clang > /dev/null 2>&1 && command -v clang++ > /dev/null 2>&1
     then
         export CC="$(command -v clang)"
         export CXX="$(command -v clang++)"


### PR DESCRIPTION
On Alpine Linux (and some other Linuxes as well), there versioned
file name for clang exists only for clang and not clang++. So
there is e.g. clang-5.0, clang and clang++. This makes build to
pick only the C compiler, but leaves the C++ unspecified, so
cmake picks g++ and the build fails.

This change fixes it by ensuring that we pick both clang and clang++
either unversioned or versioned.