### PR TITLE
Fix CharSet on GetProcAddress

### DIFF
--- a/src/Common/src/Interop/Windows/Mincore/Interop.DynamicLoad.cs
+++ b/src/Common/src/Interop/Windows/Mincore/Interop.DynamicLoad.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
         [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll")]
         internal static extern IntPtr GetProcAddress(IntPtr hModule, byte* lpProcName);
 
-        [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll", CharSet = CharSet.Unicode)]
+        [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll", CharSet = CharSet.Ansi)]
         internal static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
 
         [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll", EntryPoint = "LoadLibraryExW", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/src/Common/src/Interop/Windows/Mincore/Interop.DynamicLoad.cs
+++ b/src/Common/src/Interop/Windows/Mincore/Interop.DynamicLoad.cs
@@ -14,9 +14,6 @@ internal static partial class Interop
         [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll")]
         internal static extern IntPtr GetProcAddress(IntPtr hModule, byte* lpProcName);
 
-        [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll", CharSet = CharSet.Ansi)]
-        internal static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
-
         [DllImport("api-ms-win-core-libraryloader-l1-2-0.dll", EntryPoint = "LoadLibraryExW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hFile, int dwFlags);
 


### PR DESCRIPTION
This flavor is used in NativeLibrary.GetSymbol so we didn't hit this before.