### PR TITLE
Implement generation of function pointer metadata

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -97,7 +97,11 @@ namespace ILCompiler.DependencyAnalysis
                     GetMetadataDependencies(ref dependencies, nodeFactory, ((ParameterizedType)type).ParameterType, reason);
                     break;
                 case TypeFlags.FunctionPointer:
-                    throw new NotImplementedException();
+                    var pointerType = (FunctionPointerType)type;
+                    GetMetadataDependencies(ref dependencies, nodeFactory, pointerType.Signature.ReturnType, reason);
+                    foreach (TypeDesc paramType in pointerType.Signature)
+                        GetMetadataDependencies(ref dependencies, nodeFactory, paramType, reason);
+                    break;
 
                 case TypeFlags.SignatureMethodVariable:
                 case TypeFlags.SignatureTypeVariable:


### PR DESCRIPTION
Hit this while accidentally compiling WPF, but might as well just implement this.