### PR TITLE
Scan for `Marshal.SizeOf(Type)` usage

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionMethodBodyScanner.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionMethodBodyScanner.cs
@@ -157,6 +157,28 @@ namespace ILCompiler.DependencyAnalysis
                         }
                     }
                     break;
+                case "SizeOf" when methodCalled.OwningType.IsSystemRuntimeInteropServicesMarshal() && !methodCalled.HasInstantiation
+                    && methodCalled.Signature.Length == 1 && methodCalled.Signature[0].IsSystemType():
+                    {
+                        TypeDesc type = tracker.GetLastType();
+                        if (type != null && !type.IsGenericDefinition && !type.IsCanonicalSubtype(CanonicalFormKind.Any))
+                        {
+                            list = list ?? new DependencyList();
+
+                            MethodDesc marshalSizeOfGeneric = methodCalled.OwningType.GetKnownMethod(
+                                "SizeOf", new MethodSignature(MethodSignatureFlags.Static, 1, methodCalled.Context.GetWellKnownType(WellKnownType.Int32), TypeDesc.EmptyTypes));
+                            marshalSizeOfGeneric = marshalSizeOfGeneric.MakeInstantiatedMethod(type);
+
+                            // InteropManager is looking for the following method bodies or dictionaries to decide marshalling info need.
+                            // We should ideally model these as separate entities in the dependency graph and add those entities instead.
+                            // Fixable after https://github.com/dotnet/corert/issues/6063 is fixed.
+                            if (marshalSizeOfGeneric.GetCanonMethodTarget(CanonicalFormKind.Specific) != marshalSizeOfGeneric)
+                                list.Add(factory.MethodGenericDictionary(marshalSizeOfGeneric), "Marshal.SizeOf");
+                            else
+                                list.Add(factory.MethodEntrypoint(marshalSizeOfGeneric), "Marshal.SizeOf");
+                        }
+                    }
+                    break;
             }
         }
 
@@ -255,6 +277,14 @@ namespace ILCompiler.DependencyAnalysis
             return type is MetadataType mdType &&
                 mdType.Name == "Type" &&
                 mdType.Namespace == "System" &&
+                mdType.Module == type.Context.SystemModule;
+        }
+
+        private static bool IsSystemRuntimeInteropServicesMarshal(this TypeDesc type)
+        {
+            return type is MetadataType mdType &&
+                mdType.Name == "Marshal" &&
+                mdType.Namespace == "System.Runtime.InteropServices" &&
                 mdType.Module == type.Context.SystemModule;
         }
 


### PR DESCRIPTION
WinForms codebase is full of this pattern and there's no reason we couldn't misuse the reflection method body scanner to scan for this too.