### PR TITLE
Initial support for R2RDump in SuperIlc

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -611,13 +611,14 @@ namespace ReadyToRun.SuperIlc
         private void WritePerFolderStatistics(StreamWriter logWriter)
         {
             string baseFolder = _options.InputDirectory.FullName;
+            int baseOffset = baseFolder.Length + (baseFolder.Length > 0 && baseFolder[baseFolder.Length - 1] == Path.DirectorySeparatorChar ? 0 : 1);
             HashSet<string> folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (BuildFolder folder in FoldersToBuild)
             {
                 string relativeFolder = "";
                 if (folder.InputFolder.Length > baseFolder.Length)
                 {
-                    relativeFolder = folder.InputFolder.Substring(baseFolder.Length + 1);
+                    relativeFolder = folder.InputFolder.Substring(baseOffset);
                 }
                 int endPos = relativeFolder.IndexOf(Path.DirectorySeparatorChar);
                 if (endPos < 0)

--- a/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CommandLineOptions.cs
@@ -44,6 +44,7 @@ namespace ReadyToRun.SuperIlc
                         IssuesPath(),
                         CompilationTimeoutMinutes(),
                         ExecutionTimeoutMinutes(),
+                        R2RDumpPath(),
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileDirectoryCommand.CompileDirectory));
 
@@ -70,6 +71,7 @@ namespace ReadyToRun.SuperIlc
                         IssuesPath(),
                         CompilationTimeoutMinutes(),
                         ExecutionTimeoutMinutes(),
+                        R2RDumpPath(),
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileSubtreeCommand.CompileSubtree));
 
@@ -86,6 +88,7 @@ namespace ReadyToRun.SuperIlc
                         DegreeOfParallelism(),
                         CompilationTimeoutMinutes(),
                         ExecutionTimeoutMinutes(),
+                        R2RDumpPath(),
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileNugetCommand.CompileNuget));
 
@@ -147,6 +150,9 @@ namespace ReadyToRun.SuperIlc
 
             Option ExecutionTimeoutMinutes() =>
                 new Option(new[] { "--execution-timeout-minutes", "-et" }, "Execution timeout (minutes)", new Argument<int>());
+
+            Option R2RDumpPath() =>
+                new Option(new[] { "--r2r-dump-path", "-r2r" }, "Path to R2RDump.exe/dll", new Argument<FileInfo>().ExistingOnly());
 
             //
             // compile-nuget specific options

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -101,6 +101,7 @@ namespace ReadyToRun.SuperIlc
             {
                 builder.Append(" --naked");
             }
+
             string outputFileName = compiledExecutable + (naked ? ".naked.r2r" : ".raw.r2r");
             builder.Append($@" --out ""{outputFileName}""");
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace ReadyToRun.SuperIlc
 {
@@ -21,6 +22,11 @@ namespace ReadyToRun.SuperIlc
 
     public abstract class CompilerRunner
     {
+        /// <summary>
+        /// Timeout for running R2R Dump to disassemble compilation outputs.
+        /// </summary>
+        public const int R2RDumpTimeoutMilliseconds = 60 * 1000;
+
         protected readonly BuildOptions _options;
         protected readonly string _compilerPath;
         protected readonly IEnumerable<string> _referenceFolders;
@@ -67,6 +73,47 @@ namespace ReadyToRun.SuperIlc
             processParameters.CompilationCostHeuristic = new FileInfo(assemblyFileName).Length;
 
             return processParameters;
+        }
+
+        public ProcessParameters CompilationR2RDumpProcess(string compiledExecutable, bool naked)
+        {
+            if (_options.R2RDumpPath == null)
+            {
+                return null;
+            }
+
+            StringBuilder commonBuilder = new StringBuilder();
+
+            commonBuilder.Append($@"""{_options.R2RDumpPath.FullName}""");
+
+            commonBuilder.Append(" --normalize");
+            commonBuilder.Append(" --sc");
+            commonBuilder.Append(" --disasm");
+
+            foreach (string referencePath in _options.ReferencePaths())
+            {
+                commonBuilder.Append($@" --rp ""{referencePath}""");
+            }
+            commonBuilder.Append($@" --in ""{compiledExecutable}""");
+
+            StringBuilder builder = new StringBuilder(commonBuilder.ToString());
+            if (naked)
+            {
+                builder.Append(" --naked");
+            }
+            string outputFileName = compiledExecutable + (naked ? ".naked.r2r" : ".raw.r2r");
+            builder.Append($@" --out ""{outputFileName}""");
+
+            ProcessParameters param = new ProcessParameters();
+            param.ProcessPath = "dotnet";
+            param.Arguments = builder.ToString();
+            param.TimeoutMilliseconds = R2RDumpTimeoutMilliseconds;
+            param.LogPath = compiledExecutable + (naked ? ".naked.r2r.log" : ".raw.r2r.log");
+            param.InputFileName = compiledExecutable;
+            param.OutputFileName = outputFileName;
+            param.CompilationCostHeuristic = new FileInfo(compiledExecutable).Length;
+
+            return param;
         }
 
         protected virtual ProcessParameters ExecutionProcess(IEnumerable<string> modules, IEnumerable<string> folders, bool noEtw)
@@ -189,6 +236,24 @@ namespace ReadyToRun.SuperIlc
         public override ProcessParameters Construct()
         {
             return _runner.CompilationProcess(_outputRoot, _assemblyFileName);
+        }
+    }
+
+    public class R2RDumpProcessConstructor : CompilerRunnerProcessConstructor
+    {
+        private readonly string _compiledExecutable;
+        private readonly bool _naked;
+
+        public R2RDumpProcessConstructor(CompilerRunner runner, string compiledExecutable, bool naked)
+            : base(runner)
+        {
+            _compiledExecutable = compiledExecutable;
+            _naked = naked;
+        }
+
+        public override ProcessParameters Construct()
+        {
+            return _runner.CompilationR2RDumpProcess(_compiledExecutable, _naked);
         }
     }
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
@@ -50,6 +50,9 @@ static class PathExtensions
         return str;
     }
 
+    // TODO: this assumes we're running tests from the CoreRT root
+    internal static string DotNetAppPath => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet" : "Tools/dotnetcli/dotnet";
+
     internal static void RecreateDirectory(this string path)
     {
         if (Directory.Exists(path))

--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -236,7 +236,10 @@ public class ProcessRunner : IDisposable
         string data = eventArgs?.Data;
         if (!string.IsNullOrEmpty(data))
         {
-            _logWriter.WriteLine(data);
+            lock (_logWriter)
+            {
+                _logWriter.WriteLine(data);
+            }
         }
     }
 
@@ -245,7 +248,10 @@ public class ProcessRunner : IDisposable
         string data = eventArgs?.Data;
         if (!string.IsNullOrEmpty(data))
         {
-            _logWriter.WriteLine(data);
+            lock (_logWriter)
+            {
+                _logWriter.WriteLine(data);
+            }
         }
     }
 

--- a/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/SuperIlcHelpers.cs
@@ -37,7 +37,7 @@ namespace ReadyToRun.SuperIlc
         public int ExecutionTimeoutMinutes { get; set; }
         public DirectoryInfo[] ReferencePath { get; set; }
         public FileInfo[] IssuesPath { get; set; }
-
+        public FileInfo R2RDumpPath { get; set; }
         public string ConfigurationSuffix => (Release ? "-ret.out" : "-chk.out");
 
         public IEnumerable<string> ReferencePaths()


### PR DESCRIPTION
I have added initial minimalistic support for R2RDump to SuperIlc.
Using the new switch -r2r <path> we can specify the path to the
R2RDump tool and SuperIlc will use it to disassemble each
successfully compiled assembly in the "naked" and "raw" mode
(from a completely selfish point of view these are the modes I'm
using most of the time). These dumps make it much easier to compare
CPAOT and Crossgen output when analyzing the remaining failing
tests.

As a caveat this cannot be yet added to automated testing because
of the known backlog item "R2RDump build doesn't publish
CoreDisTools.dll it requires" (even though the library is available
in the build outputs and just copying it next to R2RDump fixes the
problem - that's what I've been doing since the very beginning).

Thanks

Tomas