### PR TITLE
Do not generate object array thunk for byref-returning delegates

### DIFF
--- a/src/Common/src/TypeSystem/IL/DelegateInfo.cs
+++ b/src/Common/src/TypeSystem/IL/DelegateInfo.cs
@@ -157,12 +157,12 @@ namespace Internal.IL
                     break;
                 }
             }
-            TypeDesc normalizedReturnType = delegateSignature.ReturnType;
-            if (normalizedReturnType.IsByRef)
-                normalizedReturnType = ((ByRefType)normalizedReturnType).ParameterType;
-            if (!normalizedReturnType.IsSignatureVariable && normalizedReturnType.IsByRefLike)
+            TypeDesc returnType = delegateSignature.ReturnType;
+            if (returnType.IsByRef)
                 generateObjectArrayThunk = false;
-            if (normalizedReturnType.IsPointer || normalizedReturnType.IsFunctionPointer)
+            if (!returnType.IsSignatureVariable && returnType.IsByRefLike)
+                generateObjectArrayThunk = false;
+            if (returnType.IsPointer || returnType.IsFunctionPointer)
                 generateObjectArrayThunk = false;
 
             if ((owningDelegate.SupportedFeatures & DelegateFeature.ObjectArrayThunk) != 0 && generateObjectArrayThunk)

--- a/src/Common/src/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
@@ -50,7 +50,9 @@ namespace Internal.IL.Stubs
             // TODO: function pointer types are odd: https://github.com/dotnet/corert/issues/1929
             // ----------------------------------------------------------------
 
-            if (UnwrapByRef(signature.ReturnType).IsFunctionPointer)
+            TypeDesc unwrappedReturnType = UnwrapByRef(signature.ReturnType);
+
+            if (unwrappedReturnType.IsFunctionPointer)
                 return false;
 
             for (int i = 0; i < signature.Length; i++)
@@ -61,7 +63,7 @@ namespace Internal.IL.Stubs
             // Methods that return ByRef-like types or take them by reference can't be reflection invoked
             // ----------------------------------------------------------------
 
-            if (!signature.ReturnType.IsSignatureVariable && UnwrapByRef(signature.ReturnType).IsByRefLike)
+            if (!unwrappedReturnType.IsSignatureVariable && unwrappedReturnType.IsByRefLike)
                 return false;
 
             for (int i = 0; i < signature.Length; i++)


### PR DESCRIPTION
Object array thunks are the weird thunks we make for delegates for the LINQ expression interpreter that dispatch to a method that takes an object array and returns object. There's no way to turn object returned from that method into a byref so we shouldn't try to make the thunks.

Also hit an assert in dynamic invoke method thunk, so fixed that too.

Fixes #7526.