### PR TITLE
More precise handling of instantiating stubs according to CoreCLR

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -521,7 +521,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private Dictionary<MethodWithToken, ISymbolNode> _dynamicHelperCellCache = new Dictionary<MethodWithToken, ISymbolNode>();
 
-        public ISymbolNode DynamicHelperCell(MethodWithToken methodWithToken, SignatureContext signatureContext)
+        public ISymbolNode DynamicHelperCell(MethodWithToken methodWithToken, bool isInstantiatingStub, SignatureContext signatureContext)
         {
             ISymbolNode result;
             if (!_dynamicHelperCellCache.TryGetValue(methodWithToken, out result))
@@ -537,7 +537,7 @@ namespace ILCompiler.DependencyAnalysis
                         methodWithToken,
                         signatureContext: signatureContext,
                         isUnboxingStub: false,
-                        isInstantiatingStub: true),
+                        isInstantiatingStub: isInstantiatingStub),
                     signatureContext);
                 _dynamicHelperCellCache.Add(methodWithToken, result);
             }


### PR DESCRIPTION
I have found a few places in ceeInfoGetCallInfo where I originally
didn't fully understand the intent of the CoreCLR code so
I converted it imprecisely. This change fixes two such imprecisions
regarding instantiating stubs and, in doing so, fixes about
300 more CoreCLR classloader Pri#1 tests.

Thanks

Tomas