### PR TITLE
Port GC changes from coreclr

### DIFF
--- a/src/Native/gc/gcinterface.dac.h
+++ b/src/Native/gc/gcinterface.dac.h
@@ -11,6 +11,7 @@
 //      GC-internal type's fields, while still maintaining the same layout.
 // This interface is strictly versioned, see gcinterface.dacvars.def for more information.
 
+#define HEAP_SEGMENT_FLAGS_READONLY     1
 #define NUM_GC_DATA_POINTS              9
 #define MAX_COMPACT_REASONS_COUNT       11
 #define MAX_EXPAND_MECHANISMS_COUNT     6

--- a/src/Native/gc/gcload.cpp
+++ b/src/Native/gc/gcload.cpp
@@ -13,6 +13,7 @@
 #include "gcenv.h"
 #include "gc.h"
 
+#ifdef BUILD_AS_STANDALONE
 #ifndef DLLEXPORT
 #ifdef _MSC_VER
 #define DLLEXPORT __declspec(dllexport)
@@ -22,6 +23,9 @@
 #endif // DLLEXPORT
 
 #define GC_EXPORT extern "C" DLLEXPORT
+#else
+#define GC_EXPORT extern "C"
+#endif
 
 // These symbols are defined in gc.cpp and populate the GcDacVars
 // structure with the addresses of DAC variables within the GC.


### PR DESCRIPTION
Porting strategy: extracting patches via `format-patch` from coreclr, adjusting paths, then `am` them on corert.