### PR TITLE
Devcontainer files for vscode cross-platform development.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
+# Debian and Ubuntu based images are supported. Alpine images are not yet supported.
+FROM debian:9
+
+# Configure apt
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1
+
+# Install git, process tools, lsb-release (common in install instructions for CLIs)
+RUN apt-get -y install git procps lsb-release
+
+# ***********************************
+# * Install stuff needed for CoreRT *
+# ***********************************
+RUN apt-get -y install cmake clang-3.9 libicu-dev uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev wget
+
+# Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=dialog
+
+# Set the default shell to bash rather than sh
+ENV SHELL /bin/bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "corert",
+	"dockerFile": "Dockerfile",
+	"extensions": [
+	],
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	]
+}


### PR DESCRIPTION
https://code.visualstudio.com/docs/remote/containers is a feature that makes it a lot easier to do linux development from a windows machine in vs code. Basically, when you launch VS Code in the corert directory, it will create a docker image with the appropriate tools installed so you can run `./build.sh` without needing to install any pre-reqs.