### PR TITLE
Remove the Crossgen-specific VSD flag from CPAOT

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
@@ -14,18 +14,31 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     {
         private readonly ReadyToRunHelper _helper;
 
+        private readonly bool _useVSD;
+
         private readonly ImportThunk _delayLoadHelper;
 
-        public DelayLoadHelperImport(ReadyToRunCodegenNodeFactory factory, ImportSectionNode importSectionNode, ReadyToRunHelper helper, Signature instanceSignature, string callSite = null)
+        public DelayLoadHelperImport(
+            ReadyToRunCodegenNodeFactory factory, 
+            ImportSectionNode importSectionNode, 
+            ReadyToRunHelper helper, 
+            Signature instanceSignature, 
+            bool useVSD = false, 
+            string callSite = null)
             : base(importSectionNode, instanceSignature, callSite)
         {
             _helper = helper;
-            _delayLoadHelper = new ImportThunk(helper, factory, this);
+            _useVSD = useVSD;
+            _delayLoadHelper = new ImportThunk(helper, factory, this, useVSD);
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
             sb.Append("DelayLoadHelperImport(");
+            if (_useVSD)
+            {
+                sb.Append("[VSD] ");
+            }
             sb.Append(_helper.ToString());
             sb.Append(") -> ");
             ImportSignature.AppendMangledName(nameMangler, sb);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperImport.cs
@@ -14,7 +14,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     {
         private readonly ReadyToRunHelper _helper;
 
-        private readonly bool _useVSD;
+        private readonly bool _useVirtualCall;
 
         private readonly ImportThunk _delayLoadHelper;
 
@@ -23,19 +23,19 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ImportSectionNode importSectionNode, 
             ReadyToRunHelper helper, 
             Signature instanceSignature, 
-            bool useVSD = false, 
+            bool useVirtualCall = false, 
             string callSite = null)
             : base(importSectionNode, instanceSignature, callSite)
         {
             _helper = helper;
-            _useVSD = useVSD;
-            _delayLoadHelper = new ImportThunk(helper, factory, this, useVSD);
+            _useVirtualCall = useVirtualCall;
+            _delayLoadHelper = new ImportThunk(helper, factory, this, useVirtualCall);
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
             sb.Append("DelayLoadHelperImport(");
-            if (_useVSD)
+            if (_useVirtualCall)
             {
                 sb.Append("[VSD] ");
             }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
@@ -32,31 +32,20 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ImportSectionNode importSectionNode, 
             ReadyToRunHelper helper, 
             MethodWithToken method,
+            bool useVSD,
             bool useInstantiatingStub,
             Signature instanceSignature, 
             SignatureContext signatureContext,
             string callSite = null)
-            : base(factory, importSectionNode, helper, instanceSignature, callSite)
+            : base(factory, importSectionNode, helper, instanceSignature, useVSD, callSite)
         {
             _helper = helper;
             _method = method;
             _useInstantiatingStub = useInstantiatingStub;
-            _delayLoadHelper = new ImportThunk(helper, factory, this);
+            _delayLoadHelper = new ImportThunk(helper, factory, this, useVSD);
             _signatureContext = signatureContext;
         }
 
-        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
-        {
-            sb.Append("DelayLoadHelperMethodImport(");
-            sb.Append(_helper.ToString());
-            sb.Append(") -> ");
-            ImportSignature.AppendMangledName(nameMangler, sb);
-            if (CallSite != null)
-            {
-                sb.Append(" @ ");
-                sb.Append(CallSite);
-            }
-        }
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
             foreach (DependencyListEntry baseEntry in base.GetStaticDependencies(factory))

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadHelperMethodImport.cs
@@ -32,17 +32,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ImportSectionNode importSectionNode, 
             ReadyToRunHelper helper, 
             MethodWithToken method,
-            bool useVSD,
+            bool useVirtualCall,
             bool useInstantiatingStub,
             Signature instanceSignature, 
             SignatureContext signatureContext,
             string callSite = null)
-            : base(factory, importSectionNode, helper, instanceSignature, useVSD, callSite)
+            : base(factory, importSectionNode, helper, instanceSignature, useVirtualCall, callSite)
         {
             _helper = helper;
             _method = method;
             _useInstantiatingStub = useInstantiatingStub;
-            _delayLoadHelper = new ImportThunk(helper, factory, this, useVSD);
+            _delayLoadHelper = new ImportThunk(helper, factory, this, useVirtualCall);
             _signatureContext = signatureContext;
         }
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
@@ -267,9 +267,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         // JIT32 x86-specific exception handling
         READYTORUN_HELPER_EndCatch = 0x110,
-
-        // A flag to indicate that a helper call uses VSD
-        READYTORUN_HELPER_FLAG_VSD = 0x10000000,
     }
 
     public enum CorElementType : byte

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportThunk.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportThunk.cs
@@ -30,13 +30,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly Kind _thunkKind;
 
-        public ImportThunk(ReadyToRunHelper helperId, ReadyToRunCodegenNodeFactory factory, Import instanceCell, bool useVSD)
+        public ImportThunk(ReadyToRunHelper helperId, ReadyToRunCodegenNodeFactory factory, Import instanceCell, bool useVirtualCall)
         {
             _helperCell = factory.GetReadyToRunHelperCell(helperId);
             _instanceCell = instanceCell;
             _moduleImport = factory.ModuleImport;
 
-            if (useVSD)
+            if (useVirtualCall)
             {
                 _thunkKind = Kind.VirtualStubDispatch;
             }
@@ -76,7 +76,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     public class DelayLoadHelperThunk_Obj : ImportThunk
     {
         public DelayLoadHelperThunk_Obj(ReadyToRunCodegenNodeFactory nodeFactory, Import instanceCell)
-            : base(ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj, nodeFactory, instanceCell, useVSD: false)
+            : base(ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj, nodeFactory, instanceCell, useVirtualCall: false)
         {
         }
     }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportThunk.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportThunk.cs
@@ -30,13 +30,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly Kind _thunkKind;
 
-        public ImportThunk(ReadyToRunHelper helperId, ReadyToRunCodegenNodeFactory factory, Import instanceCell)
+        public ImportThunk(ReadyToRunHelper helperId, ReadyToRunCodegenNodeFactory factory, Import instanceCell, bool useVSD)
         {
-            _helperCell = factory.GetReadyToRunHelperCell(helperId & ~ReadyToRunHelper.READYTORUN_HELPER_FLAG_VSD);
+            _helperCell = factory.GetReadyToRunHelperCell(helperId);
             _instanceCell = instanceCell;
             _moduleImport = factory.ModuleImport;
 
-            if ((uint)(helperId & ReadyToRunHelper.READYTORUN_HELPER_FLAG_VSD) != 0)
+            if (useVSD)
             {
                 _thunkKind = Kind.VirtualStubDispatch;
             }
@@ -76,7 +76,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     public class DelayLoadHelperThunk_Obj : ImportThunk
     {
         public DelayLoadHelperThunk_Obj(ReadyToRunCodegenNodeFactory nodeFactory, Import instanceCell)
-            : base(ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj, nodeFactory, instanceCell)
+            : base(ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj, nodeFactory, instanceCell, useVSD: false)
         {
         }
     }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -343,13 +343,13 @@ namespace ILCompiler.DependencyAnalysis
                 Import personalityRoutineImport = new Import(EagerImports, new ReadyToRunHelperSignature(
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutine));
                 PersonalityRoutine = new ImportThunk(
-                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutine, this, personalityRoutineImport, useVSD: false);
+                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutine, this, personalityRoutineImport, useVirtualCall: false);
                 graph.AddRoot(PersonalityRoutine, "Personality routine is faster to root early rather than referencing it from each unwind info");
 
                 Import filterFuncletPersonalityRoutineImport = new Import(EagerImports, new ReadyToRunHelperSignature(
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutineFilterFunclet));
                 FilterFuncletPersonalityRoutine = new ImportThunk(
-                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutineFilterFunclet, this, filterFuncletPersonalityRoutineImport, useVSD: false);
+                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutineFilterFunclet, this, filterFuncletPersonalityRoutineImport, useVirtualCall: false);
                 graph.AddRoot(FilterFuncletPersonalityRoutine, "Filter funclet personality routine is faster to root early rather than referencing it from each unwind info");
             }
 
@@ -531,7 +531,7 @@ namespace ILCompiler.DependencyAnalysis
                     DispatchImports,
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj,
                     methodWithToken,
-                    useVSD: false,
+                    useVirtualCall: false,
                     useInstantiatingStub: true,
                     MethodSignature(
                         ReadyToRunFixupKind.READYTORUN_FIXUP_VirtualEntry,

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -343,13 +343,13 @@ namespace ILCompiler.DependencyAnalysis
                 Import personalityRoutineImport = new Import(EagerImports, new ReadyToRunHelperSignature(
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutine));
                 PersonalityRoutine = new ImportThunk(
-                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutine, this, personalityRoutineImport);
+                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutine, this, personalityRoutineImport, useVSD: false);
                 graph.AddRoot(PersonalityRoutine, "Personality routine is faster to root early rather than referencing it from each unwind info");
 
                 Import filterFuncletPersonalityRoutineImport = new Import(EagerImports, new ReadyToRunHelperSignature(
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutineFilterFunclet));
                 FilterFuncletPersonalityRoutine = new ImportThunk(
-                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutineFilterFunclet, this, filterFuncletPersonalityRoutineImport);
+                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_PersonalityRoutineFilterFunclet, this, filterFuncletPersonalityRoutineImport, useVSD: false);
                 graph.AddRoot(FilterFuncletPersonalityRoutine, "Filter funclet personality routine is faster to root early rather than referencing it from each unwind info");
             }
 
@@ -531,6 +531,7 @@ namespace ILCompiler.DependencyAnalysis
                     DispatchImports,
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj,
                     methodWithToken,
+                    useVSD: false,
                     useInstantiatingStub: true,
                     MethodSignature(
                         ReadyToRunFixupKind.READYTORUN_FIXUP_VirtualEntry,

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -233,6 +233,7 @@ namespace ILCompiler.DependencyAnalysis
                 _codegenNodeFactory.DispatchImports,
                 ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj,
                 methodWithToken,
+                useVSD: false,
                 useInstantiatingStub: false,
                 _codegenNodeFactory.MethodSignature(
                     ReadyToRunFixupKind.READYTORUN_FIXUP_VirtualEntry,
@@ -682,9 +683,9 @@ namespace ILCompiler.DependencyAnalysis
                 dispatchCell = new DelayLoadHelperMethodImport(
                     _codegenNodeFactory,
                     _codegenNodeFactory.DispatchImports,
-                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_MethodCall |
-                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_FLAG_VSD,
+                    ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_MethodCall,
                     method,
+                    useVSD: true,
                     useInstantiatingStub: false,
                     _codegenNodeFactory.MethodSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_VirtualEntry,
                         method,
@@ -961,6 +962,7 @@ namespace ILCompiler.DependencyAnalysis
                     _codegenNodeFactory.HelperImports,
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
                     methodArgument,
+                    useVSD: false,
                     useInstantiatingStub: false,
                     new GenericLookupSignature(runtimeLookupKind, fixupKind, typeArgument: null, methodArgument, fieldArgument: null, methodContext, signatureContext),
                     signatureContext);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -233,7 +233,7 @@ namespace ILCompiler.DependencyAnalysis
                 _codegenNodeFactory.DispatchImports,
                 ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper_Obj,
                 methodWithToken,
-                useVSD: false,
+                useVirtualCall: false,
                 useInstantiatingStub: false,
                 _codegenNodeFactory.MethodSignature(
                     ReadyToRunFixupKind.READYTORUN_FIXUP_VirtualEntry,
@@ -685,7 +685,7 @@ namespace ILCompiler.DependencyAnalysis
                     _codegenNodeFactory.DispatchImports,
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_MethodCall,
                     method,
-                    useVSD: true,
+                    useVirtualCall: true,
                     useInstantiatingStub: false,
                     _codegenNodeFactory.MethodSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_VirtualEntry,
                         method,
@@ -962,7 +962,7 @@ namespace ILCompiler.DependencyAnalysis
                     _codegenNodeFactory.HelperImports,
                     ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
                     methodArgument,
-                    useVSD: false,
+                    useVirtualCall: false,
                     useInstantiatingStub: false,
                     new GenericLookupSignature(runtimeLookupKind, fixupKind, typeArgument: null, methodArgument, fieldArgument: null, methodContext, signatureContext),
                     signatureContext);


### PR DESCRIPTION
Based on JanK's advice I have slightly refactored CPAOT to free it
from blindly reusing the Crossgen hack of using a special bit flag
to pass information around within the ZAP logic. As part of the cleanup
I have also removed the AppendMangledName override in
DelayLoadMethodHelperImport as it wasn't adding any extra
useful information.

Thanks

Tomas