### PR TITLE
Small SuperIlc fix for wrong architecture identifier

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/TestExclusion.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/TestExclusion.cs
@@ -163,10 +163,10 @@ namespace ReadyToRun.SuperIlc
 
                 Project project = new Project();
                 project.SetGlobalProperty("XunitTestBinBase", "*");
-                project.SetGlobalProperty("BuildArch", "amd64");
+                project.SetGlobalProperty("BuildArch", "x64");
                 // TODO: cross-OS CPAOT
                 project.SetGlobalProperty("TargetsWindows", (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "true" : "false"));
-                project.SetGlobalProperty("AltJitArch", "amd64");
+                project.SetGlobalProperty("AltJitArch", "x64");
                 project.SetGlobalProperty("RunTestViaIlLink", "false");
 
                 ProjectRootElement root = project.Xml;


### PR DESCRIPTION
When analyzing the Pri#1 CPAOT results I noticed that some of the
"issues.targets" exclusions got silently ignored and I tracked it
down to incorrect architecture specification - I apparently used
"amd64" instead of the expected "x64".

Thanks

Tomas