### PR TITLE
Implement obsolete `Marshal.Write*` APIs

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreRT.cs
@@ -360,6 +360,7 @@ namespace System.Runtime.InteropServices
                 throw new ArgumentOutOfRangeException(nameof(ofs));
 
             IntPtr nativeBytes = AllocCoTaskMem(size);
+            Buffer.ZeroMemory((byte*)nativeBytes, (long)size);
 
             try
             {
@@ -455,6 +456,7 @@ namespace System.Runtime.InteropServices
                 throw new ArgumentOutOfRangeException(nameof(ofs));
 
             IntPtr nativeBytes = AllocCoTaskMem(size);
+            Buffer.ZeroMemory((byte*)nativeBytes, (long)size);
 
             try
             {


### PR DESCRIPTION
Because bad APIs come in pairs.