### PR TITLE
Implement LayoutClass/LayoutClassPtr/AsAny marshalers

### DIFF
--- a/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemHelpers.cs
@@ -66,6 +66,11 @@ namespace Internal.TypeSystem
             return paramType.ParameterType;
         }
 
+        public static bool HasLayout(this MetadataType mdType)
+        {
+            return mdType.IsSequentialLayout || mdType.IsExplicitLayout;
+        }
+
         public static LayoutInt GetElementSize(this TypeDesc type)
         {
             if (type.IsValueType)

--- a/src/Common/src/TypeSystem/Interop/MarshalAsDescriptor.cs
+++ b/src/Common/src/TypeSystem/Interop/MarshalAsDescriptor.cs
@@ -32,6 +32,7 @@ namespace Internal.TypeSystem
         Int = 0x1f,
         UInt = 0x20,
         Func = 0x26,
+        AsAny = 0x28,
         Array = 0x2a,
         LPStruct = 0x2b,    // This is not  defined in Ecma-335(II.23.4)
         LPUTF8Str = 0x30,

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -396,6 +396,59 @@ namespace Internal.Runtime.CompilerHelpers
             return PInvokeMarshal.GetCurrentCalleeDelegate<T>();
         }
 
+        internal static int AsAnyGetNativeSize(object o)
+        {
+            // Array, string and StringBuilder are not implemented.
+            if (o.EETypePtr.IsArray ||
+                o is string ||
+                o is StringBuilder)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            // Assume that this is a type with layout.
+            return Marshal.SizeOf(o.GetType());
+        }
+
+        internal static void AsAnyMarshalManagedToNative(object o, IntPtr address)
+        {
+            // Array, string and StringBuilder are not implemented.
+            if (o.EETypePtr.IsArray ||
+                o is string ||
+                o is StringBuilder)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            Marshal.StructureToPtr(o, address, fDeleteOld: false);
+        }
+
+        internal static void AsAnyMarshalNativeToManaged(IntPtr address, object o)
+        {
+            // Array, string and StringBuilder are not implemented.
+            if (o.EETypePtr.IsArray ||
+                o is string ||
+                o is StringBuilder)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            Marshal.PtrToStructureImpl(address, o);
+        }
+
+        internal static void AsAnyCleanupNative(IntPtr address, object o)
+        {
+            // Array, string and StringBuilder are not implemented.
+            if (o.EETypePtr.IsArray ||
+                o is string ||
+                o is StringBuilder)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            Marshal.DestroyStructure(address, o.GetType());
+        }
+
         [StructLayout(LayoutKind.Sequential)]
         internal unsafe struct ModuleFixupCell
         {

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreRT.cs
@@ -64,7 +64,7 @@ namespace System.Runtime.InteropServices
             PtrToStructureImpl(ptr, structure);
         }
 
-        private static unsafe void PtrToStructureImpl(IntPtr ptr, object structure)
+        internal static unsafe void PtrToStructureImpl(IntPtr ptr, object structure)
         {
             RuntimeTypeHandle structureTypeHandle = structure.GetType().TypeHandle;
 

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -835,11 +835,11 @@ namespace PInvokeTests
             ThrowIfNotEquals(true, ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp"), "LayoutClassPtr marshalling scenario1 failed.");
         }
 
-        [MethodImpl(MethodImplOptions.NoOptimization)]
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         private static void Issue6063Workaround()
         {
             // https://github.com/dotnet/corert/issues/6063
-            // Ensure there's a standalone method body for these two - this method is marked is marked NoOptimization.
+            // Ensure there's a standalone method body for these two - this method is marked NoOptimization+NoInlining.
             Marshal.SizeOf<SequentialClass>();
             Marshal.SizeOf<SequentialStruct>();
         }

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -835,13 +835,21 @@ namespace PInvokeTests
             ThrowIfNotEquals(true, ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp"), "LayoutClassPtr marshalling scenario1 failed.");
         }
 
+        [MethodImpl(MethodImplOptions.NoOptimization)]
+        private static void Issue6063Workaround()
+        {
+            // https://github.com/dotnet/corert/issues/6063
+            // Ensure there's a standalone method body for these two - this method is marked is marked NoOptimization.
+            Marshal.SizeOf<SequentialClass>();
+            Marshal.SizeOf<SequentialStruct>();
+        }
+        
         private static void TestAsAny()
         {
             if (String.Empty.Length > 0)
             {
                 // Make sure we saw these types being used in marshalling
-                Marshal.SizeOf<SequentialClass>();
-                Marshal.SizeOf<SequentialStruct>();
+                Issue6063Workaround();
             }
 
             SequentialClass sc = new SequentialClass();

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -161,6 +161,12 @@ namespace PInvokeTests
         [DllImport("*", CallingConvention = CallingConvention.StdCall)]
         static extern void StructTest_ByRef(ref SequentialStruct ss);
 
+        [DllImport("*", CallingConvention = CallingConvention.StdCall, EntryPoint = "StructTest_ByRef")]
+        static extern bool ClassTest([In, Out] SequentialClass ss);
+
+        [DllImport("*", CallingConvention = CallingConvention.StdCall, EntryPoint = "StructTest_ByRef")]
+        static extern bool AsAnyTest([In, Out, MarshalAs(40 /* UnmanagedType.AsAny */)] object o);
+
         [DllImport("*", CallingConvention = CallingConvention.StdCall)]
         static extern void StructTest_ByOut(out SequentialStruct ss);
 
@@ -169,6 +175,9 @@ namespace PInvokeTests
 
         [DllImport("*", CallingConvention = CallingConvention.StdCall)]
         static extern bool StructTest_Nested(NestedStruct ns);
+
+        [DllImport("*", CallingConvention = CallingConvention.StdCall, EntryPoint = "StructTest_Nested")]
+        static extern bool StructTest_NestedClass(NestedClass nc);
 
         [DllImport("*", CallingConvention = CallingConvention.StdCall)]
         static extern bool StructTest_Array(SequentialStruct []ns, int length);
@@ -265,6 +274,9 @@ namespace PInvokeTests
 #if !CODEGEN_CPP
             TestDelegate();
             TestStruct();
+            TestLayoutClassPtr();
+            TestLayoutClass();
+            TestAsAny();
             TestMarshalStructAPIs();
 #endif            
             return 100;
@@ -597,6 +609,18 @@ namespace PInvokeTests
         [StructLayout(LayoutKind.Sequential)]
         public struct SequentialStruct
         {
+            // NOTE: Same members as SequentialClass below
+            public short f0;
+            public int f1;
+            public float f2;
+            [MarshalAs(UnmanagedType.LPStr)]
+            public String f3;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public class SequentialClass
+        {
+            // NOTE: Same members as SequentialStruct above
             public short f0;
             public int f1;
             public float f2;
@@ -619,6 +643,22 @@ namespace PInvokeTests
         [StructLayout(LayoutKind.Explicit)]
         public struct ExplicitStruct
         {
+            // NOTE: Same layout as ExplicitClass
+            [FieldOffset(0)]
+            public int f1;
+
+            [FieldOffset(12)]
+            public float f2;
+
+            [FieldOffset(24)]
+            [MarshalAs(UnmanagedType.LPStr)]
+            public String f3;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public class ExplicitClass
+        {
+            // NOTE: Same layout as ExplicitStruct
             [FieldOffset(0)]
             public int f1;
 
@@ -636,6 +676,14 @@ namespace PInvokeTests
             public int f1;
 
             public ExplicitStruct f2;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct NestedClass
+        {
+            public int f1;
+
+            public ExplicitClass f2;
         }
 
         [StructLayout(LayoutKind.Explicit)]
@@ -773,6 +821,61 @@ namespace PInvokeTests
             callbacks.callback1 = new Callback1(callbackFunc1);
             callbacks.callback2 = new Callback2(callbackFunc2);
             ThrowIfNotEquals(true,  RegisterCallbacks(ref callbacks), "Scenario 7: Struct with delegate marshalling failed");
+        }
+
+        private static void TestLayoutClassPtr()
+        {
+            SequentialClass ss = new SequentialClass();
+            ss.f0 = 100;
+            ss.f1 = 1;
+            ss.f2 = 10.0f;
+            ss.f3 = "Hello";
+
+            ClassTest(ss);
+            ThrowIfNotEquals(true, ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp"), "LayoutClassPtr marshalling scenario1 failed.");
+        }
+
+        private static void TestAsAny()
+        {
+            if (String.Empty.Length > 0)
+            {
+                // Make sure we saw these types being used in marshalling
+                Marshal.SizeOf<SequentialClass>();
+                Marshal.SizeOf<SequentialStruct>();
+            }
+
+            SequentialClass sc = new SequentialClass();
+            sc.f0 = 100;
+            sc.f1 = 1;
+            sc.f2 = 10.0f;
+            sc.f3 = "Hello";
+
+            AsAnyTest(sc);
+            ThrowIfNotEquals(true, sc.f1 == 2 && sc.f2 == 11.0 && sc.f3.Equals("Ifmmp"), "AsAny marshalling scenario1 failed.");
+
+            SequentialStruct ss = new SequentialStruct();
+            ss.f0 = 100;
+            ss.f1 = 1;
+            ss.f2 = 10.0f;
+            ss.f3 = "Hello";
+
+            object o = ss;
+            AsAnyTest(o);
+            ss = (SequentialStruct)o;
+            ThrowIfNotEquals(true, ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp"), "AsAny marshalling scenario2 failed.");
+        }
+
+        private static void TestLayoutClass()
+        {
+            ExplicitClass es = new ExplicitClass();
+            es.f1 = 100;
+            es.f2 = 100.0f;
+            es.f3 = "Hello";
+
+            NestedClass ns = new NestedClass();
+            ns.f1 = 100;
+            ns.f2 = es;
+            ThrowIfNotEquals(true, StructTest_NestedClass(ns), "LayoutClass marshalling scenario1 failed.");
         }
 
         private static void TestMarshalStructAPIs()


### PR DESCRIPTION
This is a couple marshallers that nobody should be using for anything, but WinForms and System.Drawing uses them for everything. Frankly, it feels like the designers of .NET 1.0 got too excited about marshalling everything with these and someone should have stopped them.

These marshallers are for marshalling abritrary reference types to native code.

This is enough to get basic WinForms apps running. E.g. the MatchingGame .NET Sample works with this. Serious WinForms apps will eventually hit missing COM support, but at least the basics work now and it's enough to get a read on things like startup time.