### PR TITLE
Fix GetTypeCode of metadata-only enums

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -57,7 +57,7 @@ namespace Internal.Reflection.Augments
                 if (!type.IsEnum)
                     return TypeCode.Object;
                 Type underlyingType = Enum.GetUnderlyingType(type);
-                eeType = underlyingType.TypeHandle.EETypePtr;
+                eeType = underlyingType.TypeHandle.ToEETypePtr();
             }
 
             // Note: Type.GetTypeCode() is expected to return the underlying type's TypeCode for enums. EETypePtr.CorElementType does the same,


### PR DESCRIPTION
Found this by accident. `underlyingType.TypeHandle.EETypePtr` would box the RuntimeTypeHandle and return EEType of the RuntimeTypeHandle type.

What this code actually wanted to do is to get the EEType of the underlying type.