### PR TITLE
Prevent loading byref-like types with invalid layout

### DIFF
--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/InstanceFieldLayout.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/InstanceFieldLayout.cs
@@ -96,6 +96,24 @@ namespace Explicit
     public struct ExplicitEmptyStruct
     {
     }
+
+    [StructLayout(LayoutKind.Explicit)]
+    ref struct MisalignedPointer
+    {
+        [FieldOffset(2)]
+        public object O;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    ref struct MisalignedByRef
+    {
+        [FieldOffset(2)]
+        public ByRefStruct O;
+    }
+
+    ref struct ByRefStruct
+    {
+    }
 }
 
 namespace Sequential

--- a/src/ILCompiler.TypeSystem/tests/InstanceFieldLayoutTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/InstanceFieldLayoutTests.cs
@@ -113,6 +113,20 @@ namespace TypeSystemTests
         }
 
         [Fact]
+        public void TestInvalidExplicitTypeLayout()
+        {
+            {
+                DefType type = _testModule.GetType("Explicit", "MisalignedPointer");
+                Assert.Throws<TypeSystemException.TypeLoadException>(() => type.ComputeInstanceLayout(InstanceLayoutKind.TypeAndFields));
+            }
+
+            {
+                DefType type = _testModule.GetType("Explicit", "MisalignedByRef");
+                Assert.Throws<TypeSystemException.TypeLoadException>(() => type.ComputeInstanceLayout(InstanceLayoutKind.TypeAndFields));
+            }
+        }
+
+        [Fact]
         public void TestSequentialTypeLayout()
         {
             MetadataType class1Type = _testModule.GetType("Sequential", "Class1");


### PR DESCRIPTION
Port of dotnet/coreclr#25200.