### PR TITLE
Run CoreCLR tests in multimodule mode

### DIFF
--- a/eng/build-job.yml
+++ b/eng/build-job.yml
@@ -95,7 +95,7 @@ jobs:
         enabled: ${{ and(eq(parameters.buildConfig, 'Debug'), eq(parameters.osGroup, 'Windows_NT')) }}
 
     - ${{ if contains(parameters.testScenarios, 'CoreCLR') }}:
-      - script: $(testScriptName) $(buildConfig) $(testParameterPrefix)coreclr $(coreCLRTestSet)
+      - script: $(testScriptName) $(buildConfig) $(testParameterPrefix)multimodule $(testParameterPrefix)coreclr $(coreCLRTestSet)
         displayName: Run CoreCLR $(coreCLRTestSet) tests
         enabled: ${{ eq(parameters.buildConfig, 'Debug') }}
 


### PR DESCRIPTION
This leg is currently taking 80 minutes to complete and that's quite a long time.