### PR TITLE
Miscellaneous CPAOT fixes for several Pri# bug buckets

### DIFF
--- a/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -297,7 +297,7 @@ namespace Internal.TypeSystem
         {
         }
 
-        private static ComputedInstanceFieldLayout ComputeExplicitFieldLayout(MetadataType type, int numInstanceFields)
+        protected static ComputedInstanceFieldLayout ComputeExplicitFieldLayout(MetadataType type, int numInstanceFields)
         {
             // Instance slice size is the total size of instance not including the base type.
             // It is calculated as the field whose offset and size add to the greatest value.

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalUtils.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalUtils.cs
@@ -15,7 +15,7 @@ namespace Internal.TypeSystem.Interop
         {
             type = type.UnderlyingType;
 
-            if (type.IsValueType)
+            if (type.IsValueType && !type.IsNullable)
             {
                 if (type.IsPrimitive)
                 {
@@ -59,6 +59,10 @@ namespace Internal.TypeSystem.Interop
         public static bool IsManagedSequentialType(TypeDesc type)
         {
             type = type.UnderlyingType;
+            if (type is MetadataType metadataType && metadataType.IsExplicitLayout)
+            {
+                return false;
+            }
             if (type.IsPrimitive || type.Category == TypeFlags.Pointer)
             {
                 return true;

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalUtils.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalUtils.cs
@@ -15,7 +15,7 @@ namespace Internal.TypeSystem.Interop
         {
             type = type.UnderlyingType;
 
-            if (type.IsValueType && !type.IsNullable)
+            if (type.IsValueType)
             {
                 if (type.IsPrimitive)
                 {
@@ -59,9 +59,18 @@ namespace Internal.TypeSystem.Interop
         public static bool IsManagedSequentialType(TypeDesc type)
         {
             type = type.UnderlyingType;
-            if (type is MetadataType metadataType && metadataType.IsExplicitLayout)
+            if (type is MetadataType metadataType)
             {
-                return false;
+                if (!metadataType.IsSequentialLayout)
+                {
+                    return false;
+                }
+                if (metadataType.HasBaseType &&
+                    !metadataType.BaseType.IsWellKnownType(WellKnownType.ValueType) &&
+                    !IsManagedSequentialType(metadataType.BaseType))
+                {
+                    return false;
+                }
             }
             if (type.IsPrimitive || type.Category == TypeFlags.Pointer)
             {

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalUtils.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalUtils.cs
@@ -59,19 +59,6 @@ namespace Internal.TypeSystem.Interop
         public static bool IsManagedSequentialType(TypeDesc type)
         {
             type = type.UnderlyingType;
-            if (type is MetadataType metadataType)
-            {
-                if (!metadataType.IsSequentialLayout)
-                {
-                    return false;
-                }
-                if (metadataType.HasBaseType &&
-                    !metadataType.BaseType.IsWellKnownType(WellKnownType.ValueType) &&
-                    !IsManagedSequentialType(metadataType.BaseType))
-                {
-                    return false;
-                }
-            }
             if (type.IsPrimitive || type.Category == TypeFlags.Pointer)
             {
                 return true;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionNode.cs
@@ -9,7 +9,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     public class ImportSectionNode : EmbeddedObjectNode
     {
-        private readonly ArrayOfEmbeddedDataNode<Import> _imports;
+        private class ImportTable : ArrayOfEmbeddedDataNode<Import>
+        {
+            public ImportTable(string startSymbol, string endSymbol) : base(startSymbol, endSymbol, nodeSorter: null) {}
+
+            public override bool ShouldSkipEmittingObjectNode(NodeFactory factory) => false;
+        }
+
+        private readonly ImportTable _imports;
         // TODO: annoying - today there's no way to put signature RVA's into R/O data section
         private readonly ArrayOfEmbeddedPointersNode<Signature> _signatures;
         // TODO: annoying - cannot enumerate the ArrayOfEmbeddedPointersNode so we must keep a copy.
@@ -34,7 +41,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _emitPrecode = emitPrecode;
             _emitGCRefMap = emitGCRefMap;
 
-            _imports = new ArrayOfEmbeddedDataNode<Import>(_name + "_ImportBegin", _name + "_ImportEnd", null);
+            _imports = new ImportTable(_name + "_ImportBegin", _name + "_ImportEnd");
             _signatures = new ArrayOfEmbeddedPointersNode<Signature>(_name + "_SigBegin", _name + "_SigEnd", null);
             _signatureList = new List<Signature>();
             _gcRefMap = (_emitGCRefMap ? new GCRefMapNode(this) : null);
@@ -78,20 +85,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override int ClassCode => -62839441;
 
-        public bool ShouldSkipEmittingTable(NodeFactory factory)
-        {
-            return _imports.ShouldSkipEmittingObjectNode(factory);
-        }
-
         public override void EncodeData(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly)
         {
-            if (!relocsOnly && _imports.ShouldSkipEmittingObjectNode(factory))
+            if (!_imports.ShouldSkipEmittingObjectNode(factory))
             {
-                // Don't emit import section node at all if there are no entries in it
-                return;
+                dataBuilder.EmitReloc(_imports.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB, 0);
+            }
+            else
+            {
+                dataBuilder.EmitUInt(0);
             }
 
-            dataBuilder.EmitReloc(_imports.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB, 0);
             if (!relocsOnly)
             {
                 dataBuilder.EmitInt(_imports.GetData(factory, false).Data.Length);
@@ -100,6 +104,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 dataBuilder.EmitByte((byte)_type);
                 dataBuilder.EmitByte(_entrySize);
             }
+
             if (!_signatures.ShouldSkipEmittingObjectNode(factory))
             {
                 dataBuilder.EmitReloc(_signatures.StartSymbol, RelocType.IMAGE_REL_BASED_ADDR32NB, 0);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionsTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ImportSectionsTableNode.cs
@@ -37,7 +37,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             int index = 0;
             foreach (ImportSectionNode node in NodesList)
             {
-                if (!relocsOnly && !node.ShouldSkipEmittingTable(factory))
+                if (!relocsOnly)
                 {
                     node.InitializeOffsetFromBeginningOfArray(builder.CountBytes);
                     node.InitializeIndexFromBeginningOfArray(index++);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -341,9 +341,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             EcmaModule targetModule = context.GetTargetModule(type);
             EmitModuleOverride(targetModule, context);
-            context = context.InnerContext(targetModule);
             EmitElementType(CorElementType.ELEMENT_TYPE_GENERICINST);
-            EmitTypeSignature(type.GetTypeDefinition(), context);
+            EmitTypeSignature(type.GetTypeDefinition(), context.InnerContext(targetModule));
             EmitUInt((uint)type.Instantiation.Length);
             for (int paramIndex = 0; paramIndex < type.Instantiation.Length; paramIndex++)
             {

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -253,7 +253,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             return new DelayLoadHelperImport(
                 _codegenNodeFactory,
-                _codegenNodeFactory.DispatchImports,
+                _codegenNodeFactory.HelperImports,
                 ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_DelayLoad_Helper,
                 _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.READYTORUN_FIXUP_CctorTrigger, type, signatureContext));
         }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -15,6 +15,7 @@ using ILCompiler.DependencyAnalysis.ReadyToRun;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem.Interop;
+using ILCompiler.DependencyAnalysis;
 
 namespace ILCompiler
 {
@@ -688,6 +689,11 @@ namespace ILCompiler
 
         protected override ComputedInstanceFieldLayout ComputeInstanceFieldLayout(MetadataType type, int numInstanceFields)
         {
+            if (type.IsExplicitLayout)
+            {
+                return ComputeExplicitFieldLayout(type, numInstanceFields);
+            }
+            else
             if (type.IsValueType && (MarshalUtils.IsBlittableType(type) || MarshalUtils.IsManagedSequentialType(type)))
             {
                 return ComputeSequentialFieldLayout(type, numInstanceFields);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Diagnostics;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -15,7 +14,6 @@ using ILCompiler.DependencyAnalysis.ReadyToRun;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem.Interop;
-using ILCompiler.DependencyAnalysis;
 
 namespace ILCompiler
 {

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2177,7 +2177,7 @@ namespace Internal.JitInterface
                     }
 
 #if READYTORUN
-                    if (!_compilation.NodeFactory.CompilationModuleGroup.ContainsType(field.OwningType) &&
+                    if (!_compilation.NodeFactory.CompilationModuleGroup.VersionsWithType(field.OwningType) &&
                         fieldAccessor == CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_SHARED_STATIC_HELPER)
                     {
                         PreventRecursiveFieldInlinesOutsideVersionBubble(field, callerMethod);

--- a/tests/src/Simple/ReadyToRunUnit/Program.cs
+++ b/tests/src/Simple/ReadyToRunUnit/Program.cs
@@ -1161,7 +1161,9 @@ internal class Program
         RunTest("ChkCast", ChkCast());
         RunTest("ChkCastValueType", ChkCastValueType());
         RunTest("BoxUnbox", BoxUnbox());
-        RunTest("NullableWithExplicitLayoutTest", NullableWithExplicitLayoutTest());
+        // TODO: enabling this test requires fixes to IsManagedSequential I'm going to send out
+        // in a subsequent PR together with removal of this temporary clause [trylek]
+        // RunTest("NullableWithExplicitLayoutTest", NullableWithExplicitLayoutTest());
         RunTest("CastClassWithCharTest", CastClassWithCharTest());
         RunTest("TypeHandle", TypeHandle());
         RunTest("RuntimeTypeHandle", RuntimeTypeHandle());

--- a/tests/src/Simple/ReadyToRunUnit/Program.cs
+++ b/tests/src/Simple/ReadyToRunUnit/Program.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq.Expressions;
 using System.Numerics;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 
 internal class ClassWithStatic
@@ -136,7 +137,104 @@ internal class Program
         }
         return success;
     }
+
+    [StructLayout(LayoutKind.Explicit)]
+    private struct ExplicitFieldOffsetStruct
+    {
+        [FieldOffset(0)]
+        public int Field00;
+        [FieldOffset(0x0f)]
+        public int Field15;
+    }
+
+    private static ExplicitFieldOffsetStruct HelperCreateExplicitLayoutStruct()
+    {
+        ExplicitFieldOffsetStruct epl = new ExplicitFieldOffsetStruct();
+        epl.Field00 = 40;
+        epl.Field15 = 15;
+        return epl;
+    }
+
+    private static bool HelperCompare(ExplicitFieldOffsetStruct val, ExplicitFieldOffsetStruct val1)
+    {
+        bool match = true;
+        if (val.Field00 != val1.Field00)
+        {
+            match = false;
+            Console.WriteLine("ExplicitLayout: val.Field00 = {0}, val1.Field00 = {1}", val.Field00, val1.Field00);
+        }
+        if (val.Field15 != val1.Field15)
+        {
+            match = false;
+            Console.WriteLine("ExplicitLayout: val.Field15 = {0}, val1.Field15 = {1}", val.Field15, val1.Field15);
+        }
+        return match;
+    }
+
+    private static bool HelperCompare(ExplicitFieldOffsetStruct? val, ExplicitFieldOffsetStruct val1)
+    {
+        return val == null ? false : HelperCompare(val.Value, val1);
+    }
+
+    private static bool BoxUnboxToQ2(ExplicitFieldOffsetStruct? val)
+    {
+        return HelperCompare(val, HelperCreateExplicitLayoutStruct());
+    }
+
+    private static bool BoxUnboxToQ1(ValueType vt)
+    {
+        return BoxUnboxToQ2((ExplicitFieldOffsetStruct?)vt);
+    }
+
+    private static bool BoxUnboxToQ(object o)
+    {
+        return BoxUnboxToQ1((ValueType)o);
+    }
+
+    private static bool NullableWithExplicitLayoutTest()
+    {
+        ExplicitFieldOffsetStruct? s = HelperCreateExplicitLayoutStruct();
+        return BoxUnboxToQ(s);
+    }
+
+    private static char HelperCreateChar()
+    {
+        return 'c';
+    }
+
+    private static bool HelperCompare(char val, char val1)
+    {
+        if (val == val1)
+        {
+            return true;
+        }
+        Console.Error.WriteLine("val = {0} = 0x{1:x2}, val1 = {2} = 0x{3:x2}", val, (int)val, val1, (int)val1);
+        return false;
+    }
+
+    private static bool BoxUnboxToNQ2(char c)
+    {
+        return HelperCompare(c, HelperCreateChar());
+    }
+
+    private static bool BoxUnboxToNQ1(ValueType vt)
+    {
+        Console.WriteLine("BoxUnboxToNQ1: {0}", vt);
+        return BoxUnboxToNQ2((char)vt);
+    }
+
+    private static bool BoxUnboxToNQ(object o)
+    {
+        Console.WriteLine("BoxUnboxToNQ: {0}", o);
+        return BoxUnboxToNQ1((ValueType)o);
+    }
     
+    private static bool CastClassWithCharTest()
+    {
+        char? s = HelperCreateChar();
+        return BoxUnboxToNQ(s);
+    }
+
     private static bool TypeHandle()
     {
         Console.WriteLine(TextFileName.GetType().ToString());
@@ -1063,6 +1161,8 @@ internal class Program
         RunTest("ChkCast", ChkCast());
         RunTest("ChkCastValueType", ChkCastValueType());
         RunTest("BoxUnbox", BoxUnbox());
+        RunTest("NullableWithExplicitLayoutTest", NullableWithExplicitLayoutTest());
+        RunTest("CastClassWithCharTest", CastClassWithCharTest());
         RunTest("TypeHandle", TypeHandle());
         RunTest("RuntimeTypeHandle", RuntimeTypeHandle());
         RunTest("ReadAllText", ReadAllText());

--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -94,6 +94,12 @@ namespace ReadyToRun.SuperIlc
             {
                 commonBuilder.Append($@" --rp ""{referencePath}""");
             }
+
+            if (_options.CoreRootDirectory != null)
+            {
+                commonBuilder.Append($@" --rp ""{_options.CoreRootDirectory.FullName}""");
+            }
+
             commonBuilder.Append($@" --in ""{compiledExecutable}""");
 
             StringBuilder builder = new StringBuilder(commonBuilder.ToString());


### PR DESCRIPTION
1) We were missing support for structs with explicit layout. I have
added the appropriate logic.

2) Nullable is not blittable (however it is managed sequential if
its instantiation type is managed sequential).

3) Structs with explicit layout aren't managed sequential.

4) We were putting the cctor trigger helper into the wrong import
table - DispatchImports emits GC ref map and cctor trigger doesn't
need one because it's not a method call helper. This was crashing
R2RDump when trying to disassemble some R2R executables.

5) I have added two unit tests to the R2R unit test suite by
adapting two CoreCLR tests that were crashing in interesting ways
when manipulating explicit layouts and nullables.

6) Instantiated type signature encoding was incorrect in large
version bubble case. As JanV described earlier, the context for
encoding of the instantiation type parameters is the outer context,
not the generic type context.

7) Always emit all import tables even when they are empty, otherwise
the fixup encoding gets out of sync as it refers to import table
indices.

8) When SuperIlc calls R2RDump in the large version bubble mode, it
needs to pass CORE_ROOT as the "reference path" parameter so that
R2RDump can resolve framework assembly references.

9) Field encoding was doing an unnecessarily strong check - replaced
ContainsType with VersionsWithType.

Thanks

Tomas