### PR TITLE
Harmonize ContainsPointers flags between CoreRT & CoreCLR

### DIFF
--- a/src/Common/src/Internal/Runtime/EEType.Constants.cs
+++ b/src/Common/src/Internal/Runtime/EEType.Constants.cs
@@ -38,9 +38,9 @@ namespace Internal.Runtime
         HasFinalizerFlag = 0x0010,
 
         /// <summary>
-        /// This type contain GC pointers.
+        /// This type has optional fields present.
         /// </summary>
-        HasPointersFlag = 0x0020,
+        OptionalFieldsFlag = 0x0020,
 
         /// <summary>
         /// Type implements ICastable to allow dynamic resolution of interface casts.
@@ -54,9 +54,9 @@ namespace Internal.Runtime
         GenericVarianceFlag = 0x0080,
 
         /// <summary>
-        /// This type has optional fields present.
+        /// This type contain GC pointers.
         /// </summary>
-        OptionalFieldsFlag = 0x0100,
+        HasPointersFlag = 0x0100,
 
         /// <summary>
         /// This EEType represents an interface.

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -255,8 +255,8 @@ private:
         // This EEType represents a type which requires finalization
         HasFinalizerFlag        = 0x0010,
 
-        // This type contain gc pointers
-        HasPointersFlag         = 0x0020,
+        // This type has optional fields present.
+        OptionalFieldsFlag      = 0x0020,
 
         // Type implements ICastable to allow dynamic resolution of interface casts.
         ICastableTypeFlag       = 0x0040,
@@ -265,8 +265,8 @@ private:
         // applies to interface and delegate types.
         GenericVarianceFlag     = 0x0080,
 
-        // This type has optional fields present.
-        OptionalFieldsFlag      = 0x0100,
+        // This type contain gc pointers
+        HasPointersFlag         = 0x0100,
 
         // This EEType represents an interface.
         IsInterfaceFlag         = 0x0200,


### PR DESCRIPTION
If there's no reason for these flags to be different between coreclr and corert, I'd like to have the same value across them.

This allows the frozen segment deserializer code to not have to be forked across the runtimes.