### PR TITLE
WASM: Enable GCStaticsNode instead of llvm globals

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -3292,13 +3292,8 @@ namespace Internal.IL
                         if (field.HasGCStaticBase)
                         {
                             node = _compilation.NodeFactory.TypeGCStaticsSymbol(owningType);
-
-                            // We can't use GCStatics in the data section until we can successfully call
-                            // InitializeModules on startup, so stick with globals for now
-                            //LLVMValueRef basePtrPtr = LoadAddressOfSymbolNode(node);
-                            //staticBase = LLVM.BuildLoad(_builder, LLVM.BuildLoad(_builder, LLVM.BuildPointerCast(_builder, basePtrPtr, LLVM.PointerType(LLVM.PointerType(LLVM.PointerType(LLVM.Int8Type(), 0), 0), 0), "castBasePtrPtr"), "basePtr"), "base");
-                            staticBase = WebAssemblyObjectWriter.EmitGlobal(Module, field, _compilation.NameMangler);
-                            fieldOffset = 0;
+                            LLVMValueRef basePtrPtr = LoadAddressOfSymbolNode(node);
+                            staticBase = LLVM.BuildLoad(_builder, LLVM.BuildLoad(_builder, LLVM.BuildPointerCast(_builder, basePtrPtr, LLVM.PointerType(LLVM.PointerType(LLVM.PointerType(LLVM.Int8Type(), 0), 0), 0), "castBasePtrPtr"), "basePtr"), "base");
                         }
                         else
                         {

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -290,6 +290,16 @@ internal static class Program
 
         TestInitObjDouble();
 
+        StartTest("Non/GCStatics field access test");
+        if (new FieldStatics().TestGetSet())
+        {
+            PassTest();
+        }
+        else
+        {
+            FailTest();
+        }
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -1313,6 +1323,24 @@ class DisposableTest : IDisposable
     public void Dispose()
     {
         Disposed = true;
+    }
+}
+
+class FieldStatics
+{
+    static int X;
+    static int Y;
+    static string S1;
+    static string S2;
+
+    public bool TestGetSet()
+    {
+        X = 17;
+        Y = 347;
+        S1 = "first string";
+        S2 = "a different string";
+
+        return X == 17 && Y == 347 && S1 == "first string" && S2 == "a different string";
     }
 }
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1335,6 +1335,8 @@ class FieldStatics
 
     public bool TestGetSet()
     {
+        if (!(X == 0 && Y == 0 && S1 == null && S2 == null)) return false;
+
         X = 17;
         Y = 347;
         S1 = "first string";


### PR DESCRIPTION
In order to progress #7248 , this change enables GCStatics by uncommenting some code that was already present but commented due to the earlier problem of `InitializeModules` not being called at startup.  `InitializeModules` is now called for wasm at startup (I added a printf to be sure) and the commented GCStatics code worked as it was.  I added a test for static field access and it produces this snippet of llvm:

```
%LoadAddressOfSymbolNode4 = load i32*, i32** @__Str_first_string_31DAE213E988224C1F7CFBECD99A0DA573F5FDAB1922570E42F281A9DCFFC1E9___SYMBOL, !dbg !7923
  %LoadAddressOfSymbolNode5 = load i32*, i32** @__GCStaticBase_HelloWasm_FieldStatics___SYMBOL, !dbg !7923
  %castBasePtrPtr = bitcast i32* %LoadAddressOfSymbolNode5 to i8***, !dbg !7923
  %basePtr = load i8**, i8*** %castBasePtrPtr, !dbg !7923
  %base = load i8*, i8** %basePtr, !dbg !7923
  %S1_addr = getelementptr i8, i8* %base, i32 4, !dbg !7923
  %CastPtrstring = bitcast i8* %S1_addr to i8**, !dbg !7923
  %CastPtr = bitcast i32* %LoadAddressOfSymbolNode4 to i8*, !dbg !7923
  store i8* %CastPtr, i8** %CastPtrstring, !dbg !7923
  %LoadAddressOfSymbolNode6 = load i32*, i32** @__Str_a_different_string_1B09B108E59054EEE2BADD80C449F869A0EEBD1B5472EF5FC727ED498E6D54C8___SYMBOL, !dbg !7924
  %LoadAddressOfSymbolNode7 = load i32*, i32** @__GCStaticBase_HelloWasm_FieldStatics___SYMBOL, !dbg !7924
  %castBasePtrPtr8 = bitcast i32* %LoadAddressOfSymbolNode7 to i8***, !dbg !7924
  %basePtr9 = load i8**, i8*** %castBasePtrPtr8, !dbg !7924
  %base10 = load i8*, i8** %basePtr9, !dbg !7924
  %S2_addr = getelementptr i8, i8* %base10, i32 8, !dbg !7924
```

Where we can see that it is going to the GCStaticBase for the class and has 2 different offsets in the `getelementptr` statements, 4 and 8, so looks fine to me.

