### PR TITLE
Change error message for unsupported marshallers

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -355,7 +355,7 @@ namespace Internal.IL.Stubs
             catch (NotSupportedException)
             {
                 string message = "Method '" + method.ToString() +
-                    "' requires non-trivial marshalling that is not yet supported by this compiler.";
+                    "' requires marshalling that is not yet supported by this compiler.";
                 return MarshalHelpers.EmitExceptionBody(message, method);
             }
             catch (InvalidProgramException ex)

--- a/src/Common/src/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
@@ -287,7 +287,7 @@ namespace Internal.IL.Stubs
             catch (NotSupportedException)
             {
                 string message = "Struct '" + ((MetadataType)ManagedType).Name +
-                    "' requires non-trivial marshalling that is not yet supported by this compiler.";
+                    "' requires marshalling that is not yet supported by this compiler.";
                 return MarshalHelpers.EmitExceptionBody(message, this);
             }
             catch (InvalidProgramException ex)


### PR DESCRIPTION
We now support many marshallers that I would consider non-trivial. The error should just say the marshaller is not implemented...