### PR TITLE
Drop size of Hello World to 1.16 MB

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -100,7 +100,7 @@ See the LICENSE file in the project root for more information.
   </ItemGroup>
 
   <ItemGroup Condition="'$(ExperimentalDynamicCodeSupport)' != 'true'">
-    <AutoInitializedAssemblies Include="System.Private.StackTraceMetadata" />
+    <AutoInitializedAssemblies Include="System.Private.StackTraceMetadata" Condition="$(IlcDisableReflection) != 'true' or $(IlcGenerateStackTraceData) == 'true'"/>
     <AutoInitializedAssemblies Include="System.Private.TypeLoader" />
     <AutoInitializedAssemblies Include="System.Private.Reflection.Execution" Condition="$(IlcDisableReflection) != 'true'" />
     <AutoInitializedAssemblies Include="System.Private.DisabledReflection" Condition="$(IlcDisableReflection) == 'true'" />

--- a/src/Common/src/TypeSystem/IL/DelegateInfo.cs
+++ b/src/Common/src/TypeSystem/IL/DelegateInfo.cs
@@ -26,11 +26,6 @@ namespace Internal.IL
         private MethodDesc _getThunkMethod;
         private DelegateThunkCollection _thunks;
 
-        public static bool SupportsDynamicInvoke(TypeSystemContext context)
-        {
-            return DynamicInvokeMethodThunk.SupportsDynamicInvoke(context);
-        }
-
         /// <summary>
         /// Gets the synthetic methods that support this delegate type.
         /// </summary>
@@ -179,7 +174,7 @@ namespace Internal.IL
             // Check whether we have an open instance thunk
             //
 
-            if (delegateSignature.Length > 0)
+            if ((owningDelegate.SupportedFeatures & DelegateFeature.OpenInstanceThunk) != 0 && delegateSignature.Length > 0)
             {
                 TypeDesc firstParam = delegateSignature[0];
 
@@ -310,5 +305,8 @@ namespace Internal.IL
     {
         DynamicInvoke = 0x1,
         ObjectArrayThunk = 0x2,
+        OpenInstanceThunk = 0x4,
+
+        All = 0x7,
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -20,13 +20,13 @@ namespace ILCompiler
 {
     public partial class CompilerTypeSystemContext : MetadataTypeSystemContext, IMetadataStringDecoderProvider
     {
-        private MetadataFieldLayoutAlgorithm _metadataFieldLayoutAlgorithm = new CompilerMetadataFieldLayoutAlgorithm();
-        private RuntimeDeterminedFieldLayoutAlgorithm _runtimeDeterminedFieldLayoutAlgorithm = new RuntimeDeterminedFieldLayoutAlgorithm();
-        private VectorOfTFieldLayoutAlgorithm _vectorOfTFieldLayoutAlgorithm;
-        private VectorFieldLayoutAlgorithm _vectorFieldLayoutAlgorithm;
-        private MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();
+        private readonly MetadataFieldLayoutAlgorithm _metadataFieldLayoutAlgorithm = new CompilerMetadataFieldLayoutAlgorithm();
+        private readonly RuntimeDeterminedFieldLayoutAlgorithm _runtimeDeterminedFieldLayoutAlgorithm = new RuntimeDeterminedFieldLayoutAlgorithm();
+        private readonly VectorOfTFieldLayoutAlgorithm _vectorOfTFieldLayoutAlgorithm;
+        private readonly VectorFieldLayoutAlgorithm _vectorFieldLayoutAlgorithm;
+        private readonly MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();
         private ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
-        private MetadataVirtualMethodAlgorithm _virtualMethodAlgorithm = new MetadataVirtualMethodAlgorithm();
+        private readonly MetadataVirtualMethodAlgorithm _virtualMethodAlgorithm = new MetadataVirtualMethodAlgorithm();
 
         protected SimdHelper _simdHelper;
 
@@ -67,7 +67,7 @@ namespace ILCompiler
                 return null;
             }
         }
-        private ModuleHashtable _moduleHashtable = new ModuleHashtable();
+        private readonly ModuleHashtable _moduleHashtable = new ModuleHashtable();
 
         private class SimpleNameHashtable : LockFreeReaderHashtable<string, ModuleData>
         {
@@ -95,17 +95,21 @@ namespace ILCompiler
                 return null;
             }
         }
-        private SimpleNameHashtable _simpleNameHashtable = new SimpleNameHashtable();
+        private readonly SimpleNameHashtable _simpleNameHashtable = new SimpleNameHashtable();
 
-        private SharedGenericsMode _genericsMode;
+        private readonly SharedGenericsMode _genericsMode;
+
+        private readonly DelegateFeature _delegateFeatures;
         
-        public CompilerTypeSystemContext(TargetDetails details, SharedGenericsMode genericsMode)
+        public CompilerTypeSystemContext(TargetDetails details, SharedGenericsMode genericsMode, DelegateFeature delegateFeatures)
             : base(details)
         {
             _genericsMode = genericsMode;
 
             _vectorOfTFieldLayoutAlgorithm = new VectorOfTFieldLayoutAlgorithm(_metadataFieldLayoutAlgorithm);
             _vectorFieldLayoutAlgorithm = new VectorFieldLayoutAlgorithm(_metadataFieldLayoutAlgorithm);
+
+            _delegateFeatures = delegateFeatures;
 
             GenericsConfig = new SharedGenericsConfiguration();
         }
@@ -480,6 +484,11 @@ namespace ILCompiler
             }
 
             return reader;
+        }
+
+        protected override DelegateInfo CreateDelegateInfo(TypeDesc delegateType)
+        {
+            return new DelegateInfo(delegateType, _delegateFeatures);
         }
     }
 

--- a/src/ILCompiler.Compiler/tests/DependencyGraphTests.cs
+++ b/src/ILCompiler.Compiler/tests/DependencyGraphTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 
+using Internal.IL;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
@@ -34,7 +35,7 @@ namespace ILCompiler.Compiler.Tests
         public static IEnumerable<object[]> GetTestMethods()
         {
             var target = new TargetDetails(TargetArchitecture.X64, TargetOS.Windows, TargetAbi.CoreRT);
-            var context = new CompilerTypeSystemContext(target, SharedGenericsMode.CanonicalReferenceTypes);
+            var context = new CompilerTypeSystemContext(target, SharedGenericsMode.CanonicalReferenceTypes, DelegateFeature.All);
 
             context.InputFilePaths = new Dictionary<string, string> {
                 { "Test.CoreLib", @"Test.CoreLib.dll" },

--- a/src/ILCompiler.Compiler/tests/DevirtualizationTests.cs
+++ b/src/ILCompiler.Compiler/tests/DevirtualizationTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 
+using Internal.IL;
 using Internal.TypeSystem;
 
 using Xunit;
@@ -18,7 +19,7 @@ namespace ILCompiler.Compiler.Tests
         public DevirtualizationTests()
         {
             var target = new TargetDetails(TargetArchitecture.X64, TargetOS.Windows, TargetAbi.CoreRT);
-            _context = new CompilerTypeSystemContext(target, SharedGenericsMode.CanonicalReferenceTypes);
+            _context = new CompilerTypeSystemContext(target, SharedGenericsMode.CanonicalReferenceTypes, DelegateFeature.All);
 
             _context.InputFilePaths = new Dictionary<string, string> {
                 { "Test.CoreLib", @"Test.CoreLib.dll" },

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCompilerContext.cs
@@ -20,7 +20,7 @@ namespace ILCompiler
         VectorIntrinsicFieldLayoutAlgorithm _vectorIntrinsicFieldLayoutAlgorithm;
 
         public ReadyToRunCompilerContext(TargetDetails details, SharedGenericsMode genericsMode)
-            : base(details, genericsMode)
+            : base(details, genericsMode, delegateFeatures: 0)
         {
             _r2rFieldLayoutAlgorithm = new ReadyToRunMetadataFieldLayoutAlgorithm();
             _systemObjectFieldLayoutAlgorithm = new SystemObjectFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -305,6 +305,8 @@ namespace ILCompiler
             if (_isWasmCodegen)
                 _targetArchitecture = TargetArchitecture.Wasm32;
 
+            bool supportsReflection = !_disableReflection && !_isReadyToRunCodeGen && _systemModuleName == DefaultSystemModule;
+
             //
             // Initialize type system context
             //
@@ -318,7 +320,7 @@ namespace ILCompiler
             var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, targetAbi, simdVectorLength);
             CompilerTypeSystemContext typeSystemContext = (_isReadyToRunCodeGen
                 ? new ReadyToRunCompilerContext(targetDetails, genericsMode)
-                : new CompilerTypeSystemContext(targetDetails, genericsMode));
+                : new CompilerTypeSystemContext(targetDetails, genericsMode, supportsReflection ? DelegateFeature.All : 0));
 
             //
             // TODO: To support our pre-compiled test tree, allow input files that aren't managed assemblies since
@@ -547,8 +549,6 @@ namespace ILCompiler
                 metadataGenerationOptions |= UsageBasedMetadataGenerationOptions.ILScanning;
 
             DynamicInvokeThunkGenerationPolicy invokeThunkGenerationPolicy = new DefaultDynamicInvokeThunkGenerationPolicy();
-
-            bool supportsReflection = !_disableReflection && !_isReadyToRunCodeGen && _systemModuleName == DefaultSystemModule;
 
             MetadataManager metadataManager;
             if (_isReadyToRunCodeGen)

--- a/src/ILCompiler/src/RemovingILProvider.cs
+++ b/src/ILCompiler/src/RemovingILProvider.cs
@@ -143,6 +143,24 @@ namespace ILCompiler
                         return RemoveAction.ConvertToThrow;
                     }
 
+                    // We remove this one explicitly because it ends up calling EnumCalendarInfoExEx on Windows
+                    // and brings in delegate reverse p/invoke support into the app.
+                    if (method.Name == "GetCalendars" &&
+                        method.Signature.Length == 3 &&
+                        mdType.Name == "CalendarData" && mdType.Namespace == "System.Globalization")
+                    {
+                        return RemoveAction.ConvertToThrow;
+                    }
+
+                    // We remove this one explicitly because it ends up calling EnumTimeFormatsEx on Windows
+                    // and brings in delegate reverse p/invoke support into the app.
+                    if ((method.Name == "GetTimeFormats" || method.Name == "GetShortTimeFormats") &&
+                        method.Signature.Length == 0 &&
+                        mdType.Name == "CultureData" && mdType.Namespace == "System.Globalization")
+                    {
+                        return RemoveAction.ConvertToThrow;
+                    }
+
                     if (method.Signature.Length == 1 &&
                         method.Name == "GetCalendarInstanceRare" &&
                         mdType.Name == "CultureInfo" && mdType.Namespace == "System.Globalization")

--- a/src/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/System.Private.CoreLib/src/System/Delegate.cs
@@ -75,14 +75,20 @@ namespace System
         // If the thunk does not exist, the function will return IntPtr.Zero.
         protected virtual IntPtr GetThunk(int whichThunk)
         {
-#if DEBUG
+#if PROJECTN
             // The GetThunk function should be overriden on all delegate types, except for universal
             // canonical delegates which use calling convention converter thunks to marshal arguments
             // for the delegate call. If we execute this version of GetThunk, we can at least assert
             // that the current delegate type is a generic type.
             Debug.Assert(this.EETypePtr.IsGeneric);
-#endif
             return TypeLoaderExports.GetDelegateThunk(this, whichThunk);
+#else
+            // CoreRT doesn't support Universal Shared Code right now, so let's make this method return null for now.
+            // When CoreRT adds USG support we'll probably want to do some level of IL switching here so that
+            // we don't have this static call into type loader when USG is not enabled at compile time.
+            // The static call hurts size in our minimal targets.
+            return IntPtr.Zero;
+#endif
         }
 
         //

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.NamedTypeLookup.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.NamedTypeLookup.cs
@@ -38,7 +38,7 @@ namespace Internal.Runtime.TypeLoader
 
         private NamedTypeRuntimeTypeHandleToMetadataHashtable _runtimeTypeHandleToMetadataHashtable = new NamedTypeRuntimeTypeHandleToMetadataHashtable();
 
-        public static IntPtr NoStaticsData { get; private set; }
+        public static IntPtr NoStaticsData { get; } = (IntPtr)1;
 
         private class NamedTypeRuntimeTypeHandleToMetadataHashtable : LockFreeReaderHashtable<RuntimeTypeHandle, NamedTypeLookupResult>
         {

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -118,7 +118,7 @@ namespace Internal.Runtime.TypeLoader
         [ThreadStatic]
         private static bool t_isReentrant;
 
-        public static TypeLoaderEnvironment Instance { get; private set; }
+        public static TypeLoaderEnvironment Instance { get; } = new TypeLoaderEnvironment();
 
         /// <summary>
         /// List of loaded binary modules is typically used to locate / process various metadata blobs
@@ -136,9 +136,7 @@ namespace Internal.Runtime.TypeLoader
         // Eager initialization called from LibraryInitializer for the assembly.
         internal static void Initialize()
         {
-            Instance = new TypeLoaderEnvironment();
             RuntimeAugments.InitializeLookups(new Callbacks());
-            NoStaticsData = (IntPtr)1;
         }
 
         public TypeLoaderEnvironment()


### PR DESCRIPTION
Set of commits that allow us to drop the size of a fully self-contained native C# Hello World to 1.16 MB (with all the [documented](http://aka.ms/OptimizeCoreRT) size optimization switches enabled, that is).

See individual commits for descriptions.