### PR TITLE
ArgIterator hardening to gracefully handle indeterminate return types

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -103,7 +103,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public int GetSize()
         {
             if (IsValueType())
-                return _type.GetElementSize().AsInt;
+                return ((DefType)_type).InstanceFieldSize.AsInt;
             else
                 return PointerSize;
         }
@@ -1729,7 +1729,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             if (!_RETURN_HAS_RET_BUFFER)
             {
-                _transitionBlock.ComputeReturnValueTreatment(type, thRetType, IsVarArg, out _RETURN_HAS_RET_BUFFER, out _fpReturnSize);
+                if (!_transitionBlock.ComputeReturnValueTreatment(type, thRetType, IsVarArg, out _RETURN_HAS_RET_BUFFER, out _fpReturnSize))
+                {
+                    _hasIndeterminateSize = true;
+                }
             }
 
             _RETURN_FLAGS_COMPUTED = true;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -66,7 +66,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _transitionBlock = TransitionBlock.FromTarget(factory.Target);
         }
 
-        public bool GetCallRefMap(MethodDesc method)
+        public void GetCallRefMap(MethodDesc method)
         {
             TransitionBlock transitionBlock = TransitionBlock.FromTarget(method.Context.Target);
 
@@ -98,9 +98,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             if (argit.HasIndeterminateSize())
             {
-                // Flush an empty GC ref map block so that the list of methods remains in sync with the list of GC ref map records
-                Flush();
-                return false;
+                throw new InternalCompilerErrorException("GCRefMapBuilder->" + method.ToString());
             }
 
             int nStackBytes = argit.SizeOfFrameArgumentArray();
@@ -149,7 +147,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
 
             Flush();
-            return true;
         }
 
         /// <summary>

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -66,7 +66,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _transitionBlock = TransitionBlock.FromTarget(factory.Target);
         }
 
-        public void GetCallRefMap(MethodDesc method)
+        public bool GetCallRefMap(MethodDesc method)
         {
             TransitionBlock transitionBlock = TransitionBlock.FromTarget(method.Context.Target);
 
@@ -100,7 +100,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 // Flush an empty GC ref map block so that the list of methods remains in sync with the list of GC ref map records
                 Flush();
-                return;
+                return false;
             }
 
             int nStackBytes = argit.SizeOfFrameArgumentArray();
@@ -149,6 +149,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
 
             Flush();
+            return true;
         }
 
         /// <summary>

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -96,11 +96,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 skipFirstArg,
                 extraObjectFirstArg);
 
-            if (argit.HasIndeterminateSize())
-            {
-                throw new InternalCompilerErrorException("GCRefMapBuilder->" + method.ToString());
-            }
-
             int nStackBytes = argit.SizeOfFrameArgumentArray();
 
             // Allocate a fake stack

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
@@ -88,15 +88,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 if (methodNode == null || methodNode.IsEmpty)
                 {
                     // Flush an empty GC ref map block to prevent
-                    // the indexed records to fall out of sync with methods
+                    // the indexed records from falling out of sync with methods
                     builder.Flush();
                 }
                 else
                 {
-                    if (!builder.GetCallRefMap(methodNode.Method))
-                    {
-                        throw new InternalCompilerErrorException("GCRefMap / " + methodNode.Method.ToString());
-                    }
+                    builder.GetCallRefMap(methodNode.Method);
                 }
             }
             Debug.Assert(nextOffsetIndex == offsets.Length);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapNode.cs
@@ -19,15 +19,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public const int GCREFMAP_LOOKUP_STRIDE = 1024;
 
         private readonly ImportSectionNode _importSection;
-        private readonly List<IMethodNode> _methods;
-
-        private int _index;
+        private readonly List<MethodWithGCInfo> _methods;
 
         public GCRefMapNode(ImportSectionNode importSection)
         {
             _importSection = importSection;
-            _methods = new List<IMethodNode>();
-            _index = 0;
+            _methods = new List<MethodWithGCInfo>();
         }
 
         public override ObjectNodeSection Section => ObjectNodeSection.ReadOnlyDataSection;
@@ -42,15 +39,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public void AddImport(Import import)
         {
-            if (import is IMethodNode methodNode)
-            {
-                while (_methods.Count <= _index)
-                {
-                    _methods.Add(null);
-                }
-                _methods[_index] = methodNode;
-            }
-            _index++;
+            _methods.Add(import as IMethodNode as MethodWithGCInfo);
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -95,8 +84,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     nextOffsetIndex++;
                     nextMethodIndex += GCREFMAP_LOOKUP_STRIDE;
                 }
-                IMethodNode methodNode = _methods[methodIndex];
-                if (methodNode == null)
+                MethodWithGCInfo methodNode = _methods[methodIndex];
+                if (methodNode == null || methodNode.IsEmpty)
                 {
                     // Flush an empty GC ref map block to prevent
                     // the indexed records to fall out of sync with methods
@@ -104,7 +93,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 }
                 else
                 {
-                    builder.GetCallRefMap(methodNode.Method);
+                    if (!builder.GetCallRefMap(methodNode.Method))
+                    {
+                        throw new InternalCompilerErrorException("GCRefMap / " + methodNode.Method.ToString());
+                    }
                 }
             }
             Debug.Assert(nextOffsetIndex == offsets.Length);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -247,7 +247,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             return size > EnregisteredParamTypeMaxSize;
         }
 
-        public void ComputeReturnValueTreatment(CorElementType type, TypeHandle thRetType, bool isVarArgMethod, out bool usesRetBuffer, out uint fpReturnSize)
+        public bool ComputeReturnValueTreatment(CorElementType type, TypeHandle thRetType, bool isVarArgMethod, out bool usesRetBuffer, out uint fpReturnSize)
         {
             usesRetBuffer = false;
             fpReturnSize = 0;
@@ -294,6 +294,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                             break;
                         }
 
+                        if (thRetType.HasIndeterminateSize())
+                        {
+                            return false;
+                        }
+
                         uint size = (uint)thRetType.GetSize();
 
                         if (IsX86 || IsX64)
@@ -317,6 +322,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 default:
                     break;
             }
+
+            return true;
         }
 
         public const int InvalidOffset = -1;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -247,7 +247,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             return size > EnregisteredParamTypeMaxSize;
         }
 
-        public bool ComputeReturnValueTreatment(CorElementType type, TypeHandle thRetType, bool isVarArgMethod, out bool usesRetBuffer, out uint fpReturnSize)
+        public void ComputeReturnValueTreatment(CorElementType type, TypeHandle thRetType, bool isVarArgMethod, out bool usesRetBuffer, out uint fpReturnSize)
         {
             usesRetBuffer = false;
             fpReturnSize = 0;
@@ -294,11 +294,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                             break;
                         }
 
-                        if (thRetType.HasIndeterminateSize())
-                        {
-                            return false;
-                        }
-
                         uint size = (uint)thRetType.GetSize();
 
                         if (IsX86 || IsX64)
@@ -322,8 +317,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 default:
                     break;
             }
-
-            return true;
         }
 
         public const int InvalidOffset = -1;


### PR DESCRIPTION
When analyzing the remaining CPAOT error buckets, I noticed several
tests that were still crashing CPAOT due to indeterminate types
in the ArgIterator. I found out that I had previously only fixed
the argument types but I overlooked the need to fix the return value
in a similar manner. I have also applied a tiny cleanup that Michal
suggested earlier - using InstanceFieldSize instead of GetElementSize.

Thanks

Tomas

P.S. I double-checked the other few callers of TypeHandle.GetSize
and I believe this is the last remaining place that is not protected
by an upfront indeterminate type check and graceful bail-out.