### PR TITLE
Changing assembler constant format

### DIFF
--- a/src/Native/Runtime/amd64/AllocFast.S
+++ b/src/Native/Runtime/amd64/AllocFast.S
@@ -203,7 +203,7 @@ NESTED_END RhNewString, _TEXT
 //  ESI == element count
 NESTED_ENTRY RhpNewArray, _TEXT, NoHandler
         // we want to limit the element count to the non-negative 32-bit int range
-        cmp         rsi, 07fffffffh
+        cmp         rsi, 0x07fffffff
         ja          LOCAL_LABEL(ArraySizeOverflow)
 
         push_nonvol_reg rbx

--- a/src/Native/Runtime/amd64/WriteBarriers.S
+++ b/src/Native/Runtime/amd64/WriteBarriers.S
@@ -98,7 +98,7 @@ LOCAL_LABEL(\BASENAME\()_UpdateShadowHeap_Done_\REFREG):
     // the byte if it hasn't already been done since writes are expensive and impact scaling.
     shr     rdi, 11
     add     rdi, [C_VAR(g_card_table)]
-    cmp     byte ptr [rdi], 0FFh
+    cmp     byte ptr [rdi], 0x0FF
     jne     LOCAL_LABEL(\BASENAME\()_UpdateCardTable_\REFREG)
 
 LOCAL_LABEL(\BASENAME\()_NoBarrierRequired_\REFREG):
@@ -106,7 +106,7 @@ LOCAL_LABEL(\BASENAME\()_NoBarrierRequired_\REFREG):
 
 // We get here if it's necessary to update the card table.
 LOCAL_LABEL(\BASENAME\()_UpdateCardTable_\REFREG):
-    mov     byte ptr [rdi], 0FFh
+    mov     byte ptr [rdi], 0x0FF
     ret
 
 .endm
@@ -262,8 +262,8 @@ LEAF_ENTRY RhpByRefAssignRef, _TEXT
 
     // move current rdi value into rcx and then increment the pointers
     mov     rcx, rdi
-    add     rsi, 8h
-    add     rdi, 8h
+    add     rsi, 0x8
+    add     rdi, 0x8
 
     // We have a location on the GC heap being updated with a reference to an ephemeral object so we must
     // track this write. The location address is translated into an offset in the card table bitmap. We set
@@ -271,18 +271,18 @@ LEAF_ENTRY RhpByRefAssignRef, _TEXT
     // the byte if it hasn't already been done since writes are expensive and impact scaling.
     shr     rcx, 11
     add     rcx, [C_VAR(g_card_table)]
-    cmp     byte ptr [rcx], 0FFh
+    cmp     byte ptr [rcx], 0x0FF
     jne     LOCAL_LABEL(RhpByRefAssignRef_UpdateCardTable)
     ret
 
 // We get here if it's necessary to update the card table.
 LOCAL_LABEL(RhpByRefAssignRef_UpdateCardTable):
-    mov     byte ptr [rcx], 0FFh
+    mov     byte ptr [rcx], 0x0FF
     ret
 
 LOCAL_LABEL(RhpByRefAssignRef_NotInHeap):
     // Increment the pointers before leaving
-    add     rdi, 8h
-    add     rsi, 8h
+    add     rdi, 0x8
+    add     rsi, 0x8
     ret
 LEAF_END RhpByRefAssignRef, _TEXT

--- a/src/Native/Runtime/arm/WriteBarriers.S
+++ b/src/Native/Runtime/arm/WriteBarriers.S
@@ -124,7 +124,7 @@ LOCAL_LABEL(\BASENAME\()_UpdateShadowHeap_Done_\REFREG):
           ldr          r12, [r12]
           add          r0, r12, r0, lsr #LOG2_CLUMP_SIZE
           ldrb         r12, [r0]
-          cmp          r12, #0FFh
+          cmp          r12, #0x0FF
           bne          LOCAL_LABEL(\BASENAME\()_UpdateCardTable_\REFREG)
 
 LOCAL_LABEL(\BASENAME\()_NoBarrierRequired_\REFREG):
@@ -132,7 +132,7 @@ LOCAL_LABEL(\BASENAME\()_NoBarrierRequired_\REFREG):
 
 // We get here if it's necessary to update the card table.
 LOCAL_LABEL(\BASENAME\()_UpdateCardTable_\REFREG):
-          mov          r12, #0FFh
+          mov          r12, #0x0FF
           strb         r12, [r0]
 
 LOCAL_LABEL(\BASENAME\()_EXIT_\REFREG):
@@ -365,13 +365,13 @@ LEAF_ENTRY RhpByRefAssignRef, _TEXT
           ldr           r3, [r3]
           add           r2, r3, r2, lsr #LOG2_CLUMP_SIZE
           ldrb          r3, [r2]
-          cmp           r3, #0FFh
+          cmp           r3, #0x0FF
           bne           LOCAL_LABEL(RhpByRefAssignRef_UpdateCardTable)
           bx            lr
 
 // We get here if it's necessary to update the card table.
 LOCAL_LABEL(RhpByRefAssignRef_UpdateCardTable):
-          mov           r3, #0FFh
+          mov           r3, #0x0FF
           strb          r3, [r2]
           bx            lr
 

--- a/src/Native/Runtime/unix/unixasmmacrosamd64.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosamd64.inc
@@ -254,18 +254,18 @@ C_FUNC(\Name):
 #define GC_ALLOC_FINALIZE           1
 
 // Note: these must match the defs in PInvokeTransitionFrameFlags
-#define PTFF_SAVE_RBX            00000001h
-#define PTFF_SAVE_R12            00000010h
-#define PTFF_SAVE_R13            00000020h
-#define PTFF_SAVE_R14            00000040h
-#define PTFF_SAVE_R15            00000080h
-#define PTFF_SAVE_ALL_PRESERVED  000000F1h   // NOTE: RBP is not included in this set!
-#define PTFF_SAVE_RSP            00008000h
-#define PTFF_SAVE_RAX            00000100h   // RAX is saved if it contains a GC ref and we're in hijack handler
-#define PTFF_SAVE_ALL_SCRATCH    00007F00h
-#define PTFF_RAX_IS_GCREF        00010000h   // iff PTFF_SAVE_RAX: set -> eax is Object, clear -> eax is scalar
-#define PTFF_RAX_IS_BYREF        00020000h   // iff PTFF_SAVE_RAX: set -> eax is ByRef, clear -> eax is Object or scalar
-#define PTFF_THREAD_ABORT        00040000h   // indicates that ThreadAbortException should be thrown when returning from the transition
+#define PTFF_SAVE_RBX            0x00000001
+#define PTFF_SAVE_R12            0x00000010
+#define PTFF_SAVE_R13            0x00000020
+#define PTFF_SAVE_R14            0x00000040
+#define PTFF_SAVE_R15            0x00000080
+#define PTFF_SAVE_ALL_PRESERVED  0x000000F1   // NOTE: RBP is not included in this set!
+#define PTFF_SAVE_RSP            0x00008000
+#define PTFF_SAVE_RAX            0x00000100   // RAX is saved if it contains a GC ref and we're in hijack handler
+#define PTFF_SAVE_ALL_SCRATCH    0x00007F00
+#define PTFF_RAX_IS_GCREF        0x00010000   // iff PTFF_SAVE_RAX: set -> eax is Object, clear -> eax is scalar
+#define PTFF_RAX_IS_BYREF        0x00020000   // iff PTFF_SAVE_RAX: set -> eax is ByRef, clear -> eax is Object or scalar
+#define PTFF_THREAD_ABORT        0x00040000   // indicates that ThreadAbortException should be thrown when returning from the transition
 
 // These must match the TrapThreadsFlags enum
 #define TrapThreadsFlags_None            0
@@ -312,7 +312,7 @@ DEFAULT_FRAME_SAVE_FLAGS = PTFF_SAVE_ALL_PRESERVED + PTFF_SAVE_RSP
 .macro PUSH_COOP_PINVOKE_FRAME trashReg
     push_nonvol_reg rbp                         // push RBP frame
     mov             rbp, rsp
-    lea             \trashReg, [rsp + 10h]
+    lea             \trashReg, [rsp + 0x10]
     push_register   \trashReg                   // save caller's RSP
     push_nonvol_reg r15                         // save preserved registers
     push_nonvol_reg r14                         //   ..


### PR DESCRIPTION
Fixes #7607 

According to the [GNU assembler documentation](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.32.4503&rep=rep1&type=pdf), page 15, we are supposed to use the 0x format for hexadecimal numeric constants.

Writing a numeric constant as `0FFh` was supported for the older version of `as`. It is now unsupported on the latest assembler (In this particular issue, Command Line Tools for Xcode Beta 2 on MacOS Mojave 10.14.5), so we must use the standard hexadecimal format.