### PR TITLE
Adjust IL scanner for generic inlining

### DIFF
--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -568,6 +568,33 @@ namespace Internal.IL
                             _dependencies.Add(instParam, reason);
                         }
 
+                        if (instParam == null
+                            && !targetMethod.OwningType.IsValueType
+                            && !_factory.TypeSystemContext.IsSpecialUnboxingThunk(_canonMethod))
+                        {
+                            // We have a call to a shared instance method and we're already in a shared context.
+                            // e.g. this is a call to Foo<T>.Method() and we're about to add Foo<__Canon>.Method()
+                            // to the dependency graph).
+                            //
+                            // We will pretend the runtime determined owning type (Foo<T>) got allocated as well.
+                            // This is because RyuJIT might end up inlining the shared method body, making it concrete again,
+                            // without actually having to go through a dictionary.
+                            // (This would require inlining across two generic contexts, but RyuJIT does that.)
+                            //
+                            // If we didn't have a constructed type for this at the scanning time, we wouldn't
+                            // know the dictionary dependencies at the inlined site, leading to a compile failure.
+                            // (Remember that dictionary dependencies of instance methods on generic reference types
+                            // are tied to the owning type.)
+                            //
+                            // This is not ideal, because if e.g. Foo<string> never got allocated otherwise, this code is
+                            // unreachable and we're making the scanner scan more of it.
+                            //
+                            // Technically, we could get away with injecting a RuntimeDeterminedMethodNode here
+                            // but that introduces more complexities and doesn't seem worth it at this time.
+                            Debug.Assert(targetMethod.AcquiresInstMethodTableFromThis());
+                            _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.TypeHandle, runtimeDeterminedMethod.OwningType), reason + " - inlining protection");
+                        }
+
                         _dependencies.Add(_factory.CanonicalEntrypoint(targetMethod), reason);
                     }
                     else
@@ -607,6 +634,32 @@ namespace Internal.IL
                     if (instParam != null)
                     {
                         _dependencies.Add(instParam, reason);
+                    }
+
+                    if (instParam == null
+                        && concreteMethod != targetMethod
+                        && targetMethod.OwningType.NormalizeInstantiation() == targetMethod.OwningType
+                        && !targetMethod.OwningType.IsValueType)
+                    {
+                        // We have a call to a shared instance method and we still know the concrete
+                        // type of the generic instance (e.g. this is a call to Foo<string>.Method()
+                        // and we're about to add Foo<__Canon>.Method() to the dependency graph).
+                        //
+                        // We will pretend the concrete type got allocated as well. This is because RyuJIT might
+                        // end up inlining the shared method body, making it concrete again.
+                        //
+                        // If we didn't have a constructed type for this at the scanning time, we wouldn't
+                        // know the dictionary dependencies at the inlined site, leading to a compile failure.
+                        // (Remember that dictionary dependencies of instance methods on generic reference types
+                        // are tied to the owning type.)
+                        //
+                        // This is not ideal, because if Foo<string> never got allocated otherwise, this code is
+                        // unreachable and we're making the scanner scan more of it.
+                        //
+                        // Technically, we could get away with injecting a ShadowConcreteMethod for the concrete
+                        // method, but that's more complex and doesn't seem worth it at this time.
+                        Debug.Assert(targetMethod.AcquiresInstMethodTableFromThis());
+                        _dependencies.Add(_compilation.NodeFactory.MaximallyConstructableType(concreteMethod.OwningType), reason + " - inlining protection");
                     }
 
                     _dependencies.Add(_compilation.NodeFactory.MethodEntrypoint(targetMethod), reason);


### PR DESCRIPTION
When we turned on generic inlining in RyuJIT, we started inlining things potentially across multiple shared method bodies. There is a pathological case when we may end up inlining a shared instance method on a type that otherwise wasn't allocated in the program - RyuJIT would end up asking questions about things we didn't scan.

This is because scanning happens on canonical method bodies, and dictionary dependencies are only investigated when a specific dictionary is added to the graph. If a type wasn't allocated, there's no generic dictionary to look at.

This is a conservative fix and comes with a small size on disk regression - about 16 kB on Hello World (0 kB for the "minimal Hello World with reflection disabled"), and about 80 kB for ASP.NET.

I investigated preventing RyuJIT from inlining these methods, but RyuJIT is rather uncooperative when it comes to generic inlining. I think this is why UTC operates on runtime determined types directly rather than `__Canon`.