### PR TITLE
Initial support for IsManagedSequential diffing in SuperIlc

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -1106,7 +1106,7 @@ namespace ReadyToRun.SuperIlc
                 int matchCount = cpaot.Count(kvp => crossgen.ContainsKey(kvp.Key) && crossgen[kvp.Key] == kvp.Value);
                 int bothCount = cpaot.Count(kvp => crossgen.ContainsKey(kvp.Key));
                 logWriter.WriteLine("Types queried by both:           {0}", bothCount);
-                logWriter.WriteLine("Matching results:                {0} ({1:F6}%)", matchCount, matchCount * 100.0 / Math.Max(bothCount, 1));
+                logWriter.WriteLine("Matching results:                {0} ({1:F3}%)", matchCount, matchCount * 100.0 / Math.Max(bothCount, 1));
                 logWriter.WriteLine("Mismatched results:              {0}",
                     cpaot.Count(kvp => crossgen.ContainsKey(kvp.Key) && crossgen[kvp.Key] != kvp.Value));
                 logWriter.WriteLine("Types not queried by Crossgen:   {0}", cpaot.Count(kvp => !crossgen.ContainsKey(kvp.Key)));

--- a/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -26,6 +26,7 @@ namespace ReadyToRun.SuperIlc
         {
             ProcessParameters processParameters = base.ExecutionProcess(modules, folders, noEtw);
             processParameters.EnvironmentOverrides["COMPLUS_ReadyToRun"] = "1";
+            processParameters.EnvironmentOverrides["COMPLUS_NoGuiOnAssert"] = "1";
             return processParameters;
         }
 


### PR DESCRIPTION
This change searches compiler logs for specially formatted sections
produced by my private CPAOT and Crossgen instrumentation changes
and outputs their lists and diffs between CPAOT and Crossgen.

I have finally reached almost 100% parity between CPAOT and Crossgen
queries for the IsManagedSequential type characteristics and I have
already identified a type with mismatching results. Based on JanK's
suggestion I assume we should run this through anything we can find
to maximize our confidence in the R2R compiler.

Thanks

Tomas

P.S. I'm going to send out separate not-for-checkin PR's for the
appropriate CPAOT and Crossgen instrumentations. For SuperIlc,
I believe there's no harm in actually merging the change in.