### PR TITLE
Fix string import for CppCodeGen

### DIFF
--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -2981,7 +2981,7 @@ namespace Internal.IL
                         }
 
                         if (c < 0x20)
-                            escaped.Append("\\X" + ((int)c).ToStringInvariant("X2"));
+                            escaped.Append("\\x" + ((int)c).ToStringInvariant("X2"));
                         else
                             escaped.Append(c);
                         break;


### PR DESCRIPTION
The capital `X` is not a standard [escape sequence](https://en.cppreference.com/w/cpp/language/escape), we should use lower case `x`.