### PR TITLE
Adjust getMethodSig for generic inlining

### DIFF
--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -713,7 +713,7 @@ namespace Internal.JitInterface
                     method = _compilation.TypeSystemContext.GetMethodForInstantiatedType(method.GetTypicalMethodDefinition(), (InstantiatedType)type);
                     if (methodInst.Length > 0)
                     {
-                        method.MakeInstantiatedMethod(methodInst);
+                        method = method.MakeInstantiatedMethod(methodInst);
                     }
                 }
             }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -699,6 +699,25 @@ namespace Internal.JitInterface
         {
             MethodDesc method = HandleToObject(ftn);
 
+            // There might be a more concrete parent type specified - this can happen when inlining.
+            if (memberParent != null)
+            {
+                TypeDesc type = HandleToObject(memberParent);
+
+                // Typically, the owning type of the method is a canonical type and the member parent
+                // supplied by RyuJIT is a concrete instantiation.
+                if (type != method.OwningType)
+                {
+                    Debug.Assert(type.HasSameTypeDefinition(method.OwningType));
+                    Instantiation methodInst = method.Instantiation;
+                    method = _compilation.TypeSystemContext.GetMethodForInstantiatedType(method.GetTypicalMethodDefinition(), (InstantiatedType)type);
+                    if (methodInst.Length > 0)
+                    {
+                        method.MakeInstantiatedMethod(methodInst);
+                    }
+                }
+            }
+
             Get_CORINFO_SIG_INFO(method, sig);
         }
 

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -2392,6 +2392,27 @@ class Program
 
         static NeverAllocated<Dummy> s_neverAllocated = null;
 
+        class GenericInline<T>
+        {
+            public GenericInline()
+            {
+                _arr = (T)(object)new string[1] { "ohai" };
+            }
+            T _arr;
+            public T GetArr() => _arr;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static object InnerTest(object o, object dummy) => o;
+
+        static object OtherTest() => null;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static object Test(GenericInline<string[]> t)
+        {
+            return InnerTest(t.GetArr()[0], OtherTest());
+        }
+
         public static void Run()
         {
             // We're just making sure the compiler doesn't crash.
@@ -2403,6 +2424,10 @@ class Program
                 Console.WriteLine(s_neverAllocated.GetString());
                 Console.WriteLine(s_neverAllocated.GetStringIndirect());
             }
+
+            // Regression test for https://github.com/dotnet/corert/issues/7625
+            if ((string)Test(new GenericInline<string[]>()) != "ohai")
+                throw new Exception();
         }
     }
 }


### PR DESCRIPTION
We were not using the `memberParent` parameter, but it's critical to use it when generic inlining happens.

Fixes #7625.