### PR TITLE
Mechanical move of IsManagedSequentialType to R2R field algorithm

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/MarshalUtils.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalUtils.cs
@@ -55,29 +55,5 @@ namespace Internal.TypeSystem.Interop
 
             return false;
         }
-
-        public static bool IsManagedSequentialType(TypeDesc type)
-        {
-            type = type.UnderlyingType;
-            if (type.IsPrimitive || type.Category == TypeFlags.Pointer)
-            {
-                return true;
-            }
-            if (type.IsValueType)
-            {
-                foreach (FieldDesc field in type.GetFields())
-                {
-                    if (!field.IsStatic && !field.IsLiteral)
-                    {
-                        if (!IsManagedSequentialType(field.FieldType))
-                        {
-                            return false;
-                        }
-                    }
-                }
-                return true;
-            }
-            return false;
-        }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -692,7 +692,7 @@ namespace ILCompiler
                 return ComputeExplicitFieldLayout(type, numInstanceFields);
             }
             else
-            if (type.IsValueType && (MarshalUtils.IsBlittableType(type) || MarshalUtils.IsManagedSequentialType(type)))
+            if (type.IsValueType && (MarshalUtils.IsBlittableType(type) || IsManagedSequentialType(type)))
             {
                 return ComputeSequentialFieldLayout(type, numInstanceFields);
             }
@@ -729,5 +729,29 @@ namespace ILCompiler
             }
         }
 
+
+        public static bool IsManagedSequentialType(TypeDesc type)
+        {
+            type = type.UnderlyingType;
+            if (type.IsPrimitive || type.Category == TypeFlags.Pointer)
+            {
+                return true;
+            }
+            if (type.IsValueType)
+            {
+                foreach (FieldDesc field in type.GetFields())
+                {
+                    if (!field.IsStatic && !field.IsLiteral)
+                    {
+                        if (!IsManagedSequentialType(field.FieldType))
+                        {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1606,7 +1606,7 @@ namespace Internal.JitInterface
 
         private bool HasLayoutMetadata(TypeDesc type)
         {
-            if (type.IsValueType && (MarshalUtils.IsBlittableType(type) || MarshalUtils.IsManagedSequentialType(type)))
+            if (type.IsValueType && (MarshalUtils.IsBlittableType(type) || ReadyToRunMetadataFieldLayoutAlgorithm.IsManagedSequentialType(type)))
             {
                 // Sequential layout
                 return true;


### PR DESCRIPTION
Based on JanK's suggestion I'm moving IsManagedSequentialType
to ReadyToRunMetadataFieldLayoutAlgorithm. In this change I'm not
making any semantic changes to the method; I'll send out a subsequent
PR for an additional delta fixing discrepancies in the method
as discovered by the instrumentation I recently implemented.

Thanks

Tomas