### PR TITLE
CoreCLR Pri#1 fixes for the IsManagedSequential method

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -731,29 +731,31 @@ namespace ILCompiler
 
         public static bool IsManagedSequentialType(TypeDesc type)
         {
-            if (type is MetadataType metadataType && (metadataType.IsExplicitLayout || !metadataType.IsSequentialLayout))
+            if (!type.IsValueType)
             {
                 return false;
             }
-            if (type.IsPrimitive || type.Category == TypeFlags.Pointer)
+
+            MetadataType metadataType = (MetadataType)type;
+            if (metadataType.IsExplicitLayout || !metadataType.IsSequentialLayout)
+            {
+                return false;
+            }
+
+            if (type.IsPrimitive)
             {
                 return true;
             }
-            if (type.IsValueType)
+
+            foreach (FieldDesc field in type.GetFields())
             {
-                foreach (FieldDesc field in type.GetFields())
+                if (!field.IsStatic && !IsManagedSequentialType(field.FieldType.UnderlyingType))
                 {
-                    if (!field.IsStatic &&
-                        !field.IsLiteral &&
-                        !field.FieldType.IsEnum &&
-                        !IsManagedSequentialType(field.FieldType))
-                    {
-                        return false;
-                    }
+                    return false;
                 }
-                return true;
             }
-            return false;
+
+            return true;
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -729,10 +729,12 @@ namespace ILCompiler
             }
         }
 
-
         public static bool IsManagedSequentialType(TypeDesc type)
         {
-            type = type.UnderlyingType;
+            if (type is MetadataType metadataType && (metadataType.IsExplicitLayout || !metadataType.IsSequentialLayout))
+            {
+                return false;
+            }
             if (type.IsPrimitive || type.Category == TypeFlags.Pointer)
             {
                 return true;
@@ -741,12 +743,12 @@ namespace ILCompiler
             {
                 foreach (FieldDesc field in type.GetFields())
                 {
-                    if (!field.IsStatic && !field.IsLiteral)
+                    if (!field.IsStatic &&
+                        !field.IsLiteral &&
+                        !field.FieldType.IsEnum &&
+                        !IsManagedSequentialType(field.FieldType))
                     {
-                        if (!IsManagedSequentialType(field.FieldType))
-                        {
-                            return false;
-                        }
+                        return false;
                     }
                 }
                 return true;

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -731,6 +731,11 @@ namespace ILCompiler
 
         public static bool IsManagedSequentialType(TypeDesc type)
         {
+            if (type.IsPointer)
+            {
+                return true;
+            }
+
             if (!type.IsValueType)
             {
                 return false;


### PR DESCRIPTION
This change fixes all remaining differences between CPAOT
and Crossgen for the CoreCLR Pri#1 tests w.r.t. my recently
implemented IsManagedSequential instrumentation.

Thanks

Tomas