### PR TITLE
Revert "Fix enumeration value of R2R helpers [Dbl|Flt][Rem|Round]"

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
@@ -238,10 +238,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         READYTORUN_HELPER_Dbl2ULngOvf = 0xD7,
 
         // Floating point ops
-        READYTORUN_HELPER_FltRem = 0xE0,
-        READYTORUN_HELPER_DblRem = 0xE1,
-        READYTORUN_HELPER_FltRound = 0xE2,
-        READYTORUN_HELPER_DblRound = 0xE3,
+        READYTORUN_HELPER_DblRem = 0xE0,
+        READYTORUN_HELPER_FltRem = 0xE1,
+        READYTORUN_HELPER_DblRound = 0xE2,
+        READYTORUN_HELPER_FltRound = 0xE3,
 
         // Personality rountines
         READYTORUN_HELPER_PersonalityRoutine = 0xF0,


### PR DESCRIPTION
Reverts dotnet/corert#6779

This is so that the enum matches CoreCLR readytorun.h.