### PR TITLE
Fork RyuJit and ReadyToRun version of getGSCookie

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1696,6 +1696,12 @@ namespace Internal.JitInterface
             }
         }
 
+        private void getGSCookie(IntPtr* pCookieVal, IntPtr** ppCookieVal)
+        {
+            *pCookieVal = IntPtr.Zero;
+            *ppCookieVal = (IntPtr *)ObjectToHandle(_compilation.NodeFactory.GetReadyToRunHelperCell(ILCompiler.DependencyAnalysis.ReadyToRun.ReadyToRunHelper.READYTORUN_HELPER_GSCookie));
+        }
+
         private void getMethodVTableOffset(CORINFO_METHOD_STRUCT_* method, ref uint offsetOfIndirection, ref uint offsetAfterIndirection, ref bool isRelative)
         { throw new NotImplementedException("getMethodVTableOffset"); }
         private void expandRawHandleIntrinsic(ref CORINFO_RESOLVED_TOKEN pResolvedToken, ref CORINFO_GENERICHANDLE_RESULT pResult)

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1519,5 +1519,27 @@ namespace Internal.JitInterface
 
             pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ExternSymbol(externName));
         }
+
+        private void getGSCookie(IntPtr* pCookieVal, IntPtr** ppCookieVal)
+        {
+            // TODO: fully implement GS cookies
+
+            if (pCookieVal != null)
+            {
+                if (PointerSize == 4)
+                {
+                    *pCookieVal = (IntPtr)0x3F796857;
+                }
+                else
+                {
+                    *pCookieVal = (IntPtr)0x216D6F6D202C6948;
+                }
+                *ppCookieVal = null;
+            }
+            else
+            {
+                throw new NotImplementedException("getGSCookie");
+            }
+        }
     }
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -926,28 +926,6 @@ namespace Internal.JitInterface
         private CORINFO_METHOD_STRUCT_* mapMethodDeclToMethodImpl(CORINFO_METHOD_STRUCT_* method)
         { throw new NotImplementedException("mapMethodDeclToMethodImpl"); }
 
-        private void getGSCookie(IntPtr* pCookieVal, IntPtr** ppCookieVal)
-        {
-            // TODO: fully implement GS cookies
-
-            if (pCookieVal != null)
-            {
-                if (PointerSize == 4)
-                {
-                    *pCookieVal = (IntPtr)0x3F796857;
-                }
-                else
-                {
-                    *pCookieVal = (IntPtr)0x216D6F6D202C6948;
-                }
-                *ppCookieVal = null;
-            }
-            else
-            {
-                throw new NotImplementedException("getGSCookie");
-            }
-        }
-
         private static object ResolveTokenWithSubstitution(MethodIL methodIL, mdToken token, Instantiation typeInst, Instantiation methodInst)
         {
             // Grab the generic definition of the method IL, resolve the token within the definition,


### PR DESCRIPTION
In CPAOT, we need a CoreCLR-compatible version of the GS cookie
using the appropriate R2R helper, not some hardcoded constant
presumably used by the full AOT CoreRT runtime.

Thanks

Tomas