### PR TITLE
Add R2R implementation of getMethodSync

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1700,8 +1700,13 @@ namespace Internal.JitInterface
         { throw new NotImplementedException("getMethodVTableOffset"); }
         private void expandRawHandleIntrinsic(ref CORINFO_RESOLVED_TOKEN pResolvedToken, ref CORINFO_GENERICHANDLE_RESULT pResult)
         { throw new NotImplementedException("expandRawHandleIntrinsic"); }
+
         private void* getMethodSync(CORINFO_METHOD_STRUCT_* ftn, ref void* ppIndirection)
-        { throw new NotImplementedException("getMethodSync"); }
+        {
+            // Used with CORINFO_HELP_MON_ENTER_STATIC/CORINFO_HELP_MON_EXIT_STATIC - we don't have this fixup in R2R.
+            throw new RequiresRuntimeJitException($"{MethodBeingCompiled} -> {nameof(getMethodSync)}");
+        }
+
         private void getAddressOfPInvokeTarget(CORINFO_METHOD_STRUCT_* method, ref CORINFO_CONST_LOOKUP pLookup)
         { throw new NotImplementedException("getAddressOfPInvokeTarget"); }
     }


### PR DESCRIPTION
The R2R implementation is to just throw.

This doesn't throw in crossgen, but it takes an NGen-specific code path and _then_ throws when we deal with `CORINFO_HELP_MON_ENTER_STATIC`/`CORINFO_HELP_MON_EXIT_STATIC` (that the result of `getMethodSync` is the parameter for).