### PR TITLE
One more fix for SuperILC OOM

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -997,9 +997,25 @@ namespace ReadyToRun.SuperIlc
                             ProcessInfo compilationProcess = compilation[(int)runner.Index];
                             if (compilationProcess != null)
                             {
-                                string log = $"\nCOMPILE {runner.CompilerName}:{compilationProcess.Parameters.InputFileName}\n" + File.ReadAllText(compilationProcess.Parameters.LogPath);
-                                perRunnerLog[(int)runner.Index].Write(log);
-                                combinedLog.Write(log);
+                                string log = $"\nCOMPILE {runner.CompilerName}:{compilationProcess.Parameters.InputFileName}";
+                                StreamWriter runnerLog = perRunnerLog[(int)runner.Index];
+                                runnerLog.WriteLine(log);
+                                combinedLog.WriteLine(log);
+                                try
+                                {
+                                    using (Stream input = new FileStream(compilationProcess.Parameters.LogPath, FileMode.Open, FileAccess.Read))
+                                    {
+                                        input.CopyTo(combinedLog.BaseStream);
+                                        input.Seek(0, SeekOrigin.Begin);
+                                        input.CopyTo(runnerLog.BaseStream);
+                                    }
+                                }
+                                catch (Exception ex)
+                                {
+                                    combinedLog.WriteLine(" -> " + ex.Message);
+                                    runnerLog.WriteLine(" -> " + ex.Message);
+                                }
+
                                 if (!compilationProcess.Succeeded)
                                 {
                                     compilationErrorPerRunner[(int)runner.Index] = true;


### PR DESCRIPTION
In my previous change I fixed OOM's caused by copying too long
execution log files but I forgot to apply the same fix to compilation
logs. This additional delta does just that.

Thanks

Tomas