### PR TITLE
Split interop manager to usage- and analysis-based

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/AnalysisBasedInteropStubManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/AnalysisBasedInteropStubManager.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Internal.IL;
+using Internal.TypeSystem;
+
+using ILCompiler.DependencyAnalysis;
+
+using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Represents an interop stub manager whose list of stubs has been determined ahead of time.
+    /// </summary>
+    public class AnalysisBasedInteropStubManager : CompilerGeneratedInteropStubManager
+    {
+        private readonly IEnumerable<DefType> _typesWithStructMarshalling;
+        private readonly IEnumerable<DefType> _typesWithDelegateMarshalling;
+
+        public AnalysisBasedInteropStubManager(InteropStateManager interopStateManager, PInvokeILEmitterConfiguration pInvokeILEmitterConfiguration, IEnumerable<DefType> typesWithStructMarshalling, IEnumerable<DefType> typesWithDelegateMarshalling)
+            : base(interopStateManager, pInvokeILEmitterConfiguration)
+        {
+            _typesWithStructMarshalling = typesWithStructMarshalling;
+            _typesWithDelegateMarshalling = typesWithDelegateMarshalling;
+        }
+
+        public override void AddCompilationRoots(IRootingServiceProvider rootProvider)
+        {
+            foreach (DefType type in _typesWithStructMarshalling)
+            {
+                rootProvider.RootStructMarshallingData(type, "Analysis based interop root");
+            }
+
+            foreach (DefType type in _typesWithDelegateMarshalling)
+            {
+                rootProvider.RootDelegateMarshallingData(type, "Analysis based interop root");
+            }
+        }
+
+        public override void AddDependeciesDueToPInvoke(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+        }
+
+        public override void AddInterestingInteropConstructedTypeDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
+        {
+        }
+
+        public override void AddMarshalAPIsGenericDependencies(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -45,7 +45,6 @@ namespace ILCompiler
             ILProvider ilProvider,
             DebugInformationProvider debugInformationProvider,
             DevirtualizationManager devirtualizationManager,
-            PInvokeILEmitterConfiguration pInvokeConfiguration,
             Logger logger)
         {
             _dependencyGraph = dependencyGraph;
@@ -66,9 +65,9 @@ namespace ILCompiler
             _assemblyGetExecutingAssemblyMethodThunks = new AssemblyGetExecutingAssemblyMethodThunkCache(globalModuleGeneratedType);
             _methodBaseGetCurrentMethodThunks = new MethodBaseGetCurrentMethodThunkCache();
 
-            if (!(nodeFactory.InteropStubManager is EmptyInteropStubManager))
+            PInvokeILProvider = _nodeFactory.InteropStubManager.CreatePInvokeILProvider();
+            if (PInvokeILProvider != null)
             {
-                PInvokeILProvider = new PInvokeILProvider(pInvokeConfiguration, nodeFactory.InteropStubManager.InteropStateManager);
                 ilProvider = new CombinedILProvider(ilProvider, PInvokeILProvider);
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Compilation.cs
@@ -480,7 +480,7 @@ namespace ILCompiler
     public class CompilationResults
     {
         private readonly DependencyAnalyzerBase<NodeFactory> _graph;
-        private readonly NodeFactory _factory;
+        protected readonly NodeFactory _factory;
 
         protected ImmutableArray<DependencyNodeCore<NodeFactory>> MarkedNodes
         {

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
@@ -25,11 +25,11 @@ namespace ILCompiler
         protected IEnumerable<ICompilationRootProvider> _compilationRoots = Array.Empty<ICompilationRootProvider>();
         protected OptimizationMode _optimizationMode = OptimizationMode.None;
         protected MetadataManager _metadataManager;
+        protected InteropStubManager _interopStubManager = new EmptyInteropStubManager();
         protected VTableSliceProvider _vtableSliceProvider = new LazyVTableSliceProvider();
         protected DictionaryLayoutProvider _dictionaryLayoutProvider = new LazyDictionaryLayoutProvider();
         protected DebugInformationProvider _debugInformationProvider = new DebugInformationProvider();
         protected DevirtualizationManager _devirtualizationManager = new DevirtualizationManager();
-        protected PInvokeILEmitterConfiguration _pinvokePolicy = new DirectPInvokePolicy();
         protected bool _methodBodyFolding;
 
         public CompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup compilationGroup, NameMangler nameMangler)
@@ -61,6 +61,12 @@ namespace ILCompiler
         public CompilationBuilder UseMetadataManager(MetadataManager metadataManager)
         {
             _metadataManager = metadataManager;
+            return this;
+        }
+
+        public CompilationBuilder UseInteropStubManager(InteropStubManager interopStubManager)
+        {
+            _interopStubManager = interopStubManager;
             return this;
         }
 
@@ -100,12 +106,6 @@ namespace ILCompiler
             return this;
         }
 
-        public CompilationBuilder UsePInvokePolicy(PInvokeILEmitterConfiguration policy)
-        {
-            _pinvokePolicy = policy;
-            return this;
-        }
-
         public CompilationBuilder UseMethodBodyFolding(bool enable)
         {
             _methodBodyFolding = enable;
@@ -125,7 +125,7 @@ namespace ILCompiler
 
         public ILScannerBuilder GetILScannerBuilder(CompilationModuleGroup compilationGroup = null)
         {
-            return new ILScannerBuilder(_context, compilationGroup ?? _compilationGroup, _nameMangler, GetILProvider(), _pinvokePolicy);
+            return new ILScannerBuilder(_context, compilationGroup ?? _compilationGroup, _nameMangler, GetILProvider());
         }
 
         public abstract ICompilation ToCompilation();

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedInteropStubManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedInteropStubManager.cs
@@ -2,17 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-
 using Internal.IL;
-using Internal.IL.Stubs;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Interop;
+
 using ILCompiler.DependencyAnalysis;
 
 using Debug = System.Diagnostics.Debug;
 using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+using ReflectionMapBlob = Internal.Runtime.ReflectionMapBlob;
 
 namespace ILCompiler
 {
@@ -21,101 +19,20 @@ namespace ILCompiler
     /// </summary>
     public sealed class CompilerGeneratedInteropStubManager : InteropStubManager
     {
-        private readonly HashSet<TypeDesc> _delegateMarshalingTypes = new HashSet<TypeDesc>();
-        private readonly HashSet<TypeDesc> _structMarshallingTypes = new HashSet<TypeDesc>();
         private readonly PInvokeILEmitterConfiguration _pInvokeILEmitterConfiguration;
-
-        public InteropStateManager InteropStateManager { get; }
+        internal readonly InteropStateManager _interopStateManager;
 
         public CompilerGeneratedInteropStubManager(InteropStateManager interopStateManager, PInvokeILEmitterConfiguration pInvokeILEmitterConfiguration)
         {
-            InteropStateManager = interopStateManager;
+            _interopStateManager = interopStateManager;
             _pInvokeILEmitterConfiguration = pInvokeILEmitterConfiguration;
         }
 
         public override PInvokeILProvider CreatePInvokeILProvider()
         {
-            return new PInvokeILProvider(_pInvokeILEmitterConfiguration, InteropStateManager);
-        }
-
-        internal struct DelegateMarshallingThunks
-        {
-            public TypeDesc DelegateType;
-            public MethodDesc OpenStaticDelegateMarshallingThunk;
-            public MethodDesc ClosedDelegateMarshallingThunk;
-            public MethodDesc DelegateCreationThunk;
-        }
-
-        internal IEnumerable<DelegateMarshallingThunks> GetDelegateMarshallingThunks()
-        {
-            foreach (var delegateType in _delegateMarshalingTypes)
-            {
-                yield return
-                    new DelegateMarshallingThunks()
-                    {
-                        DelegateType = delegateType,
-                        OpenStaticDelegateMarshallingThunk = InteropStateManager.GetOpenStaticDelegateMarshallingThunk(delegateType),
-                        ClosedDelegateMarshallingThunk = InteropStateManager.GetClosedDelegateMarshallingThunk(delegateType),
-                        DelegateCreationThunk = InteropStateManager.GetForwardDelegateCreationThunk(delegateType)
-                    };
-            }
-        }
-
-        internal struct StructMarshallingThunks
-        {
-            public TypeDesc StructType;
-            public NativeStructType NativeStructType;
-            public MethodDesc MarshallingThunk;
-            public MethodDesc UnmarshallingThunk;
-            public MethodDesc CleanupThunk;
-        }
-
-        internal IEnumerable<StructMarshallingThunks> GetStructMarshallingTypes()
-        {
-            foreach (var structType in _structMarshallingTypes)
-            {
-                yield return
-                    new StructMarshallingThunks()
-                    {
-                        StructType = structType,
-                        NativeStructType = InteropStateManager.GetStructMarshallingNativeType(structType),
-                        MarshallingThunk = InteropStateManager.GetStructMarshallingManagedToNativeThunk(structType),
-                        UnmarshallingThunk = InteropStateManager.GetStructMarshallingNativeToManagedThunk(structType),
-                        CleanupThunk = InteropStateManager.GetStructMarshallingCleanupThunk(structType)
-                    };
-            }
+            return new PInvokeILProvider(_pInvokeILEmitterConfiguration, _interopStateManager);
         }
         
-        private void AddDependenciesDueToPInvokeStructDelegateField(ref DependencyList dependencies, NodeFactory factory, TypeDesc typeDesc)
-        {
-            if (typeDesc is ByRefType)
-            {
-                typeDesc = typeDesc.GetParameterType();
-            }
-
-            MetadataType metadataType = typeDesc as MetadataType;
-            if (metadataType != null) 
-            {
-                foreach (FieldDesc field in metadataType.GetFields())
-                {
-                    if (field.IsStatic)
-                    {
-                        continue;
-                    }
-                    TypeDesc fieldType = field.FieldType;
-
-                    if (fieldType.IsDelegate)
-                    {
-                        AddDependenciesDueToPInvokeDelegate(ref dependencies, factory, fieldType);
-                    }
-                    else if (MarshalHelpers.IsStructMarshallingRequired(fieldType))
-                    {
-                        AddDependenciesDueToPInvokeStructDelegateField(ref dependencies, factory, fieldType);
-                    }
-                }
-            }
-        }
-
         public override void AddDependeciesDueToPInvoke(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
             if (method.IsPInvoke)
@@ -123,21 +40,11 @@ namespace ILCompiler
                 dependencies = dependencies ?? new DependencyList();
 
                 MethodSignature methodSig = method.Signature;
-                AddDependenciesDueToPInvokeDelegate(ref dependencies, factory, methodSig.ReturnType);
-
-                // struct may contain delegate fields, hence we need to add dependencies for it
-                if (MarshalHelpers.IsStructMarshallingRequired(methodSig.ReturnType))
-                {
-                    AddDependenciesDueToPInvokeStructDelegateField(ref dependencies, factory, methodSig.ReturnType);
-                }
+                AddParameterMarshallingDependencies(ref dependencies, factory, methodSig.ReturnType);
 
                 for (int i = 0; i < methodSig.Length; i++)
                 {
-                    AddDependenciesDueToPInvokeDelegate(ref dependencies, factory, methodSig[i]);
-                    if (MarshalHelpers.IsStructMarshallingRequired(methodSig[i]))
-                    {
-                        AddDependenciesDueToPInvokeStructDelegateField(ref dependencies, factory, methodSig[i]);
-                    }
+                    AddParameterMarshallingDependencies(ref dependencies, factory, methodSig[i]);
                 }
             }
 
@@ -148,6 +55,23 @@ namespace ILCompiler
             }
         }
 
+        private static void AddParameterMarshallingDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
+        {
+            if (type.IsDelegate)
+            {
+                dependencies.Add(factory.DelegateMarshallingData((DefType)type), "Delegate marshaling");
+            }
+
+            // struct may contain delegate fields, hence we need to add dependencies for it
+            if (type.IsByRef)
+                type = ((ParameterizedType)type).ParameterType;
+
+            if (MarshalHelpers.IsStructMarshallingRequired(type))
+            {
+                dependencies.Add(factory.StructMarshallingData((DefType)type), "Struct marshalling");
+            }
+        }
+
         public override void AddInterestingInteropConstructedTypeDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
         {
             if (type.IsDelegate)
@@ -155,7 +79,8 @@ namespace ILCompiler
                 var delegateType = (MetadataType)type;
                 if (delegateType.HasCustomAttribute("System.Runtime.InteropServices", "UnmanagedFunctionPointerAttribute"))
                 {
-                    AddDependenciesDueToPInvokeDelegate(ref dependencies, factory, delegateType);
+                    dependencies = dependencies ?? new DependencyList();
+                    dependencies.Add(factory.DelegateMarshallingData(delegateType), "Delegate marshalling");
                 }
             }
         }
@@ -184,47 +109,28 @@ namespace ILCompiler
                     {
                         foreach (TypeDesc type in method.Instantiation)
                         {
-                            AddDependenciesDueToPInvokeDelegate(ref dependencies, factory, type);
-                            AddDependenciesDueToPInvokeStruct(ref dependencies, factory, type, methodName == "OffsetOf");
+                            dependencies = dependencies ?? new DependencyList();
+                            if (type.IsDelegate)
+                            {
+                                dependencies.Add(factory.DelegateMarshallingData((DefType)type), "Delegate marshlling");
+                            }
+                            else if (MarshalHelpers.IsStructMarshallingRequired(type) || (methodName == "OffsetOf" && type is DefType))
+                            {
+                                dependencies.Add(factory.StructMarshallingData((DefType)type), "Struct marshalling");
+                            }
                         }
                     }
                 }
             }
         }
 
-        private void AddDependenciesDueToPInvokeDelegate(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
+        public override void AddToReadyToRunHeader(ReadyToRunHeaderNode header, NodeFactory nodeFactory, ExternalReferencesTableNode commonFixupsTableNode)
         {
-            if (type.IsDelegate)
-            {
-                _delegateMarshalingTypes.Add(type);
+            var delegateMapNode = new DelegateMarshallingStubMapNode(commonFixupsTableNode, _interopStateManager);
+            header.Add(MetadataManager.BlobIdToReadyToRunSection(ReflectionMapBlob.DelegateMarshallingStubMap), delegateMapNode, delegateMapNode, delegateMapNode.EndSymbol);
 
-                dependencies.Add(factory.NecessaryTypeSymbol(type), "Delegate Marshalling Stub");
-
-                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetOpenStaticDelegateMarshallingThunk(type)), "Delegate Marshalling Stub");
-                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetClosedDelegateMarshallingThunk(type)), "Delegate Marshalling Stub");
-                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetForwardDelegateCreationThunk(type)), "Delegate Marshalling Stub");
-            }
-        }
-
-        private void AddDependenciesDueToPInvokeStruct(ref DependencyList dependencies, NodeFactory factory, TypeDesc type, bool fieldOffsetsRequired)
-        {
-            dependencies.Add(factory.NecessaryTypeSymbol(type), "Struct Marshalling Stub");
-
-            if (MarshalHelpers.IsStructMarshallingRequired(type))
-            {
-                _structMarshallingTypes.Add(type);
-
-                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetStructMarshallingManagedToNativeThunk(type)), "Struct Marshalling stub");
-                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetStructMarshallingNativeToManagedThunk(type)), "Struct Marshalling stub");
-                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetStructMarshallingCleanupThunk(type)), "Struct Marshalling stub");
-
-                AddDependenciesDueToPInvokeStructDelegateField(ref dependencies, factory, type);
-            }
-
-            if (fieldOffsetsRequired)
-            {
-                _structMarshallingTypes.Add(type);
-            }
+            var structMapNode = new StructMarshallingStubMapNode(commonFixupsTableNode, _interopStateManager);
+            header.Add(MetadataManager.BlobIdToReadyToRunSection(ReflectionMapBlob.StructMarshallingStubMap), structMapNode, structMapNode, structMapNode.EndSymbol);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedInteropStubManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedInteropStubManager.cs
@@ -38,66 +38,6 @@ namespace ILCompiler
             return new PInvokeILProvider(_pInvokeILEmitterConfiguration, InteropStateManager);
         }
 
-        private MethodDesc GetOpenStaticDelegateMarshallingStub(TypeDesc delegateType)
-        {
-            var stub = InteropStateManager.GetOpenStaticDelegateMarshallingThunk(delegateType);
-            Debug.Assert(stub != null);
-
-            _delegateMarshalingTypes.Add(delegateType);
-            return stub;
-        }
-
-        private MethodDesc GetClosedDelegateMarshallingStub(TypeDesc delegateType)
-        {
-            var stub = InteropStateManager.GetClosedDelegateMarshallingThunk(delegateType);
-            Debug.Assert(stub != null);
-
-            _delegateMarshalingTypes.Add(delegateType);
-            return stub;
-        }
-        private MethodDesc GetForwardDelegateCreationStub(TypeDesc delegateType)
-        {
-            var stub = InteropStateManager.GetForwardDelegateCreationThunk(delegateType);
-            Debug.Assert(stub != null);
-
-            _delegateMarshalingTypes.Add(delegateType);
-            return stub;
-        }
-
-        private MethodDesc GetStructMarshallingManagedToNativeStub(TypeDesc structType)
-        {
-            MethodDesc stub = InteropStateManager.GetStructMarshallingManagedToNativeThunk(structType);
-            Debug.Assert(stub != null);
-
-            _structMarshallingTypes.Add(structType);
-            return stub;
-        }
-
-        private MethodDesc GetStructMarshallingNativeToManagedStub(TypeDesc structType)
-        {
-            MethodDesc stub = InteropStateManager.GetStructMarshallingNativeToManagedThunk(structType);
-            Debug.Assert(stub != null);
-
-            _structMarshallingTypes.Add(structType);
-            return stub;
-        }
-
-        private MethodDesc GetStructMarshallingCleanupStub(TypeDesc structType)
-        {
-            MethodDesc stub = InteropStateManager.GetStructMarshallingCleanupThunk(structType);
-            Debug.Assert(stub != null);
-
-            _structMarshallingTypes.Add(structType);
-            return stub;
-        }
-
-        private TypeDesc GetInlineArrayType(InlineArrayCandidate candidate)
-        {
-            TypeDesc inlineArrayType = InteropStateManager.GetInlineArrayType(candidate);
-            Debug.Assert(inlineArrayType != null);
-            return inlineArrayType;
-        }
-
         internal struct DelegateMarshallingThunks
         {
             public TypeDesc DelegateType;
@@ -256,11 +196,13 @@ namespace ILCompiler
         {
             if (type.IsDelegate)
             {
+                _delegateMarshalingTypes.Add(type);
+
                 dependencies.Add(factory.NecessaryTypeSymbol(type), "Delegate Marshalling Stub");
 
-                dependencies.Add(factory.MethodEntrypoint(GetOpenStaticDelegateMarshallingStub(type)), "Delegate Marshalling Stub");
-                dependencies.Add(factory.MethodEntrypoint(GetClosedDelegateMarshallingStub(type)), "Delegate Marshalling Stub");
-                dependencies.Add(factory.MethodEntrypoint(GetForwardDelegateCreationStub(type)), "Delegate Marshalling Stub");
+                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetOpenStaticDelegateMarshallingThunk(type)), "Delegate Marshalling Stub");
+                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetClosedDelegateMarshallingThunk(type)), "Delegate Marshalling Stub");
+                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetForwardDelegateCreationThunk(type)), "Delegate Marshalling Stub");
             }
         }
 
@@ -270,9 +212,11 @@ namespace ILCompiler
 
             if (MarshalHelpers.IsStructMarshallingRequired(type))
             {
-                dependencies.Add(factory.MethodEntrypoint(GetStructMarshallingManagedToNativeStub(type)), "Struct Marshalling stub");
-                dependencies.Add(factory.MethodEntrypoint(GetStructMarshallingNativeToManagedStub(type)), "Struct Marshalling stub");
-                dependencies.Add(factory.MethodEntrypoint(GetStructMarshallingCleanupStub(type)), "Struct Marshalling stub");
+                _structMarshallingTypes.Add(type);
+
+                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetStructMarshallingManagedToNativeThunk(type)), "Struct Marshalling stub");
+                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetStructMarshallingNativeToManagedThunk(type)), "Struct Marshalling stub");
+                dependencies.Add(factory.MethodEntrypoint(InteropStateManager.GetStructMarshallingCleanupThunk(type)), "Struct Marshalling stub");
 
                 AddDependenciesDueToPInvokeStructDelegateField(ref dependencies, factory, type);
             }

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedInteropStubManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerGeneratedInteropStubManager.cs
@@ -4,12 +4,9 @@
 
 using Internal.IL;
 using Internal.TypeSystem;
-using Internal.TypeSystem.Interop;
 
 using ILCompiler.DependencyAnalysis;
 
-using Debug = System.Diagnostics.Debug;
-using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
 using ReflectionMapBlob = Internal.Runtime.ReflectionMapBlob;
 
 namespace ILCompiler
@@ -17,7 +14,7 @@ namespace ILCompiler
     /// <summary>
     /// This class is responsible for managing stub methods for interop
     /// </summary>
-    public sealed class CompilerGeneratedInteropStubManager : InteropStubManager
+    public abstract class CompilerGeneratedInteropStubManager : InteropStubManager
     {
         private readonly PInvokeILEmitterConfiguration _pInvokeILEmitterConfiguration;
         internal readonly InteropStateManager _interopStateManager;
@@ -28,103 +25,12 @@ namespace ILCompiler
             _pInvokeILEmitterConfiguration = pInvokeILEmitterConfiguration;
         }
 
-        public override PInvokeILProvider CreatePInvokeILProvider()
+        public sealed override PInvokeILProvider CreatePInvokeILProvider()
         {
             return new PInvokeILProvider(_pInvokeILEmitterConfiguration, _interopStateManager);
         }
         
-        public override void AddDependeciesDueToPInvoke(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
-        {
-            if (method.IsPInvoke)
-            {
-                dependencies = dependencies ?? new DependencyList();
-
-                MethodSignature methodSig = method.Signature;
-                AddParameterMarshallingDependencies(ref dependencies, factory, methodSig.ReturnType);
-
-                for (int i = 0; i < methodSig.Length; i++)
-                {
-                    AddParameterMarshallingDependencies(ref dependencies, factory, methodSig[i]);
-                }
-            }
-
-            if (method.HasInstantiation)
-            {
-                dependencies = dependencies ?? new DependencyList();
-                AddMarshalAPIsGenericDependencies(ref dependencies, factory, method);
-            }
-        }
-
-        private static void AddParameterMarshallingDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
-        {
-            if (type.IsDelegate)
-            {
-                dependencies.Add(factory.DelegateMarshallingData((DefType)type), "Delegate marshaling");
-            }
-
-            // struct may contain delegate fields, hence we need to add dependencies for it
-            if (type.IsByRef)
-                type = ((ParameterizedType)type).ParameterType;
-
-            if (MarshalHelpers.IsStructMarshallingRequired(type))
-            {
-                dependencies.Add(factory.StructMarshallingData((DefType)type), "Struct marshalling");
-            }
-        }
-
-        public override void AddInterestingInteropConstructedTypeDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
-        {
-            if (type.IsDelegate)
-            {
-                var delegateType = (MetadataType)type;
-                if (delegateType.HasCustomAttribute("System.Runtime.InteropServices", "UnmanagedFunctionPointerAttribute"))
-                {
-                    dependencies = dependencies ?? new DependencyList();
-                    dependencies.Add(factory.DelegateMarshallingData(delegateType), "Delegate marshalling");
-                }
-            }
-        }
-
-        /// <summary>
-        /// For Marshal generic APIs(eg. Marshal.StructureToPtr<T>, GetFunctionPointerForDelegate) we add
-        /// the generic parameter as dependencies so that we can generate runtime data for them
-        /// </summary>
-        public override void AddMarshalAPIsGenericDependencies(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
-        {
-            Debug.Assert(method.HasInstantiation);
-
-            TypeDesc owningType = method.OwningType;
-            MetadataType metadataType = owningType as MetadataType;
-            if (metadataType != null && metadataType.Module == factory.TypeSystemContext.SystemModule)
-            {
-                if (metadataType.Name == "Marshal" && metadataType.Namespace == "System.Runtime.InteropServices")
-                {
-                    string methodName = method.Name;
-                    if (methodName == "GetFunctionPointerForDelegate" ||
-                        methodName == "GetDelegateForFunctionPointer" ||
-                        methodName == "PtrToStructure" ||
-                        methodName == "StructureToPtr" ||
-                        methodName == "SizeOf" ||
-                        methodName == "OffsetOf")
-                    {
-                        foreach (TypeDesc type in method.Instantiation)
-                        {
-                            dependencies = dependencies ?? new DependencyList();
-                            if (type.IsDelegate)
-                            {
-                                dependencies.Add(factory.DelegateMarshallingData((DefType)type), "Delegate marshlling");
-                            }
-                            else if (MarshalHelpers.IsStructMarshallingRequired(type) || (methodName == "OffsetOf" && type is DefType))
-                            {
-                                dependencies.Add(factory.StructMarshallingData((DefType)type), "Struct marshalling");
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        public override void AddToReadyToRunHeader(ReadyToRunHeaderNode header, NodeFactory nodeFactory, ExternalReferencesTableNode commonFixupsTableNode)
+        public sealed override void AddToReadyToRunHeader(ReadyToRunHeaderNode header, NodeFactory nodeFactory, ExternalReferencesTableNode commonFixupsTableNode)
         {
             var delegateMapNode = new DelegateMarshallingStubMapNode(commonFixupsTableNode, _interopStateManager);
             header.Add(MetadataManager.BlobIdToReadyToRunSection(ReflectionMapBlob.DelegateMarshallingStubMap), delegateMapNode, delegateMapNode, delegateMapNode.EndSymbol);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DelegateMarshallingDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DelegateMarshallingDataNode.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents an entry in the <see cref="DelegateMarshallingStubMapNode"/> table.
+    /// </summary>
+    public class DelegateMarshallingDataNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly DefType _type;
+
+        public DefType Type => _type;
+
+        public DelegateMarshallingDataNode(DefType type)
+        {
+            Debug.Assert(type.IsDelegate);
+            _type = type;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            InteropStateManager stateManager = ((CompilerGeneratedInteropStubManager)factory.InteropStubManager)._interopStateManager;
+
+            return new DependencyListEntry[]
+            {
+                new DependencyListEntry(factory.NecessaryTypeSymbol(_type), "Delegate Marshalling Stub"),
+                new DependencyListEntry(factory.MethodEntrypoint(stateManager.GetOpenStaticDelegateMarshallingThunk(_type)), "Delegate Marshalling Stub"),
+                new DependencyListEntry(factory.MethodEntrypoint(stateManager.GetClosedDelegateMarshallingThunk(_type)), "Delegate Marshalling Stub"),
+                new DependencyListEntry(factory.MethodEntrypoint(stateManager.GetForwardDelegateCreationThunk(_type)), "Delegate Marshalling Stub"),
+            };
+        }
+
+        protected override string GetName(NodeFactory context)
+        {
+            return $"Delegate marshaling data for {_type}";
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -370,6 +370,16 @@ namespace ILCompiler.DependencyAnalysis
                 return new NamedJumpStubNode(id.Item1, id.Item2);
             });
 
+            _delegateMarshalingDataNodes = new NodeCache<DefType, DelegateMarshallingDataNode>(type =>
+            {
+                return new DelegateMarshallingDataNode(type);
+            });
+
+            _structMarshalingDataNodes = new NodeCache<DefType, StructMarshallingDataNode>(type =>
+            {
+                return new StructMarshallingDataNode(type);
+            });
+
             _vTableNodes = new NodeCache<TypeDesc, VTableSliceNode>((TypeDesc type ) =>
             {
                 if (CompilationModuleGroup.ShouldProduceFullVTable(type))
@@ -998,7 +1008,21 @@ namespace ILCompiler.DependencyAnalysis
         {
             return _namedJumpStubNodes.GetOrAdd(new Tuple<string, ISymbolNode>(name, target));
         }
-        
+
+        private NodeCache<DefType, DelegateMarshallingDataNode> _delegateMarshalingDataNodes;
+
+        public DelegateMarshallingDataNode DelegateMarshallingData(DefType type)
+        {
+            return _delegateMarshalingDataNodes.GetOrAdd(type);
+        }
+
+        private NodeCache<DefType, StructMarshallingDataNode> _structMarshalingDataNodes;
+
+        public StructMarshallingDataNode StructMarshallingData(DefType type)
+        {
+            return _structMarshalingDataNodes.GetOrAdd(type);
+        }
+
         /// <summary>
         /// Returns alternative symbol name that object writer should produce for given symbols
         /// in addition to the regular one.

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StructMarshallingDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StructMarshallingDataNode.cs
@@ -38,27 +38,6 @@ namespace ILCompiler.DependencyAnalysis
                 yield return new DependencyListEntry(factory.MethodEntrypoint(stateManager.GetStructMarshallingManagedToNativeThunk(_type)), "Struct Marshalling stub");
                 yield return new DependencyListEntry(factory.MethodEntrypoint(stateManager.GetStructMarshallingNativeToManagedThunk(_type)), "Struct Marshalling stub");
                 yield return new DependencyListEntry(factory.MethodEntrypoint(stateManager.GetStructMarshallingCleanupThunk(_type)), "Struct Marshalling stub");
-
-                // We might need marshalers for the individual fields
-
-                foreach (FieldDesc field in _type.GetFields())
-                {
-                    if (field.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    TypeDesc fieldType = field.FieldType;
-
-                    if (fieldType.IsDelegate)
-                    {
-                        yield return new DependencyListEntry(factory.DelegateMarshallingData((DefType)fieldType), "Struct marshalling");
-                    }
-                    else if (MarshalHelpers.IsStructMarshallingRequired(fieldType))
-                    {
-                        yield return new DependencyListEntry(factory.StructMarshallingData((DefType)fieldType), "Struct marshalling");
-                    }
-                }
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StructMarshallingDataNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StructMarshallingDataNode.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Interop;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents an entry in the <see cref="StructMarshallingStubMapNode"/> table.
+    /// </summary>
+    public class StructMarshallingDataNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly DefType _type;
+
+        public DefType Type => _type;
+
+        public StructMarshallingDataNode(DefType type)
+        {
+            _type = type;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            InteropStateManager stateManager = ((CompilerGeneratedInteropStubManager)factory.InteropStubManager)._interopStateManager;
+
+            yield return new DependencyListEntry(factory.NecessaryTypeSymbol(_type), "Struct Marshalling Stub");
+
+            // Not all StructMarshalingDataNodes require marshalling - some are only present because we want to
+            // generate field offset information for Marshal.OffsetOf.
+            if (MarshalHelpers.IsStructMarshallingRequired(_type))
+            {
+                yield return new DependencyListEntry(factory.MethodEntrypoint(stateManager.GetStructMarshallingManagedToNativeThunk(_type)), "Struct Marshalling stub");
+                yield return new DependencyListEntry(factory.MethodEntrypoint(stateManager.GetStructMarshallingNativeToManagedThunk(_type)), "Struct Marshalling stub");
+                yield return new DependencyListEntry(factory.MethodEntrypoint(stateManager.GetStructMarshallingCleanupThunk(_type)), "Struct Marshalling stub");
+
+                // We might need marshalers for the individual fields
+
+                foreach (FieldDesc field in _type.GetFields())
+                {
+                    if (field.IsStatic)
+                    {
+                        continue;
+                    }
+
+                    TypeDesc fieldType = field.FieldType;
+
+                    if (fieldType.IsDelegate)
+                    {
+                        yield return new DependencyListEntry(factory.DelegateMarshallingData((DefType)fieldType), "Struct marshalling");
+                    }
+                    else if (MarshalHelpers.IsStructMarshallingRequired(fieldType))
+                    {
+                        yield return new DependencyListEntry(factory.StructMarshallingData((DefType)fieldType), "Struct marshalling");
+                    }
+                }
+            }
+        }
+
+        protected override string GetName(NodeFactory context)
+        {
+            return $"Struct marshaling data for {_type}";
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/UtcNodeFactory.cs
@@ -92,12 +92,6 @@ namespace ILCompiler
             }
         }
 
-        private static InteropStubManager NewEmptyInteropStubManager(CompilerTypeSystemContext context, CompilationModuleGroup compilationModuleGroup)
-        {
-            // On Project N, the compiler doesn't generate the interop code on the fly
-            return new EmptyInteropStubManager(compilationModuleGroup, context, null);
-        }
-
         public UtcNodeFactory(
             CompilerTypeSystemContext context, 
             CompilationModuleGroup compilationModuleGroup, 
@@ -115,7 +109,7 @@ namespace ILCompiler
             : base(context, 
                   compilationModuleGroup, 
                   PickMetadataManager(context, compilationModuleGroup, inputModules, inputMetadataOnlyAssemblies, metadataFile, emitStackTraceMetadata, disableExceptionMessages, allowInvokeThunks),
-                  NewEmptyInteropStubManager(context, compilationModuleGroup), 
+                  new EmptyInteropStubManager(),
                   nameMangler, 
                   new AttributeDrivenLazyGenericsPolicy(), 
                   null, 

--- a/src/ILCompiler.Compiler/src/Compiler/EmptyInteropStubManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/EmptyInteropStubManager.cs
@@ -8,6 +8,7 @@ using Internal.TypeSystem;
 using ILCompiler.DependencyAnalysis;
 
 using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+using Internal.IL;
 
 namespace ILCompiler
 {
@@ -16,9 +17,9 @@ namespace ILCompiler
     /// </summary>
     public sealed class EmptyInteropStubManager : InteropStubManager
     {
-        public EmptyInteropStubManager(CompilationModuleGroup compilationModuleGroup, CompilerTypeSystemContext typeSystemContext, InteropStateManager interopStateManager) :
-            base(compilationModuleGroup, typeSystemContext, interopStateManager)
+        public override PInvokeILProvider CreatePInvokeILProvider()
         {
+            return null;
         }
 
         public override void AddDependeciesDueToPInvoke(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)

--- a/src/ILCompiler.Compiler/src/Compiler/EmptyInteropStubManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/EmptyInteropStubManager.cs
@@ -33,9 +33,5 @@ namespace ILCompiler
         public override void AddMarshalAPIsGenericDependencies(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
         }
-
-        public override void AddToReadyToRunHeader(ReadyToRunHeaderNode header, NodeFactory nodeFactory, ExternalReferencesTableNode commonFixupsTableNode)
-        {
-        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
@@ -30,9 +30,8 @@ namespace ILCompiler
             IEnumerable<ICompilationRootProvider> roots,
             ILProvider ilProvider,
             DebugInformationProvider debugInformationProvider,
-            PInvokeILEmitterConfiguration pinvokePolicy,
             Logger logger)
-            : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, null, pinvokePolicy, logger)
+            : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, null, logger)
         {
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILScanner.cs
@@ -104,6 +104,13 @@ namespace ILCompiler
         {
         }
 
+        public AnalysisBasedInteropStubManager GetInteropStubManager(InteropStateManager stateManager, PInvokeILEmitterConfiguration pinvokePolicy)
+        {
+            return new AnalysisBasedInteropStubManager(stateManager, pinvokePolicy,
+                _factory.MetadataManager.GetTypesWithStructMarshalling(),
+                _factory.MetadataManager.GetTypesWithDelegateMarshalling());
+        }
+
         public VTableSliceProvider GetVTableLayoutInfo()
         {
             return new ScannedVTableProvider(MarkedNodes);

--- a/src/ILCompiler.Compiler/src/Compiler/ILScannerBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILScannerBuilder.cs
@@ -58,11 +58,11 @@ namespace ILCompiler
 
         public IILScanner ToILScanner()
         {
-            var interopStubManager = new CompilerGeneratedInteropStubManager(_compilationGroup, _context, new InteropStateManager(_context.GeneratedAssembly));
+            var interopStubManager = new CompilerGeneratedInteropStubManager(new InteropStateManager(_context.GeneratedAssembly), _pinvokePolicy);
             var nodeFactory = new ILScanNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler);
             DependencyAnalyzerBase<NodeFactory> graph = _dependencyTrackingLevel.CreateDependencyGraph(nodeFactory);
 
-            return new ILScanner(graph, nodeFactory, _compilationRoots, _ilProvider, new NullDebugInformationProvider(), _pinvokePolicy, _logger);
+            return new ILScanner(graph, nodeFactory, _compilationRoots, _ilProvider, new NullDebugInformationProvider(), _logger);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/IRootingServiceProvider.cs
@@ -19,5 +19,7 @@ namespace ILCompiler
         void RootVirtualMethodForReflection(MethodDesc method, string reason);
         void RootModuleMetadata(ModuleDesc module, string reason);
         void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, string exportName);
+        void RootDelegateMarshallingData(DefType type, string reason);
+        void RootStructMarshallingData(DefType type, string reason);
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/InteropStubManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/InteropStubManager.cs
@@ -9,7 +9,6 @@ using Internal.TypeSystem;
 using ILCompiler.DependencyAnalysis;
 
 using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
-using ReflectionMapBlob = Internal.Runtime.ReflectionMapBlob;
 
 namespace ILCompiler
 {
@@ -32,11 +31,6 @@ namespace ILCompiler
 
         public virtual void AddToReadyToRunHeader(ReadyToRunHeaderNode header, NodeFactory nodeFactory, ExternalReferencesTableNode commonFixupsTableNode)
         {
-            var delegateMapNode = new DelegateMarshallingStubMapNode(commonFixupsTableNode);
-            header.Add(MetadataManager.BlobIdToReadyToRunSection(ReflectionMapBlob.DelegateMarshallingStubMap), delegateMapNode, delegateMapNode, delegateMapNode.EndSymbol);
-
-            var structMapNode = new StructMarshallingStubMapNode(commonFixupsTableNode);
-            header.Add(MetadataManager.BlobIdToReadyToRunSection(ReflectionMapBlob.StructMarshallingStubMap), structMapNode, structMapNode, structMapNode.EndSymbol);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/InteropStubManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/InteropStubManager.cs
@@ -15,7 +15,7 @@ namespace ILCompiler
     /// <summary>
     /// This class is responsible for managing stub methods for interop
     /// </summary>
-    public abstract class InteropStubManager
+    public abstract class InteropStubManager : ICompilationRootProvider
     {
         public abstract void AddDependeciesDueToPInvoke(ref DependencyList dependencies, NodeFactory factory, MethodDesc method);
         
@@ -30,6 +30,10 @@ namespace ILCompiler
         public abstract void AddMarshalAPIsGenericDependencies(ref DependencyList dependencies, NodeFactory factory, MethodDesc method);
 
         public virtual void AddToReadyToRunHeader(ReadyToRunHeaderNode header, NodeFactory nodeFactory, ExternalReferencesTableNode commonFixupsTableNode)
+        {
+        }
+
+        public virtual void AddCompilationRoots(IRootingServiceProvider rootProvider)
         {
         }
     }

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -22,6 +22,7 @@ using TypeSpecification = Internal.Metadata.NativeFormat.Writer.TypeSpecificatio
 using ConstantStringValue = Internal.Metadata.NativeFormat.Writer.ConstantStringValue;
 using TypeInstantiationSignature = Internal.Metadata.NativeFormat.Writer.TypeInstantiationSignature;
 using MethodInstantiation = Internal.Metadata.NativeFormat.Writer.MethodInstantiation;
+using System.Collections;
 
 namespace ILCompiler
 {
@@ -52,6 +53,8 @@ namespace ILCompiler
         private HashSet<GenericDictionaryNode> _genericDictionariesGenerated = new HashSet<GenericDictionaryNode>();
         private HashSet<IMethodBodyNode> _methodBodiesGenerated = new HashSet<IMethodBodyNode>();
         private List<TypeGVMEntriesNode> _typeGVMEntries = new List<TypeGVMEntriesNode>();
+        private List<DefType> _typesWithDelegateMarshalling = new List<DefType>();
+        private List<DefType> _typesWithStructMarshalling = new List<DefType>();
 
         internal NativeLayoutInfoNode NativeLayoutInfo { get; private set; }
         internal DynamicInvokeTemplateDataNode DynamicInvokeTemplateData { get; private set; }
@@ -208,6 +211,16 @@ namespace ILCompiler
             if (dictionaryNode != null)
             {
                 _genericDictionariesGenerated.Add(dictionaryNode);
+            }
+
+            if (obj is StructMarshallingDataNode structMarshallingDataNode)
+            {
+                _typesWithStructMarshalling.Add(structMarshallingDataNode.Type);
+            }
+
+            if (obj is DelegateMarshallingDataNode delegateMarshallingDataNode)
+            {
+                _typesWithDelegateMarshalling.Add(delegateMarshallingDataNode.Type);
             }
         }
 
@@ -576,6 +589,16 @@ namespace ILCompiler
         internal IReadOnlyCollection<GenericDictionaryNode> GetCompiledGenericDictionaries()
         {
             return _genericDictionariesGenerated;
+        }
+
+        internal IEnumerable<DefType> GetTypesWithStructMarshalling()
+        {
+            return _typesWithStructMarshalling;
+        }
+
+        internal IEnumerable<DefType> GetTypesWithDelegateMarshalling()
+        {
+            return _typesWithDelegateMarshalling;
         }
 
         public IEnumerable<MethodDesc> GetCompiledMethods()

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -22,7 +22,6 @@ using TypeSpecification = Internal.Metadata.NativeFormat.Writer.TypeSpecificatio
 using ConstantStringValue = Internal.Metadata.NativeFormat.Writer.ConstantStringValue;
 using TypeInstantiationSignature = Internal.Metadata.NativeFormat.Writer.TypeInstantiationSignature;
 using MethodInstantiation = Internal.Metadata.NativeFormat.Writer.MethodInstantiation;
-using System.Collections;
 
 namespace ILCompiler
 {
@@ -53,8 +52,8 @@ namespace ILCompiler
         private HashSet<GenericDictionaryNode> _genericDictionariesGenerated = new HashSet<GenericDictionaryNode>();
         private HashSet<IMethodBodyNode> _methodBodiesGenerated = new HashSet<IMethodBodyNode>();
         private List<TypeGVMEntriesNode> _typeGVMEntries = new List<TypeGVMEntriesNode>();
-        private List<DefType> _typesWithDelegateMarshalling = new List<DefType>();
-        private List<DefType> _typesWithStructMarshalling = new List<DefType>();
+        private HashSet<DefType> _typesWithDelegateMarshalling = new HashSet<DefType>();
+        private HashSet<DefType> _typesWithStructMarshalling = new HashSet<DefType>();
 
         internal NativeLayoutInfoNode NativeLayoutInfo { get; private set; }
         internal DynamicInvokeTemplateDataNode DynamicInvokeTemplateData { get; private set; }

--- a/src/ILCompiler.Compiler/src/Compiler/RootingServiceProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RootingServiceProvider.cs
@@ -119,5 +119,15 @@ namespace ILCompiler
             _rootAdder(blob, reason);
             _factory.NodeAliases.Add(blob, exportName);
         }
+
+        public void RootDelegateMarshallingData(DefType type, string reason)
+        {
+            _rootAdder(_factory.DelegateMarshallingData(type), reason);
+        }
+
+        public void RootStructMarshallingData(DefType type, string reason)
+        {
+            _rootAdder(_factory.StructMarshallingData(type), reason);
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/UsageBasedInteropStubManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/UsageBasedInteropStubManager.cs
@@ -10,6 +10,7 @@ using ILCompiler.DependencyAnalysis;
 
 using Debug = System.Diagnostics.Debug;
 using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+using System.Runtime.InteropServices;
 
 namespace ILCompiler
 {
@@ -58,7 +59,13 @@ namespace ILCompiler
 
             if (MarshalHelpers.IsStructMarshallingRequired(type))
             {
-                dependencies.Add(factory.StructMarshallingData((DefType)type), "Struct marshalling");
+                foreach (FieldDesc field in type.GetFields())
+                {
+                    if (field.IsStatic)
+                        continue;
+
+                    AddParameterMarshallingDependencies(ref dependencies, factory, field.FieldType);
+                }
             }
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/UsageBasedInteropStubManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/UsageBasedInteropStubManager.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.IL;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Interop;
+
+using ILCompiler.DependencyAnalysis;
+
+using Debug = System.Diagnostics.Debug;
+using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Represents an interop stub manager whose list of stubs is determined by statical usage seen in the compiled program.
+    /// </summary>
+    public class UsageBasedInteropStubManager : CompilerGeneratedInteropStubManager
+    {
+        public UsageBasedInteropStubManager(InteropStateManager interopStateManager, PInvokeILEmitterConfiguration pInvokeILEmitterConfiguration)
+            : base(interopStateManager, pInvokeILEmitterConfiguration)
+        {
+        }
+
+        public override void AddDependeciesDueToPInvoke(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            if (method.IsPInvoke)
+            {
+                dependencies = dependencies ?? new DependencyList();
+
+                MethodSignature methodSig = method.Signature;
+                AddParameterMarshallingDependencies(ref dependencies, factory, methodSig.ReturnType);
+
+                for (int i = 0; i < methodSig.Length; i++)
+                {
+                    AddParameterMarshallingDependencies(ref dependencies, factory, methodSig[i]);
+                }
+            }
+
+            if (method.HasInstantiation)
+            {
+                dependencies = dependencies ?? new DependencyList();
+                AddMarshalAPIsGenericDependencies(ref dependencies, factory, method);
+            }
+        }
+
+        private static void AddParameterMarshallingDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
+        {
+            if (type.IsDelegate)
+            {
+                dependencies.Add(factory.DelegateMarshallingData((DefType)type), "Delegate marshaling");
+            }
+
+            // struct may contain delegate fields, hence we need to add dependencies for it
+            if (type.IsByRef)
+                type = ((ParameterizedType)type).ParameterType;
+
+            if (MarshalHelpers.IsStructMarshallingRequired(type))
+            {
+                dependencies.Add(factory.StructMarshallingData((DefType)type), "Struct marshalling");
+            }
+        }
+
+        public override void AddInterestingInteropConstructedTypeDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
+        {
+            if (type.IsDelegate)
+            {
+                var delegateType = (MetadataType)type;
+                if (delegateType.HasCustomAttribute("System.Runtime.InteropServices", "UnmanagedFunctionPointerAttribute"))
+                {
+                    dependencies = dependencies ?? new DependencyList();
+                    dependencies.Add(factory.DelegateMarshallingData(delegateType), "Delegate marshalling");
+                }
+            }
+        }
+
+        /// <summary>
+        /// For Marshal generic APIs(eg. Marshal.StructureToPtr<T>, GetFunctionPointerForDelegate) we add
+        /// the generic parameter as dependencies so that we can generate runtime data for them
+        /// </summary>
+        public override void AddMarshalAPIsGenericDependencies(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            Debug.Assert(method.HasInstantiation);
+
+            TypeDesc owningType = method.OwningType;
+            MetadataType metadataType = owningType as MetadataType;
+            if (metadataType != null && metadataType.Module == factory.TypeSystemContext.SystemModule)
+            {
+                if (metadataType.Name == "Marshal" && metadataType.Namespace == "System.Runtime.InteropServices")
+                {
+                    string methodName = method.Name;
+                    if (methodName == "GetFunctionPointerForDelegate" ||
+                        methodName == "GetDelegateForFunctionPointer" ||
+                        methodName == "PtrToStructure" ||
+                        methodName == "StructureToPtr" ||
+                        methodName == "SizeOf" ||
+                        methodName == "OffsetOf")
+                    {
+                        foreach (TypeDesc type in method.Instantiation)
+                        {
+                            dependencies = dependencies ?? new DependencyList();
+                            if (type.IsDelegate)
+                            {
+                                dependencies.Add(factory.DelegateMarshallingData((DefType)type), "Delegate marshlling");
+                            }
+                            else if (MarshalHelpers.IsStructMarshallingRequired(type) || (methodName == "OffsetOf" && type is DefType))
+                            {
+                                dependencies.Add(factory.StructMarshallingData((DefType)type), "Struct marshalling");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -97,6 +97,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\TypeSystemThrowingILEmitter.cs">
       <Link>IL\Stubs\TypeSystemThrowingILEmitter.cs</Link>
     </Compile>
+    <Compile Include="Compiler\AnalysisBasedInteropStubManager.cs" />
     <Compile Include="Compiler\AnalysisBasedMetadataManager.cs" />
     <Compile Include="Compiler\BlockedInternalsBlockingPolicy.cs" />
     <Compile Include="Compiler\CodeGenerationFailedException.cs" />
@@ -355,6 +356,7 @@
     <Compile Include="Compiler\TypeExtensions.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.TypeInit.cs" />
     <Compile Include="Compiler\CoreRTNameMangler.cs" />
+    <Compile Include="Compiler\UsageBasedInteropStubManager.cs" />
     <Compile Include="Compiler\UsageBasedMetadataManager.cs" />
     <Compile Include="Compiler\UserDefinedTypeDescriptor.cs" />
     <Compile Include="Compiler\UniversalGenericsRootProvider.cs" />

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Compiler\CompilerGeneratedInteropStubManager.cs" />
     <Compile Include="Compiler\DebugInformationProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\DefaultConstructorMapNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\DelegateMarshallingDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolsImportedNodeProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolsWithIndirectionImportedNodeProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IndirectionExtensions.cs" />
@@ -116,6 +117,7 @@
     <Compile Include="Compiler\DependencyAnalysis\MrtProcessedImportAddressTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectionMethodBodyScanner.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RuntimeDecodableJumpStub.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\StructMarshallingDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\WindowsDebugILImagesSection.cs" />
     <Compile Include="Compiler\DependencyAnalysis\WindowsDebugManagedNativeDictionaryInfoSection.cs" />
     <Compile Include="Compiler\DependencyAnalysis\WindowsDebugMergedAssemblyRecordsSection.cs" />

--- a/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilation.cs
+++ b/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilation.cs
@@ -25,10 +25,9 @@ namespace ILCompiler
             IEnumerable<ICompilationRootProvider> roots,
             ILProvider ilProvider,
             DebugInformationProvider debugInformationProvider,
-            PInvokeILEmitterConfiguration pinvokePolicy,
             Logger logger,
             CppCodegenConfigProvider options)
-            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), ilProvider, debugInformationProvider, null, pinvokePolicy, logger)
+            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), ilProvider, debugInformationProvider, null, logger)
         {
             Options = options;
         }

--- a/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilationBuilder.cs
@@ -44,11 +44,11 @@ namespace ILCompiler
 
         public override ICompilation ToCompilation()
         {
-            var interopStubManager = new CompilerGeneratedInteropStubManager(_compilationGroup, _context, new InteropStateManager(_context.GeneratedAssembly));
+            var interopStubManager = new CompilerGeneratedInteropStubManager(new InteropStateManager(_context.GeneratedAssembly), _pinvokePolicy);
             CppCodegenNodeFactory factory = new CppCodegenNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
 
-            return new CppCodegenCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _pinvokePolicy, _logger, _config);
+            return new CppCodegenCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _config);
         }
     }
 

--- a/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilationBuilder.cs
@@ -44,8 +44,7 @@ namespace ILCompiler
 
         public override ICompilation ToCompilation()
         {
-            var interopStubManager = new CompilerGeneratedInteropStubManager(new InteropStateManager(_context.GeneratedAssembly), _pinvokePolicy);
-            CppCodegenNodeFactory factory = new CppCodegenNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
+            CppCodegenNodeFactory factory = new CppCodegenNodeFactory(_context, _compilationGroup, _metadataManager, _interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory);
 
             return new CppCodegenCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _config);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -44,12 +44,11 @@ namespace ILCompiler
             IEnumerable<ICompilationRootProvider> roots,
             ILProvider ilProvider,
             DebugInformationProvider debugInformationProvider,
-            PInvokeILEmitterConfiguration pInvokePolicy,
             Logger logger,
             DevirtualizationManager devirtualizationManager,
             JitConfigProvider configProvider,
             string inputFilePath)
-            : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, devirtualizationManager, pInvokePolicy, logger)
+            : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, devirtualizationManager, logger)
         {
             NodeFactory = nodeFactory;
             SymbolNodeFactory = new ReadyToRunSymbolNodeFactory(nodeFactory);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -76,7 +76,7 @@ namespace ILCompiler
 
         public override ICompilation ToCompilation()
         {
-            var interopStubManager = new EmptyInteropStubManager(_compilationGroup, _context, new InteropStateManager(_context.GeneratedAssembly));
+            var interopStubManager = new EmptyInteropStubManager();
 
             ModuleTokenResolver moduleTokenResolver = new ModuleTokenResolver(_compilationGroup, _context);
             SignatureContext signatureContext = new SignatureContext(_inputModule, moduleTokenResolver);
@@ -123,7 +123,6 @@ namespace ILCompiler
                 _compilationRoots,
                 _ilProvider,
                 _debugInformationProvider,
-                _pinvokePolicy,
                 _logger,
                 _devirtualizationManager,
                 jitConfig,

--- a/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilation.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilation.cs
@@ -28,12 +28,11 @@ namespace ILCompiler
             IEnumerable<ICompilationRootProvider> roots,
             ILProvider ilProvider,
             DebugInformationProvider debugInformationProvider,
-            PInvokeILEmitterConfiguration pinvokePolicy,
             Logger logger,
             DevirtualizationManager devirtualizationManager,
             JitConfigProvider configProvider,
             RyuJitCompilationOptions options)
-            : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, devirtualizationManager, pinvokePolicy, logger)
+            : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, devirtualizationManager, logger)
         {
             _jitConfigProvider = configProvider;
             _compilationOptions = options;

--- a/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilationBuilder.cs
@@ -103,12 +103,12 @@ namespace ILCompiler
             if (_methodBodyFolding)
                 options |= RyuJitCompilationOptions.MethodBodyFolding;
 
-            var interopStubManager = new CompilerGeneratedInteropStubManager(_compilationGroup, _context, new InteropStateManager(_context.GeneratedAssembly));
+            var interopStubManager = new CompilerGeneratedInteropStubManager(new InteropStateManager(_context.GeneratedAssembly), _pinvokePolicy);
             var factory = new RyuJitNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
 
             var jitConfig = new JitConfigProvider(jitFlagBuilder.ToArray(), _ryujitOptions);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
-            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _pinvokePolicy, _logger, _devirtualizationManager, jitConfig, options);
+            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _devirtualizationManager, jitConfig, options);
         }
     }
 }

--- a/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilationBuilder.cs
@@ -103,8 +103,7 @@ namespace ILCompiler
             if (_methodBodyFolding)
                 options |= RyuJitCompilationOptions.MethodBodyFolding;
 
-            var interopStubManager = new CompilerGeneratedInteropStubManager(new InteropStateManager(_context.GeneratedAssembly), _pinvokePolicy);
-            var factory = new RyuJitNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
+            var factory = new RyuJitNodeFactory(_context, _compilationGroup, _metadataManager, _interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
 
             var jitConfig = new JitConfigProvider(jitFlagBuilder.ToArray(), _ryujitOptions);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
@@ -27,10 +27,9 @@ namespace ILCompiler
             IEnumerable<ICompilationRootProvider> roots,
             ILProvider ilProvider,
             DebugInformationProvider debugInformationProvider,
-            PInvokeILEmitterConfiguration pinvokePolicy,
             Logger logger,
             WebAssemblyCodegenConfigProvider options)
-            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), ilProvider, debugInformationProvider, null, pinvokePolicy, logger)
+            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), ilProvider, debugInformationProvider, null, logger)
         {
             NodeFactory = nodeFactory;
             Module = LLVM.ModuleCreateWithName("netscripten");

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilationBuilder.cs
@@ -44,10 +44,10 @@ namespace ILCompiler
 
         public override ICompilation ToCompilation()
         {
-            var interopStubManager = new CompilerGeneratedInteropStubManager(_compilationGroup, _context, new InteropStateManager(_context.GeneratedAssembly));
+            var interopStubManager = new CompilerGeneratedInteropStubManager(new InteropStateManager(_context.GeneratedAssembly), _pinvokePolicy);
             WebAssemblyCodegenNodeFactory factory = new WebAssemblyCodegenNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
-            return new WebAssemblyCodegenCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _pinvokePolicy, _logger, _config);
+            return new WebAssemblyCodegenCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _config);
         }
     }
 

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilationBuilder.cs
@@ -44,8 +44,7 @@ namespace ILCompiler
 
         public override ICompilation ToCompilation()
         {
-            var interopStubManager = new CompilerGeneratedInteropStubManager(new InteropStateManager(_context.GeneratedAssembly), _pinvokePolicy);
-            WebAssemblyCodegenNodeFactory factory = new WebAssemblyCodegenNodeFactory(_context, _compilationGroup, _metadataManager, interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
+            WebAssemblyCodegenNodeFactory factory = new WebAssemblyCodegenNodeFactory(_context, _compilationGroup, _metadataManager, _interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
             return new WebAssemblyCodegenCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _config);
         }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -630,10 +630,6 @@ namespace Internal.JitInterface
             if (method.IsPInvoke)
             {
                 result |= CorInfoFlag.CORINFO_FLG_PINVOKE;
-
-                // TODO: Enable PInvoke inlining
-                // https://github.com/dotnet/corert/issues/6063
-                result |= CorInfoFlag.CORINFO_FLG_DONT_INLINE;
             }
 
             if (method.IsAggressiveOptimization)

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -835,21 +835,13 @@ namespace PInvokeTests
             ThrowIfNotEquals(true, ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp"), "LayoutClassPtr marshalling scenario1 failed.");
         }
 
-        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
-        private static void Issue6063Workaround()
-        {
-            // https://github.com/dotnet/corert/issues/6063
-            // Ensure there's a standalone method body for these two - this method is marked NoOptimization+NoInlining.
-            Marshal.SizeOf<SequentialClass>();
-            Marshal.SizeOf<SequentialStruct>();
-        }
-        
         private static void TestAsAny()
         {
             if (String.Empty.Length > 0)
             {
                 // Make sure we saw these types being used in marshalling
-                Issue6063Workaround();
+                Marshal.SizeOf<SequentialClass>();
+                Marshal.SizeOf<SequentialStruct>();
             }
 
             SequentialClass sc = new SequentialClass();

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -2,6 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if MULTIMODULE_BUILD && !DEBUG
+// Some tests won't work if we're using optimizing codegen, but scanner doesn't run.
+// This currently happens in optimized multi-obj builds.
+#define OPTIMIZED_MODE_WITHOUT_SCANNER
+#endif
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -126,8 +132,13 @@ namespace PInvokeTests
 
         delegate int Delegate_Int_AggressiveInlining(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j);
         [DllImport("*", CallingConvention = CallingConvention.StdCall, EntryPoint = "ReversePInvoke_Int")]
+#if OPTIMIZED_MODE_WITHOUT_SCANNER
+        [MethodImpl(MethodImplOptions.NoInlining)]
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         static extern bool ReversePInvoke_Int_AggressiveInlining(Delegate_Int_AggressiveInlining del);
+
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet=CharSet.Ansi)]
         delegate bool Delegate_String(string s);
@@ -835,6 +846,16 @@ namespace PInvokeTests
             ThrowIfNotEquals(true, ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp"), "LayoutClassPtr marshalling scenario1 failed.");
         }
 
+#if OPTIMIZED_MODE_WITHOUT_SCANNER
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        private static void Workaround()
+        {
+            // Ensure there's a standalone method body for these two - this method is marked NoOptimization+NoInlining.
+            Marshal.SizeOf<SequentialClass>();
+            Marshal.SizeOf<SequentialStruct>();
+        }
+#endif
+
         private static void TestAsAny()
         {
             if (String.Empty.Length > 0)
@@ -842,6 +863,9 @@ namespace PInvokeTests
                 // Make sure we saw these types being used in marshalling
                 Marshal.SizeOf<SequentialClass>();
                 Marshal.SizeOf<SequentialStruct>();
+#if OPTIMIZED_MODE_WITHOUT_SCANNER
+                Workaround();
+#endif
             }
 
             SequentialClass sc = new SequentialClass();


### PR DESCRIPTION
This puts interop manager on the same plan as metadata manager. The reason we need two managers is inlining: to determine what structs/delegates need marshaling data, we look at what methods got compiled. This works great as long as there's no inlining of these methods. If we inline a method used as such marker, we lose track of what needs interop data.

With this split, we can collect usage information during the IL scanning phase, and for codegen phase, we can reuse the information from the scanner.

Commit 4c1058a removes a bunch of workarounds that we had in place because of this.

The commits mostly make sense (might help reviewing this big change), although I'm planning to squash them anyway. The `Don't make so much marshalling data` commit undoes something I did wrong in the `Track interop dependencies in the dependency graph` commit.

Fixes #6063.