### PR TITLE
Add support for embedding and processing embedded stacktrace line infos

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -918,7 +918,8 @@ namespace Internal.Runtime.Augments
             if (ip == IntPtr.Zero)
                 return null;
 
-            return callbacks.TryGetMethodNameFromStartAddress(ip);
+            callbacks.TryGetMethodNameFromStartAddress(ip, 0, out string methodName, out _, out _);
+            return methodName;
         }
 
         private static volatile ReflectionExecutionDomainCallbacks s_reflectionExecutionDomainCallbacks;

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/StackTraceMetadataCallbacks.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/StackTraceMetadataCallbacks.cs
@@ -25,6 +25,6 @@ namespace Internal.Runtime.Augments
         /// </summary>
         /// <param name="methodStartAddress">Memory address representing the start of a method</param>
         /// <returns>Formatted method name or null if metadata for the method is not available</returns>
-        public abstract string TryGetMethodNameFromStartAddress(IntPtr methodStartAddress);
+        public abstract bool TryGetMethodNameFromStartAddress(IntPtr methodStartAddress, int offset, out string methodName, out string fileName, out int lineNumber);
     }
 }


### PR DESCRIPTION
As discussed @MichalStrehovsky 
**TODO**:
- configurability
- compression
- disabling reflection fallback

Uncompressed numbers for sizes:
For a debug Hello World application (which includes debug information for corelib).

| Section | bytes | count |
| --- | --- | --- |
| rvaTokenMap | 127.788 | 10.648 |
| sequencePoints | 1.012.608 | 111.737 |
| stringHeap | 70.160 | 767 |