### PR TITLE
Prevent computing bad layout

### DIFF
--- a/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -327,7 +327,15 @@ namespace Internal.TypeSystem
 
                 // GC pointers MUST be aligned.
                 // We treat byref-like structs as GC pointers too.
-                if (!computedOffset.IsIndeterminate && (fieldType.IsGCPointer || fieldType.IsByRefLike))
+                bool needsToBeAligned =
+                    !computedOffset.IsIndeterminate
+                    &&
+                    (
+                        fieldType.IsGCPointer
+                        || fieldType.IsByRefLike
+                        || (fieldType.IsValueType && ((DefType)fieldType).ContainsGCPointers)
+                    );
+                if (needsToBeAligned)
                 {
                     int offsetModulo = computedOffset.AsInt % type.Context.Target.PointerSize;
                     if (offsetModulo != 0)

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunMetadataFieldLayoutAlgorithm.cs
@@ -717,7 +717,7 @@ namespace ILCompiler
             {
                 return;
             }
-            HashSet<DefType> recursionGuard = new HashSet<DefType>();
+
             if (!_compilationGroup.ContainsTypeLayout(baseType))
             {
                 LayoutInt alignment = new LayoutInt(type.Context.Target.PointerSize);


### PR DESCRIPTION
Value type fields that contain GC pointers need to start at pointer boundaries.

CoreCLR does this check a bit differently (it technically allows unaligned fields, provided the GC pointer inside the valuetype ends up being aligned with respect to the beginning of the type, but in reality, I don't think it's possible to end up in such situation - the layout of the field type itself would end up being invalid).

Fixes one of the CPAOT failures.