### PR TITLE
Fix stack traces when reflection is disabled

### DIFF
--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
@@ -93,6 +93,10 @@ namespace Internal.Reflection.Execution
             typeHandle = default(TypeDefinitionHandle);
             methodHandle = default(MethodHandle);
 
+            // If ExecutionEnvironment is null, reflection must be disabled.
+            if (ExecutionEnvironment == null)
+                return false;
+
             RuntimeTypeHandle declaringTypeHandle = default(RuntimeTypeHandle);
             if (!ExecutionEnvironment.TryGetMethodForStartAddress(methodStartAddress,
                 ref declaringTypeHandle, out QMethodDefinition qMethodDefinition))


### PR DESCRIPTION
This enables stack trace metadata when `IlcDisableReflection == true` and `IlcGenerateStackTraceData == true`. Enabling stack trace metadata had no effect before this change.

This also has a side effect of always generating the metadata blob. This is necessary because `ModuleList` tends to ignore modules that don't have the embedded metadata blob (https://github.com/dotnet/corert/blob/635cf21aca11265ded9d78d216424bd609c052f5/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/ModuleList.cs#L713-L720). Emitting an empty blob fixes the bug where delegate interop didn't work with reflection disabled.