### PR TITLE
Unify calling convention of casting helpers

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
@@ -232,28 +232,28 @@ namespace ILCompiler
                     break;
 
                 case ReadyToRunHelper.CheckCastAny:
-                    mangledName = "RhTypeCast_CheckCast2";
+                    mangledName = "RhTypeCast_CheckCast";
                     break;
                 case ReadyToRunHelper.CheckInstanceAny:
-                    mangledName = "RhTypeCast_IsInstanceOf2";
+                    mangledName = "RhTypeCast_IsInstanceOf";
                     break;
                 case ReadyToRunHelper.CheckCastInterface:
-                    mangledName = "RhTypeCast_CheckCastInterface2";
+                    mangledName = "RhTypeCast_CheckCastInterface";
                     break;
                 case ReadyToRunHelper.CheckInstanceInterface:
-                    mangledName = "RhTypeCast_IsInstanceOfInterface2";
+                    mangledName = "RhTypeCast_IsInstanceOfInterface";
                     break;
                 case ReadyToRunHelper.CheckCastClass:
-                    mangledName = "RhTypeCast_CheckCastClass2";
+                    mangledName = "RhTypeCast_CheckCastClass";
                     break;
                 case ReadyToRunHelper.CheckInstanceClass:
-                    mangledName = "RhTypeCast_IsInstanceOfClass2";
+                    mangledName = "RhTypeCast_IsInstanceOfClass";
                     break;
                 case ReadyToRunHelper.CheckCastArray:
-                    mangledName = "RhTypeCast_CheckCastArray2";
+                    mangledName = "RhTypeCast_CheckCastArray";
                     break;
                 case ReadyToRunHelper.CheckInstanceArray:
-                    mangledName = "RhTypeCast_IsInstanceOfArray2";
+                    mangledName = "RhTypeCast_IsInstanceOfArray";
                     break;
 
                 case ReadyToRunHelper.MonitorEnter:

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -1020,21 +1020,22 @@ namespace Internal.IL
 
             Append(opcode == ILOpcode.isinst ? "__isinst" : "__castclass");
             Append("(");
-            Append(value);
-            Append(", ");
             if (runtimeDeterminedType.IsRuntimeDeterminedSubtype)
             {
                 Append("(MethodTable *)");
                 Append(GetGenericLookupHelperAndAddReference(ReadyToRunHelperId.TypeHandle, runtimeDeterminedType));
                 Append("(");
                 Append(GetGenericContext());
-                Append("))");
+                Append(")");
             }
             else
             {
                 Append(_writer.GetCppTypeName(runtimeDeterminedType));
-                Append("::__getMethodTable())");
+                Append("::__getMethodTable()");
             }
+            Append(", ");
+            Append(value);
+            Append(")");
             AppendSemicolon();
         }
 

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1481,8 +1481,8 @@ namespace Internal.IL
 
             var arguments = new StackEntry[]
             {
-                _stack.Pop(),
-                new LoadExpressionEntry(StackValueKind.ValueType, "eeType", GetEETypePointerForTypeDesc(type, true), _compilation.TypeSystemContext.SystemModule.GetKnownType("System", "EETypePtr"))
+                new LoadExpressionEntry(StackValueKind.ValueType, "eeType", GetEETypePointerForTypeDesc(type, true), _compilation.TypeSystemContext.SystemModule.GetKnownType("System", "EETypePtr")),
+                _stack.Pop()
             };
 
             _stack.Push(CallRuntime(_compilation.TypeSystemContext, TypeCast, function, arguments, type));

--- a/src/Native/Bootstrap/common.h
+++ b/src/Native/Bootstrap/common.h
@@ -44,8 +44,8 @@ void __shutdown_runtime();
 
 extern "C" Object * __allocate_object(MethodTable * pMT);
 extern "C" Object * __allocate_array(size_t elements, MethodTable * pMT);
-extern "C" Object * __castclass(void * obj, MethodTable * pMT);
-extern "C" Object * __isinst(void * obj, MethodTable * pMT);
+extern "C" Object * __castclass(MethodTable * pMT, void * obj);
+extern "C" Object * __isinst(MethodTable * pMT, void * obj);
 extern "C" __NORETURN void __throw_exception(void * pEx);
 extern "C" void __debug_break();
 

--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -112,8 +112,8 @@ static char& __unbox_z = __stop___unbox;
 
 extern "C" Object * RhNewObject(MethodTable * pMT);
 extern "C" Object * RhNewArray(MethodTable * pMT, int32_t elements);
-extern "C" void * RhTypeCast_IsInstanceOf(void * pObject, MethodTable * pMT);
-extern "C" void * RhTypeCast_CheckCast(void * pObject, MethodTable * pMT);
+extern "C" void * RhTypeCast_IsInstanceOf(MethodTable * pMT, void* pObject);
+extern "C" void * RhTypeCast_CheckCast(MethodTable * pMT, void* pObject);
 extern "C" void RhpStelemRef(void * pArray, int index, void * pObj);
 extern "C" void * RhpLdelemaRef(void * pArray, int index, MethodTable * pMT);
 extern "C" __NORETURN void RhpThrowEx(void * pEx);
@@ -129,14 +129,14 @@ extern "C" Object * __allocate_array(size_t elements, MethodTable * pMT)
     return RhNewArray(pMT, (int32_t)elements); // TODO: type mismatch
 }
 
-extern "C" Object * __castclass(void * obj, MethodTable * pTargetMT)
+extern "C" Object * __castclass(MethodTable * pTargetMT, void* obj)
 {
-    return (Object *)RhTypeCast_CheckCast(obj, pTargetMT);
+    return (Object *)RhTypeCast_CheckCast(pTargetMT, obj);
 }
 
-extern "C" Object * __isinst(void * obj, MethodTable * pTargetMT)
+extern "C" Object * __isinst(MethodTable * pTargetMT, void* obj)
 {
-    return (Object *)RhTypeCast_IsInstanceOf(obj, pTargetMT);
+    return (Object *)RhTypeCast_IsInstanceOf(pTargetMT, obj);
 }
 
 extern "C" void __stelem_ref(void * pArray, unsigned idx, void * obj)

--- a/src/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -900,7 +900,7 @@ namespace System.Runtime
             AssertNotRuntimeObject(pClauseType);
 #endif
 
-            return TypeCast.IsInstanceOfClass(exception, pClauseType) != null;
+            return TypeCast.IsInstanceOfClass(pClauseType, exception) != null;
         }
 
         private static void InvokeSecondPass(ref ExInfo exInfo, uint idxStart)

--- a/src/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -184,7 +184,7 @@ namespace System.Runtime
             }
             else
             {
-                if (o != null && (TypeCast.IsInstanceOf(o, ptrUnboxToEEType) == null))
+                if (o != null && (TypeCast.IsInstanceOf(ptrUnboxToEEType, o) == null))
                 {
                     throw ptrUnboxToEEType->GetClasslibException(ExceptionIDs.InvalidCast);
                 }

--- a/src/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -43,14 +43,8 @@ namespace System.Runtime
             AllowSizeEquivalence = 2,
         }
 
-        [RuntimeExport("RhTypeCast_IsInstanceOfClass2")]
-        public static unsafe object IsInstanceOfClass2(void* pvTargetType, object obj)
-        {
-            return IsInstanceOfClass(obj, pvTargetType);
-        }
-
         [RuntimeExport("RhTypeCast_IsInstanceOfClass")]
-        public static unsafe object IsInstanceOfClass(object obj, void* pvTargetType)
+        public static unsafe object IsInstanceOfClass(void* pvTargetType, object obj)
         {
             if (obj == null)
             {
@@ -159,20 +153,14 @@ namespace System.Runtime
             }
         }
 
-        [RuntimeExport("RhTypeCast_CheckCastClass2")]
-        public static unsafe object CheckCastClass2(void* pvTargetEEType, object obj)
-        {
-            return CheckCastClass(obj, pvTargetEEType);
-        }
-
         [RuntimeExport("RhTypeCast_CheckCastClass")]
-        public static unsafe object CheckCastClass(object obj, void* pvTargetEEType)
+        public static unsafe object CheckCastClass(void* pvTargetEEType, object obj)
         {
             // a null value can be cast to anything
             if (obj == null)
                 return null;
 
-            object result = IsInstanceOfClass(obj, pvTargetEEType);
+            object result = IsInstanceOfClass(pvTargetEEType, obj);
 
             if (result == null)
             {
@@ -202,14 +190,8 @@ namespace System.Runtime
             throw obj.EEType->GetClasslibException(ExceptionIDs.InvalidCast);
         }
 
-        [RuntimeExport("RhTypeCast_IsInstanceOfArray2")]
-        public static unsafe object IsInstanceOfArray2(void* pvTargetType, object obj)
-        {
-            return IsInstanceOfArray(obj, pvTargetType);
-        }
-
         [RuntimeExport("RhTypeCast_IsInstanceOfArray")]
-        public static unsafe object IsInstanceOfArray(object obj, void* pvTargetType)
+        public static unsafe object IsInstanceOfArray(void* pvTargetType, object obj)
         {
             if (obj == null)
             {
@@ -256,20 +238,14 @@ namespace System.Runtime
             return null;
         }
 
-        [RuntimeExport("RhTypeCast_CheckCastArray2")]
-        public static unsafe object CheckCastArray2(void* pvTargetEEType, object obj)
-        {
-            return CheckCastArray(obj, pvTargetEEType);
-        }
-
         [RuntimeExport("RhTypeCast_CheckCastArray")]
-        public static unsafe object CheckCastArray(object obj, void* pvTargetEEType)
+        public static unsafe object CheckCastArray(void* pvTargetEEType, object obj)
         {
             // a null value can be cast to anything
             if (obj == null)
                 return null;
 
-            object result = IsInstanceOfArray(obj, pvTargetEEType);
+            object result = IsInstanceOfArray(pvTargetEEType, obj);
 
             if (result == null)
             {
@@ -282,14 +258,8 @@ namespace System.Runtime
             return result;
         }
 
-        [RuntimeExport("RhTypeCast_IsInstanceOfInterface2")]
-        public static unsafe object IsInstanceOfInterface2(void* pvTargetType, object obj)
-        {
-            return IsInstanceOfInterface(obj, pvTargetType);
-        }
-
         [RuntimeExport("RhTypeCast_IsInstanceOfInterface")]
-        public static unsafe object IsInstanceOfInterface(object obj, void* pvTargetType)
+        public static unsafe object IsInstanceOfInterface(void* pvTargetType, object obj)
         {
             if (obj == null)
             {
@@ -766,14 +736,8 @@ namespace System.Runtime
             return false;
         }
 
-        [RuntimeExport("RhTypeCast_CheckCastInterface2")]
-        public static unsafe object CheckCastInterface2(void* pvTargetEEType, object obj)
-        {
-            return CheckCastInterface(obj, pvTargetEEType);
-        }
-
         [RuntimeExport("RhTypeCast_CheckCastInterface")]
-        public static unsafe object CheckCastInterface(object obj, void* pvTargetEEType)
+        public static unsafe object CheckCastInterface(void* pvTargetEEType, object obj)
         {
             // a null value can be cast to anything
             if (obj == null)
@@ -993,44 +957,32 @@ namespace System.Runtime
             return false;
         }
 
-        [RuntimeExport("RhTypeCast_IsInstanceOf2")]  // Helper with RyuJIT calling convention
-        public static unsafe object IsInstanceOf2(void* pvTargetType, object obj)
-        {
-            return IsInstanceOf(obj, pvTargetType);
-        }
-
         // this is necessary for shared generic code - Foo<T> may be executing
         // for T being an interface, an array or a class
         [RuntimeExport("RhTypeCast_IsInstanceOf")]
-        public static unsafe object IsInstanceOf(object obj, void* pvTargetType)
+        public static unsafe object IsInstanceOf(void* pvTargetType, object obj)
         {
             // @TODO: consider using the cache directly, but beware of ICastable in the interface case
             EEType* pTargetType = (EEType*)pvTargetType;
             if (pTargetType->IsArray)
-                return IsInstanceOfArray(obj, pvTargetType);
+                return IsInstanceOfArray(pvTargetType, obj);
             else if (pTargetType->IsInterface)
-                return IsInstanceOfInterface(obj, pvTargetType);
+                return IsInstanceOfInterface(pvTargetType, obj);
             else
-                return IsInstanceOfClass(obj, pvTargetType);
-        }
-
-        [RuntimeExport("RhTypeCast_CheckCast2")] // Helper with RyuJIT calling convention
-        public static unsafe object CheckCast2(void* pvTargetType, object obj)
-        {
-            return CheckCast(obj, pvTargetType);
+                return IsInstanceOfClass(pvTargetType, obj);
         }
 
         [RuntimeExport("RhTypeCast_CheckCast")]
-        public static unsafe object CheckCast(object obj, void* pvTargetType)
+        public static unsafe object CheckCast(void* pvTargetType, object obj)
         {
             // @TODO: consider using the cache directly, but beware of ICastable in the interface case
             EEType* pTargetType = (EEType*)pvTargetType;
             if (pTargetType->IsArray)
-                return CheckCastArray(obj, pvTargetType);
+                return CheckCastArray(pvTargetType, obj);
             else if (pTargetType->IsInterface)
-                return CheckCastInterface(obj, pvTargetType);
+                return CheckCastInterface(pvTargetType, obj);
             else
-                return CheckCastClass(obj, pvTargetType);
+                return CheckCastClass(pvTargetType, obj);
         }
 
         // Returns true of the two types are equivalent primitive types. Used by array casts.

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -535,7 +535,7 @@ namespace Internal.Runtime.Augments
 
         public static bool IsInstanceOfInterface(object obj, RuntimeTypeHandle interfaceTypeHandle)
         {
-            return (null != RuntimeImports.IsInstanceOfInterface(obj, interfaceTypeHandle.ToEETypePtr()));
+            return (null != RuntimeImports.IsInstanceOfInterface(interfaceTypeHandle.ToEETypePtr(), obj));
         }
 
         //

--- a/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -408,7 +408,7 @@ namespace System
                 for (int i = 0; i < length; i++)
                 {
                     object value = Unsafe.Add(ref refSourceArray, sourceIndex - i);
-                    if (mustCastCheckEachElement && value != null && RuntimeImports.IsInstanceOf(value, destinationElementEEType) == null)
+                    if (mustCastCheckEachElement && value != null && RuntimeImports.IsInstanceOf(destinationElementEEType, value) == null)
                         throw new InvalidCastException(SR.InvalidCast_DownCastArrayElement);
                     Unsafe.Add(ref refDestinationArray, destinationIndex - i) = value;
                 }
@@ -418,7 +418,7 @@ namespace System
                 for (int i = 0; i < length; i++)
                 {
                     object value = Unsafe.Add(ref refSourceArray, sourceIndex + i);
-                    if (mustCastCheckEachElement && value != null && RuntimeImports.IsInstanceOf(value, destinationElementEEType) == null)
+                    if (mustCastCheckEachElement && value != null && RuntimeImports.IsInstanceOf(destinationElementEEType, value) == null)
                         throw new InvalidCastException(SR.InvalidCast_DownCastArrayElement);
                     Unsafe.Add(ref refDestinationArray, destinationIndex + i) = value;
                 }

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
@@ -291,17 +291,17 @@ namespace System.Runtime.InteropServices
 
         public static bool IsInstanceOf(object obj, RuntimeTypeHandle typeHandle)
         {
-            return (null != RuntimeImports.IsInstanceOf(obj, typeHandle.ToEETypePtr()));
+            return (null != RuntimeImports.IsInstanceOf(typeHandle.ToEETypePtr(), obj));
         }
 
         public static bool IsInstanceOfClass(object obj, RuntimeTypeHandle classTypeHandle)
         {
-            return (null != RuntimeImports.IsInstanceOfClass(obj, classTypeHandle.ToEETypePtr()));
+            return (null != RuntimeImports.IsInstanceOfClass(classTypeHandle.ToEETypePtr(), obj));
         }
 
         public static bool IsInstanceOfInterface(object obj, RuntimeTypeHandle interfaceTypeHandle)
         {
-            return (null != RuntimeImports.IsInstanceOfInterface(obj, interfaceTypeHandle.ToEETypePtr()));
+            return (null != RuntimeImports.IsInstanceOfInterface(interfaceTypeHandle.ToEETypePtr(), obj));
         }
 
         public static bool GuidEquals(ref Guid left, ref Guid right)

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -339,15 +339,15 @@ namespace System.Runtime
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhTypeCast_IsInstanceOf")]
-        internal static extern object IsInstanceOf(object obj, EETypePtr pTargetType);
+        internal static extern object IsInstanceOf(EETypePtr pTargetType, object obj);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhTypeCast_IsInstanceOfClass")]
-        internal static extern object IsInstanceOfClass(object obj, EETypePtr pTargetType);
+        internal static extern object IsInstanceOfClass(EETypePtr pTargetType, object obj);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhTypeCast_IsInstanceOfInterface")]
-        internal static extern object IsInstanceOfInterface(object obj, EETypePtr pTargetType);
+        internal static extern object IsInstanceOfInterface(EETypePtr pTargetType, object obj);
 
         //
         // calls to runtime for allocation


### PR DESCRIPTION
Use the RyuJIT calling convention (type first, object second) everywhere.