### PR TITLE
Use CORINFO_VIRTUALCALL_STUB for virtual methods

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -36,7 +36,6 @@ namespace ILCompiler.DependencyAnalysis
         MethodDictionary,
         TypeDictionary,
         MethodEntry,
-        VirtualEntry,
         VirtualDispatchCell,
         DefaultConstructor,
         TypeHandleForCasting,

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1010,7 +1010,7 @@ namespace Internal.JitInterface
                 // Insert explicit null checks for cross-version bubble non-interface calls.
                 // It is required to handle null checks properly for non-virtual <-> virtual change between versions
                 pResult->nullInstanceCheck = callVirtCrossingVersionBubble && !targetMethod.OwningType.IsInterface;
-                pResult->kind = CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_LDVIRTFTN;
+                pResult->kind = CORINFO_CALL_KIND.CORINFO_VIRTUALCALL_STUB;
 
                 // We can't make stub calls when we need exact information
                 // for interface calls from shared code.
@@ -1257,7 +1257,7 @@ namespace Internal.JitInterface
                         else if (entryKind == DictionaryEntryKind.MethodEntrySlot || entryKind == DictionaryEntryKind.ConstrainedMethodEntrySlot)
                             pResultLookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.MethodEntry;
                         else
-                            pResultLookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.VirtualEntry;
+                            pResultLookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.VirtualDispatchCell;
 
                         pResultLookup.lookupKind.runtimeLookupArgs = pConstrainedResolvedToken;
                         break;


### PR DESCRIPTION
Crossgen does the same thing.

Also deleting `ReadyToRunHelperId.VirtualEntry` because the constant was used in one spot, and we didn't handle it anywhere else (leading to compilation failures because the rest of the code couldn't handle it).