### PR TITLE
Generate resource directory entry

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/ObjectWriter/R2RPEBuilder.cs
@@ -460,6 +460,7 @@ namespace ILCompiler.PEWriter
         {
             PEDirectoriesBuilder builder = new PEDirectoriesBuilder();
             builder.CorHeaderTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.CorHeaderTableDirectory);
+            builder.ResourceTable = RelocateDirectoryEntry(_peReader.PEHeaders.PEHeader.ResourceTableDirectory);
 
             _sectionBuilder.UpdateDirectories(builder);
 


### PR DESCRIPTION
R2RPEBuilder goes through lengths to restore .rsrc section, but drops the directory entry, making resources not actually work E2E.