### PR TITLE
Implement getILIntrinsicImplementation and friends

### DIFF
--- a/src/Common/src/TypeSystem/IL/CoreRTILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/CoreRTILProvider.cs
@@ -53,6 +53,12 @@ namespace Internal.IL
                             return UnsafeIntrinsics.EmitIL(method);
                     }
                     break;
+                case "Volatile":
+                    {
+                        if (owningType.Namespace == "System.Threading")
+                            return VolatileIntrinsics.EmitIL(method);
+                    }
+                    break;
                 case "Debug":
                     {
                         if (owningType.Namespace == "System.Diagnostics" && method.Name == "DebugBreak")

--- a/src/Common/src/TypeSystem/IL/CoreRTILProvider.cs
+++ b/src/Common/src/TypeSystem/IL/CoreRTILProvider.cs
@@ -47,6 +47,12 @@ namespace Internal.IL
 
             switch (owningType.Name)
             {
+                case "Interlocked":
+                    {
+                        if (owningType.Namespace == "System.Threading")
+                            return InterlockedIntrinsics.EmitIL(method);
+                    }
+                    break;
                 case "Unsafe":
                     {
                         if (owningType.Namespace == "Internal.Runtime.CompilerServices")
@@ -111,36 +117,8 @@ namespace Internal.IL
             {
                 case "RuntimeHelpers":
                     {
-                        if ((methodName == "IsReferenceOrContainsReferences" || methodName == "IsReference" || methodName == "IsBitwiseEquatable")
-                            && owningType.Namespace == "System.Runtime.CompilerServices")
-                        {
-                            TypeDesc elementType = method.Instantiation[0];
-
-                            // Fallback to non-intrinsic implementation for universal generics
-                            if (elementType.IsCanonicalSubtype(CanonicalFormKind.Universal))
-                                return null;
-
-                            bool result = false;
-                            if (methodName == "IsBitwiseEquatable")
-                            {
-                                // Fallback to non-intrinsic implementation for valuetypes
-                                if (!elementType.IsGCPointer)
-                                    return null;
-                            }
-                            else
-                            {
-                                result = elementType.IsGCPointer;
-                                if (methodName == "IsReferenceOrContainsReferences")
-                                {
-                                    result |= (elementType.IsDefType ? ((DefType)elementType).ContainsGCPointers : false);
-                                }
-                            }
-
-                            return new ILStubMethodIL(method, new byte[] {
-                                    result ? (byte)ILOpcode.ldc_i4_1 : (byte)ILOpcode.ldc_i4_0,
-                                    (byte)ILOpcode.ret }, 
-                                Array.Empty<LocalVariableDefinition>(), null);
-                        }
+                        if (owningType.Namespace == "System.Runtime.CompilerServices")
+                            return RuntimeHelpersIntrinsics.EmitIL(method);
                     }
                     break;
                 case "Comparer`1":

--- a/src/Common/src/TypeSystem/IL/Stubs/InterlockedIntrinsics.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/InterlockedIntrinsics.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Provides method bodies for System.Threading.Interlocked intrinsics.
+    /// </summary>
+    public static class InterlockedIntrinsics
+    {
+        public static MethodIL EmitIL(MethodDesc method)
+        {
+            Debug.Assert(((MetadataType)method.OwningType).Name == "Interlocked");
+
+            if (method.HasInstantiation && method.Name == "CompareExchange")
+            {
+                TypeDesc objectType = method.Context.GetWellKnownType(WellKnownType.Object);
+                MethodDesc compareExchangeObject = method.OwningType.GetKnownMethod("CompareExchange",
+                    new MethodSignature(
+                        MethodSignatureFlags.Static,
+                        genericParameterCount: 0,
+                        returnType: objectType,
+                        parameters: new TypeDesc[] { objectType.MakeByRefType(), objectType, objectType }));
+
+                ILEmitter emit = new ILEmitter();
+                ILCodeStream codeStream = emit.NewCodeStream();
+                codeStream.EmitLdArg(0);
+                codeStream.EmitLdArg(1);
+                codeStream.EmitLdArg(2);
+                codeStream.Emit(ILOpcode.call, emit.NewToken(compareExchangeObject));
+                codeStream.Emit(ILOpcode.ret);
+                return emit.Link(method);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Common/src/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Provides method bodies for System.Runtime.CompilerServices.RuntimeHelpers intrinsics.
+    /// </summary>
+    public static class RuntimeHelpersIntrinsics
+    {
+        public static MethodIL EmitIL(MethodDesc method)
+        {
+            Debug.Assert(((MetadataType)method.OwningType).Name == "RuntimeHelpers");
+            string methodName = method.Name;
+
+            if (methodName == "GetRawSzArrayData")
+            {
+                ILEmitter emit = new ILEmitter();
+                ILCodeStream codeStream = emit.NewCodeStream();
+                codeStream.EmitLdArg(0);
+                codeStream.Emit(ILOpcode.ldflda, emit.NewToken(method.Context.SystemModule.GetKnownType("System.Runtime.CompilerServices", "RawSzArrayData").GetField("Data")));
+                codeStream.Emit(ILOpcode.ret);
+                return emit.Link(method);
+            }
+
+            // All the methods handled below are per-instantiation generic methods
+            if (method.Instantiation.Length != 1 || method.IsTypicalMethodDefinition)
+                return null;
+
+            TypeDesc elementType = method.Instantiation[0];
+
+            // Fallback to non-intrinsic implementation for universal generics
+            if (elementType.IsCanonicalSubtype(CanonicalFormKind.Universal))
+                return null;
+
+            bool result;
+            if (methodName == "IsReferenceOrContainsReferences")
+            {
+                result = elementType.IsGCPointer || (elementType is DefType defType && defType.ContainsGCPointers);
+            }
+            else if (methodName == "IsReference")
+            {
+                result = elementType.IsGCPointer;
+            }
+            else if (methodName == "IsBitwiseEquatable")
+            {
+                // Ideally we could detect automatically whether a type is trivially equatable
+                // (i.e., its operator == could be implemented via memcmp). But for now we'll
+                // do the simple thing and hardcode the list of types we know fulfill this contract.
+                // n.b. This doesn't imply that the type's CompareTo method can be memcmp-implemented,
+                // as a method like CompareTo may need to take a type's signedness into account.
+                switch (elementType.UnderlyingType.Category)
+                {
+                    case TypeFlags.Boolean:
+                    case TypeFlags.Byte:
+                    case TypeFlags.SByte:
+                    case TypeFlags.Char:
+                    case TypeFlags.UInt16:
+                    case TypeFlags.Int16:
+                    case TypeFlags.UInt32:
+                    case TypeFlags.Int32:
+                    case TypeFlags.UInt64:
+                    case TypeFlags.Int64:
+                    case TypeFlags.IntPtr:
+                    case TypeFlags.UIntPtr:
+                        result = true;
+                        break;
+                    default:
+                        var mdType = elementType as MetadataType;
+                        if (mdType != null && mdType.Name == "Rune" && mdType.Namespace == "System.Text")
+                            result = true;
+                        else if (mdType != null && mdType.Name == "Char8" && mdType.Namespace == "System")
+                            result = true;
+                        else
+                            result = false;
+                        break;
+                }
+            }
+            else
+            {
+                return null;
+            }
+
+            ILOpcode opcode = result ? ILOpcode.ldc_i4_1 : ILOpcode.ldc_i4_0;
+
+            return new ILStubMethodIL(method, new byte[] { (byte)opcode, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), Array.Empty<object>());
+        }
+    }
+}
+

--- a/src/Common/src/TypeSystem/IL/Stubs/VolatileIntrinsics.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/VolatileIntrinsics.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.IL.Stubs
+{
+    /// <summary>
+    /// Provides method bodies for System.Threading.Volatile intrinsics.
+    /// </summary>
+    public static class VolatileIntrinsics
+    {
+        public static MethodIL EmitIL(MethodDesc method)
+        {
+            Debug.Assert(((MetadataType)method.OwningType).Name == "Volatile");
+
+            bool isRead = method.Name == "Read";
+            if (!isRead && method.Name != "Write")
+                return null;
+
+            // All interesting methods have a signature that starts with `ref location`
+            if (method.Signature.Length == 0 || !method.Signature[0].IsByRef)
+                return null;
+
+            ILOpcode opcode;
+            switch (((ByRefType)method.Signature[0]).ParameterType.Category)
+            {
+                case TypeFlags.SignatureMethodVariable:
+                    opcode = isRead ? ILOpcode.ldind_ref : ILOpcode.stind_ref;
+                    break;
+
+                case TypeFlags.Boolean:
+                case TypeFlags.SByte:
+                    opcode = isRead ? ILOpcode.ldind_i1 : ILOpcode.stind_i1;
+                    break;
+                case TypeFlags.Byte:
+                    opcode = isRead ? ILOpcode.ldind_u1 : ILOpcode.stind_i1;
+                    break;
+                case TypeFlags.Int16:
+                    opcode = isRead ? ILOpcode.ldind_i2 : ILOpcode.stind_i2;
+                    break;
+                case TypeFlags.UInt16:
+                    opcode = isRead ? ILOpcode.ldind_u2 : ILOpcode.stind_i2;
+                    break;
+                case TypeFlags.Int32:
+                    opcode = isRead ? ILOpcode.ldind_i4 : ILOpcode.stind_i4;
+                    break;
+                case TypeFlags.UInt32:
+                    opcode = isRead ? ILOpcode.ldind_u4 : ILOpcode.stind_i4;
+                    break;
+                case TypeFlags.IntPtr:
+                case TypeFlags.UIntPtr:
+                    opcode = isRead ? ILOpcode.ldind_i : ILOpcode.stind_i;
+                    break;
+                case TypeFlags.Single:
+                    opcode = isRead ? ILOpcode.ldind_r4 : ILOpcode.stind_r4;
+                    break;
+
+                //
+                // Ordinary volatile loads and stores only guarantee atomicity for pointer-sized (or smaller) data.
+                // So, on 32-bit platforms we must use Interlocked operations instead for the 64-bit types.
+                // The implementation in mscorlib already does this, so we will only substitute a new
+                // IL body if we're running on a 64-bit platform.
+                //
+                case TypeFlags.Int64 when method.Context.Target.PointerSize == 8:
+                case TypeFlags.UInt64 when method.Context.Target.PointerSize == 8:
+                    opcode = isRead ? ILOpcode.ldind_i8 : ILOpcode.stind_i8;
+                    break;
+                case TypeFlags.Double when method.Context.Target.PointerSize == 8:
+                    opcode = isRead ? ILOpcode.ldind_r8 : ILOpcode.stind_r8;
+                    break;
+                default:
+                    return null;
+            }
+
+            byte[] ilBytes;
+            if (isRead)
+            {
+                ilBytes = new byte[]
+                {
+                    (byte)ILOpcode.ldarg_0,
+                    (byte)ILOpcode.prefix1, unchecked((byte)ILOpcode.volatile_),
+                    (byte)opcode,
+                    (byte)ILOpcode.ret
+                };
+            }
+            else
+            {
+                ilBytes = new byte[]
+                {
+                    (byte)ILOpcode.ldarg_0,
+                    (byte)ILOpcode.ldarg_1,
+                    (byte)ILOpcode.prefix1, unchecked((byte)ILOpcode.volatile_),
+                    (byte)opcode,
+                    (byte)ILOpcode.ret
+                };
+            }
+
+            return new ILStubMethodIL(method, ilBytes, Array.Empty<LocalVariableDefinition>(), null);
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -410,6 +410,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\UnsafeIntrinsics.cs">
       <Link>IL\Stubs\UnsafeIntrinsics.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\VolatileIntrinsics.cs">
+      <Link>IL\Stubs\VolatileIntrinsics.cs</Link>
+    </Compile>
     <Compile Include="..\..\JitInterface\src\CorInfoTypes.VarInfo.cs">
       <Link>JitInterface\CorInfoTypes.VarInfo.cs</Link>
     </Compile>

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -73,6 +73,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\GetCanonTypeIntrinsic.cs">
       <Link>IL\Stubs\GetCanonTypeIntrinsic.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\InterlockedIntrinsics.cs" Link="IL\Stubs\InterlockedIntrinsics.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\MethodBaseGetCurrentMethodThunk.cs">
       <Link>IL\Stubs\MethodBaseGetCurrentMethodThunk.cs</Link>
     </Compile>
@@ -88,6 +89,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\MethodBaseGetCurrentMethodThunk.Sorting.cs">
       <Link>IL\Stubs\MethodBaseGetCurrentMethodThunk.Sorting.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\RuntimeHelpersIntrinsics.cs" Link="IL\Stubs\RuntimeHelpersIntrinsics.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\Stubs\TypeGetTypeMethodThunk.cs">
       <Link>IL\Stubs\TypeGetTypeMethodThunk.cs</Link>
     </Compile>

--- a/src/ILCompiler.ReadyToRun/src/IL/ReadyToRunILProvider.cs
+++ b/src/ILCompiler.ReadyToRun/src/IL/ReadyToRunILProvider.cs
@@ -9,12 +9,114 @@ using Internal.TypeSystem.Ecma;
 
 using Internal.IL.Stubs;
 
-using Debug = System.Diagnostics.Debug;
-
 namespace Internal.IL
 {
+    using Workarounds;
+
     public sealed class ReadyToRunILProvider : ILProvider
     {
+        private MethodIL TryGetIntrinsicMethodILForInterlocked(MethodDesc method)
+        {
+            if (method.HasInstantiation && method.Name == "CompareExchange")
+            {
+                TypeDesc objectType = method.Context.GetWellKnownType(WellKnownType.Object);
+                MethodDesc compareExchangeObject = method.OwningType.GetKnownMethod("CompareExchange",
+                    new MethodSignature(
+                        MethodSignatureFlags.Static,
+                        genericParameterCount: 0,
+                        returnType: objectType,
+                        parameters: new TypeDesc[] { objectType.MakeByRefType(), objectType, objectType }));
+
+                ILEmitter emit = new ILEmitter();
+                ILCodeStream codeStream = emit.NewCodeStream();
+                codeStream.EmitLdArg(0);
+                codeStream.EmitLdArg(1);
+                codeStream.EmitLdArg(2);
+                codeStream.Emit(ILOpcode.call, emit.NewToken(compareExchangeObject));
+                codeStream.Emit(ILOpcode.ret);
+                return emit.Link(method);
+            }
+
+            return null;
+        }
+
+        private MethodIL TryGetIntrinsicMethodILForActivator(MethodDesc method)
+        {
+            if (method.Instantiation.Length == 1
+                && method.Signature.Length == 0
+                && method.Name == "CreateInstance")
+            {
+                TypeDesc type = method.Instantiation[0];
+                if (type.IsValueType && type.GetDefaultConstructor() == null)
+                {
+                    // Replace the body with implementation that just returns "default"
+                    MethodDesc createDefaultInstance = method.OwningType.GetKnownMethod("CreateDefaultInstance", method.GetTypicalMethodDefinition().Signature);
+                    return GetMethodIL(createDefaultInstance.MakeInstantiatedMethod(type));
+                }
+            }
+
+            return null;
+        }
+
+        private MethodIL TryGetIntrinsicMethodILForRuntimeHelpers(MethodDesc method)
+        {
+            if (method.Name == "IsReferenceOrContainsReferences")
+            {
+                TypeDesc type = method.Instantiation[0];
+                if (type.IsGCPointer)
+                    return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.ldc_i4_1, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), Array.Empty<object>());
+                else
+                    return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.ldc_i4_0, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), Array.Empty<object>());
+            }
+
+            // Ideally we could detect automatically whether a type is trivially equatable
+            // (i.e., its operator == could be implemented via memcmp). But for now we'll
+            // do the simple thing and hardcode the list of types we know fulfill this contract.
+            // n.b. This doesn't imply that the type's CompareTo method can be memcmp-implemented,
+            // as a method like CompareTo may need to take a type's signedness into account.
+            if (method.Name == "IsBitwiseEquatable")
+            {
+                TypeDesc type = method.Instantiation[0];
+                switch (type.UnderlyingType.Category)
+                {
+                    case TypeFlags.Boolean:
+                    case TypeFlags.Byte:
+                    case TypeFlags.SByte:
+                    case TypeFlags.Char:
+                    case TypeFlags.UInt16:
+                    case TypeFlags.Int16:
+                    case TypeFlags.UInt32:
+                    case TypeFlags.Int32:
+                    case TypeFlags.UInt64:
+                    case TypeFlags.Int64:
+                    case TypeFlags.IntPtr:
+                    case TypeFlags.UIntPtr:
+                        return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.ldc_i4_1, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), Array.Empty<object>());
+                    default:
+                        var mdType = type as MetadataType;
+                        if (mdType != null && mdType.Name == "Rune" && mdType.Namespace == "System.Text")
+                            goto case TypeFlags.UInt32;
+
+                        if (mdType != null && mdType.Name == "Char8" && mdType.Namespace == "System")
+                            goto case TypeFlags.Byte;
+
+                        return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.ldc_i4_0, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), Array.Empty<object>());
+                }
+            }
+
+            if (method.Name == "GetRawSzArrayData")
+            {
+                ILEmitter emit = new ILEmitter();
+                ILCodeStream codeStream = emit.NewCodeStream();
+                codeStream.EmitLdArg(0);
+                codeStream.Emit(ILOpcode.ldflda, emit.NewToken(method.Context.SystemModule.GetKnownType("System.Runtime.CompilerServices", "RawSzArrayData").GetField("Data")));
+                codeStream.Emit(ILOpcode.ret);
+                return emit.Link(method);
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Provides method bodies for intrinsics recognized by the compiler.
         /// It can return null if it's not an intrinsic recognized by the compiler,
@@ -22,6 +124,20 @@ namespace Internal.IL
         /// </summary>
         private MethodIL TryGetIntrinsicMethodIL(MethodDesc method)
         {
+            var mdType = method.OwningType as MetadataType;
+            if (mdType == null)
+                return null;
+
+            if (mdType.Name == "RuntimeHelpers" && mdType.Namespace == "System.Runtime.CompilerServices")
+            {
+                return TryGetIntrinsicMethodILForRuntimeHelpers(method);
+            }
+
+            if (mdType.Name == "Unsafe" && mdType.Namespace == "Internal.Runtime.CompilerServices")
+            {
+                return UnsafeIntrinsics.EmitIL(method);
+            }
+
             return null;
         }
 
@@ -32,6 +148,25 @@ namespace Internal.IL
         /// </summary>
         private MethodIL TryGetPerInstantiationIntrinsicMethodIL(MethodDesc method)
         {
+            var mdType = method.OwningType as MetadataType;
+            if (mdType == null)
+                return null;
+
+            if (mdType.Name == "RuntimeHelpers" && mdType.Namespace == "System.Runtime.CompilerServices")
+            {
+                return TryGetIntrinsicMethodILForRuntimeHelpers(method);
+            }
+
+            if (mdType.Name == "Interlocked" && mdType.Namespace == "System.Threading")
+            {
+                return TryGetIntrinsicMethodILForInterlocked(method);
+            }
+
+            if (mdType.Name == "Activator" && mdType.Namespace == "System")
+            {
+                return TryGetIntrinsicMethodILForActivator(method);
+            }
+
             return null;
         }
 
@@ -39,7 +174,7 @@ namespace Internal.IL
         {
             if (method is EcmaMethod)
             {
-                if (method.IsIntrinsic)
+                if (method.IsIntrinsicWorkaround())
                 {
                     MethodIL result = TryGetIntrinsicMethodIL(method);
                     if (result != null)
@@ -55,7 +190,7 @@ namespace Internal.IL
             else if (method is MethodForInstantiatedType || method is InstantiatedMethod)
             {
                 // Intrinsics specialized per instantiation
-                if (method.IsIntrinsic)
+                if (method.IsIntrinsicWorkaround())
                 {
                     MethodIL methodIL = TryGetPerInstantiationIntrinsicMethodIL(method);
                     if (methodIL != null)
@@ -71,6 +206,19 @@ namespace Internal.IL
             {
                 return null;
             }
+        }
+    }
+}
+
+namespace Internal.IL.Workarounds
+{
+    static class IntrinsicExtensions
+    {
+        // We should ideally mark interesting methods a [Intrinsic] to avoid having to
+        // name match everything in CoreLib.
+        public static bool IsIntrinsicWorkaround(this MethodDesc method)
+        {
+            return method.OwningType is MetadataType mdType && mdType.Module == method.Context.SystemModule;
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/IL/ReadyToRunILProvider.cs
+++ b/src/ILCompiler.ReadyToRun/src/IL/ReadyToRunILProvider.cs
@@ -138,6 +138,11 @@ namespace Internal.IL
                 return UnsafeIntrinsics.EmitIL(method);
             }
 
+            if (mdType.Name == "Volatile" && mdType.Namespace == "System.Threading")
+            {
+                return VolatileIntrinsics.EmitIL(method);
+            }
+
             return null;
         }
 

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -23,6 +23,7 @@ using ILCompiler;
 using ILCompiler.DependencyAnalysis;
 
 #if READYTORUN
+using System.Reflection.Metadata.Ecma335;
 using ILCompiler.DependencyAnalysis.ReadyToRun;
 #endif
 
@@ -1052,6 +1053,67 @@ namespace Internal.JitInterface
                 owningType is EcmaType owningEcmaType)
             {
                 tokenContextToRecord = owningEcmaType.EcmaModule;
+
+                mdToken token = pResolvedToken.token;
+
+                // If the method body is synthetized by the compiler (the definition of the MethodIL is not
+                // an EcmaMethodIL), the tokens in the MethodIL are not actual tokens: they're just
+                // "per-MethodIL unique cookies". For ready to run, we need to be able to get to an actual
+                // token to refer to the result of token lookup in the R2R fixups.
+                //
+                // We replace the token with the token of the ECMA entity. This only works for **non-generic
+                // types/members within the current module**, but this happens to be good enough because
+                // we only do this replacement within CoreLib to replace method bodies in places
+                // that we cannot express in C# right now).
+                MethodIL methodILDef = methodIL.GetMethodILDefinition();
+                object resultDef = null;
+                bool isFauxMethodIL = !(methodILDef is EcmaMethodIL);
+                if (isFauxMethodIL)
+                {
+                    resultDef = methodILDef.GetObject((int)pResolvedToken.token);
+                }
+                    
+                if (result is MethodDesc method)
+                {
+                    if (isFauxMethodIL)
+                    {
+                        Debug.Assert(resultDef is EcmaMethod && ((EcmaMethod)resultDef).Module == tokenContextToRecord);
+                        token = (mdToken)MetadataTokens.GetToken(((EcmaMethod)resultDef).Handle);
+                    }
+
+                    _compilation.NodeFactory.Resolver.AddModuleTokenForMethod(method, new ModuleToken(tokenContextToRecord, token));
+                }
+                else if (result is FieldDesc field)
+                {
+                    if (isFauxMethodIL)
+                    {
+                        Debug.Assert(resultDef is EcmaField && ((EcmaField)resultDef).Module == tokenContextToRecord);
+                        token = (mdToken)MetadataTokens.GetToken(((EcmaField)resultDef).Handle);
+                    }
+
+                    _compilation.NodeFactory.Resolver.AddModuleTokenForField(field, new ModuleToken(tokenContextToRecord, token));
+                }
+                else
+                {
+                    if (isFauxMethodIL)
+                    {
+                        if (resultDef is EcmaType ecmaType)
+                        {
+                            Debug.Assert(ecmaType.Module == tokenContextToRecord);
+                            token = (mdToken)MetadataTokens.GetToken(((EcmaType)resultDef).Handle);
+                        }
+                        else
+                        {
+                            // To replace !!0, we need to find the token for a !!0 TypeSpec within the image.
+                            Debug.Assert(resultDef is SignatureMethodVariable);
+                            Debug.Assert(((SignatureMethodVariable)resultDef).Index == 0);
+                            token = FindGenericMethodArgTypeSpec(tokenContextToRecord);
+                        }
+                        
+                    }
+
+                    _compilation.NodeFactory.Resolver.AddModuleTokenForType((TypeDesc)result, new ModuleToken(tokenContextToRecord, token));
+                }
             }
 #endif
 
@@ -1060,13 +1122,6 @@ namespace Internal.JitInterface
                 MethodDesc method = result as MethodDesc;
                 pResolvedToken.hMethod = ObjectToHandle(method);
                 pResolvedToken.hClass = ObjectToHandle(method.OwningType);
-
-#if READYTORUN
-            if (tokenContextToRecord != null)
-            {
-                _compilation.NodeFactory.Resolver.AddModuleTokenForMethod(method, new ModuleToken(tokenContextToRecord, (mdToken)pResolvedToken.token));
-            }
-#endif
             }
             else
             if (result is FieldDesc)
@@ -1080,24 +1135,10 @@ namespace Internal.JitInterface
 
                 pResolvedToken.hField = ObjectToHandle(field);
                 pResolvedToken.hClass = ObjectToHandle(field.OwningType);
-
-#if READYTORUN
-                if (tokenContextToRecord != null)
-                {
-                    _compilation.NodeFactory.Resolver.AddModuleTokenForField(field, new ModuleToken(tokenContextToRecord, (mdToken)pResolvedToken.token));
-                }
-#endif
             }
             else
             {
                 TypeDesc type = (TypeDesc)result;
-#if READYTORUN
-                if (tokenContextToRecord != null)
-                {
-                    _compilation.NodeFactory.Resolver.AddModuleTokenForType(type, new ModuleToken(tokenContextToRecord, (mdToken)pResolvedToken.token));
-                }
-#endif
-
                 if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Newarr)
                 {
                     if (type.IsVoid)

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreRT.cs
@@ -226,23 +226,9 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsBitwiseEquatable<T>()
         {
-            return
-                typeof(T) == typeof(bool) ||
-                typeof(T) == typeof(byte) ||
-                typeof(T) == typeof(sbyte) ||
-#if FEATURE_UTF8STRING
-                typeof(T) == typeof(Char8) ||
-#endif
-                typeof(T) == typeof(char) ||
-                typeof(T) == typeof(short) ||
-                typeof(T) == typeof(ushort) ||
-                typeof(T) == typeof(int) ||
-                typeof(T) == typeof(uint) ||
-                typeof(T) == typeof(long) ||
-                typeof(T) == typeof(ulong) ||
-                typeof(T) == typeof(IntPtr) ||
-                typeof(T) == typeof(UIntPtr) ||
-                typeof(T) == typeof(Rune);
+            // Only reachable for universal shared code - the compiler replaces this otherwise.
+            // Returning false is conservative.
+            return false;
         }
 
         // Returns true iff the object has a component size;

--- a/src/System.Private.Jit/src/System.Private.Jit.csproj
+++ b/src/System.Private.Jit/src/System.Private.Jit.csproj
@@ -79,6 +79,8 @@
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\PInvokeTargetNativeMethod.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\StructMarshallingThunk.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\TypeGetTypeMethodThunk.cs" />
+    <Compile Include="$(TypeSystemBasePath)\IL\Stubs\InterlockedIntrinsics.cs" />
+    <Compile Include="$(TypeSystemBasePath)\IL\Stubs\RuntimeHelpersIntrinsics.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\UnsafeIntrinsics.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\VolatileIntrinsics.cs" />
     <Compile Include="$(TypeSystemBasePath)\Interop\IL\Marshaller.cs" />

--- a/src/System.Private.Jit/src/System.Private.Jit.csproj
+++ b/src/System.Private.Jit/src/System.Private.Jit.csproj
@@ -80,6 +80,7 @@
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\StructMarshallingThunk.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\TypeGetTypeMethodThunk.cs" />
     <Compile Include="$(TypeSystemBasePath)\IL\Stubs\UnsafeIntrinsics.cs" />
+    <Compile Include="$(TypeSystemBasePath)\IL\Stubs\VolatileIntrinsics.cs" />
     <Compile Include="$(TypeSystemBasePath)\Interop\IL\Marshaller.cs" />
     <Compile Include="$(TypeSystemBasePath)\Interop\IL\MarshalHelpers.cs" />
     <Compile Include="$(TypeSystemBasePath)\Interop\IL\MarshalUtils.cs" />


### PR DESCRIPTION
This ports a couple handcrafted IL intrinsics from CoreCLR (some of which are required for correctness and some only for perf). See code around getILIntrinsicImplementation in CoreCLR's JitInterface.

This is needed to be able to compile an actually working 3.0 R2R CoreLib.

I've used CoreRT's `ILProvider` instead of handcrafting buffers with IL bytes like crossgen does. It's more comfortable on the generation side and it also lets us share the provider for `Unsafe` intrinsics with what we already wrote for full AOT. But we need to fix up tokens in the generated IL in JitInterface...

The `FindGenericMethodArgTypeSpec` also exists in crossgen (under the same name).  It's part of the token rewriting business. It's kind of gross, but it works.