### PR TITLE
Two small improvements in SuperIlc

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CompilerRunner.cs
@@ -67,7 +67,7 @@ namespace ReadyToRun.SuperIlc
             {
                 processParameters.TimeoutMilliseconds = ProcessParameters.DefaultIlcTimeout;
             }
-            processParameters.LogPath = Path.ChangeExtension(outputFileName, ".ilc.log");
+            processParameters.LogPath = outputFileName + ".ilc.log";
             processParameters.InputFileName = assemblyFileName;
             processParameters.OutputFileName = outputFileName;
             processParameters.CompilationCostHeuristic = new FileInfo(assemblyFileName).Length;
@@ -118,7 +118,15 @@ namespace ReadyToRun.SuperIlc
             param.LogPath = compiledExecutable + (naked ? ".naked.r2r.log" : ".raw.r2r.log");
             param.InputFileName = compiledExecutable;
             param.OutputFileName = outputFileName;
-            param.CompilationCostHeuristic = new FileInfo(compiledExecutable).Length;
+            try
+            {
+                param.CompilationCostHeuristic = new FileInfo(compiledExecutable).Length;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("File not found: {0}: {1}", compiledExecutable, ex);
+                param.CompilationCostHeuristic = 0;
+            }
 
             return param;
         }
@@ -215,7 +223,7 @@ namespace ReadyToRun.SuperIlc
             Path.Combine(GetOutputPath(outputRoot), $"{Path.GetFileName(fileName)}");
 
         public string GetResponseFileName(string outputRoot, string assemblyFileName) =>
-            Path.Combine(GetOutputPath(outputRoot), Path.GetFileNameWithoutExtension(assemblyFileName) + ".rsp");
+            Path.Combine(GetOutputPath(outputRoot), Path.GetFileName(assemblyFileName) + ".rsp");
     }
 
     public abstract class CompilerRunnerProcessConstructor : ProcessConstructor


### PR DESCRIPTION
1) Add support for another CPAOT vs. Crossgen instrumentation dealing
with the check MethodRequiresMarshaling used for inlining PInvokes.

2) Include output file name extension in compiler log and response
file path - there are several Pri#1 tests that include an exe and
dll pair with the same name. These had previously clashing response
and log file names, causing weird race conditions in parallel build.

Thanks

Tomas