### PR TITLE
Bind to S.P.CoreLib by default

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionMethodBodyScanner.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionMethodBodyScanner.cs
@@ -241,10 +241,10 @@ namespace ILCompiler.DependencyAnalysis
             // Resolve type in the assembly
             type = referenceModule.GetType(typeNamespace.ToString(), typeName.ToString(), false);
             
-            // If it didn't resolve and wasn't assembly-qualified, we also try mscorlib
+            // If it didn't resolve and wasn't assembly-qualified, we also try core library
             if (type == null && assemblyName.Length == 0)
             {
-                referenceModule = context.ResolveAssembly(new AssemblyName("mscorlib"), false);
+                referenceModule = context.SystemModule;
                 type = referenceModule.GetType(typeNamespace.ToString(), typeName.ToString(), false);
             }
             

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
@@ -28,7 +28,7 @@ namespace Internal.Reflection.Core
     //
     public abstract class AssemblyBinder
     {
-        public const String DefaultAssemblyNameForGetType = "System.Private.CoreLib";
+        public const String DefaultAssemblyNameForGetType = "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
 
         public abstract bool Bind(RuntimeAssemblyName refName, bool cacheMissedLookups, out AssemblyBindResult result, out Exception exception);
 

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
@@ -28,7 +28,7 @@ namespace Internal.Reflection.Core
     //
     public abstract class AssemblyBinder
     {
-        public const String DefaultAssemblyNameForGetType = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+        public const String DefaultAssemblyNameForGetType = "System.Private.CoreLib";
 
         public abstract bool Bind(RuntimeAssemblyName refName, bool cacheMissedLookups, out AssemblyBindResult result, out Exception exception);
 


### PR DESCRIPTION
When I was doing size investigations for CPAOT/.NET 5 two weeks ago, the reflection method body scanner was crashing when IL Linker decided to trim mscorlib. I worked around by just copying mscorlib back and brushed it off as a Linker bug (that I forgot to file).

Now a similar issue was reported in #7679 which prompted me to look how CoreCLR does `Type.GetType` binding when type name is not assembly-qualified. Seems like we were trying to be more compatible with desktop CLR than CoreCLR.

Since CoreCLR doesn't care about types in mscorlib that don't live in S.P.CoreLib, neither needs CPAOT.