### PR TITLE
Validate types referenced from IL

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.Validation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.Validation.cs
@@ -1,0 +1,151 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler
+{
+    // Validates types to the extent that is required to make sure the compilation won't fail
+    // in unpredictable spots.
+    partial class CompilerTypeSystemContext
+    {
+        /// <summary>
+        /// Ensures that the type can be fully loaded. The method will throw one of the type system
+        /// exceptions if the type is not loadable.
+        /// </summary>
+        public void EnsureLoadableType(TypeDesc type)
+        {
+            _validTypes.GetOrCreateValue(type);
+        }
+
+        class ValidTypeHashTable : LockFreeReaderHashtable<TypeDesc, TypeDesc>
+        {
+            protected override bool CompareKeyToValue(TypeDesc key, TypeDesc value) => key == value;
+            protected override bool CompareValueToValue(TypeDesc value1, TypeDesc value2) => value1 == value2;
+            protected override TypeDesc CreateValueFromKey(TypeDesc key) => EnsureLoadableTypeUncached(key);
+            protected override int GetKeyHashCode(TypeDesc key) => key.GetHashCode();
+            protected override int GetValueHashCode(TypeDesc value) => value.GetHashCode();
+        }
+        private readonly ValidTypeHashTable _validTypes = new ValidTypeHashTable();
+
+        private static TypeDesc EnsureLoadableTypeUncached(TypeDesc type)
+        {
+            if (type.IsParameterizedType)
+            {
+                // Validate parameterized types
+                var parameterizedType = (ParameterizedType)type;
+
+                TypeDesc parameterType = parameterizedType.ParameterType;
+
+                // Make sure type of the parameter is loadable.
+                ((CompilerTypeSystemContext)type.Context).EnsureLoadableType(parameterType);
+
+                // Validate we're not constructing a type over a ByRef
+                if (parameterType.IsByRef)
+                {
+                    // CLR compat note: "ldtoken int32&&" will actually fail with a message about int32&; "ldtoken int32&[]"
+                    // will fail with a message about being unable to create an array of int32&. This is a middle ground.
+                    ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
+                }
+
+                // Validate the parameter is not an uninstantiated generic.
+                if (parameterType.IsGenericDefinition)
+                {
+                    ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
+                }
+
+                if (parameterizedType.IsArray)
+                {
+                    if (parameterType.IsFunctionPointer)
+                    {
+                        // Arrays of function pointers are not currently supported
+                        ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
+                    }
+
+                    LayoutInt elementSize = parameterType.GetElementSize();
+                    if (!elementSize.IsIndeterminate && elementSize.AsInt >= ushort.MaxValue)
+                    {
+                        // Element size over 64k can't be encoded in the GCDesc
+                        ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadValueClassTooLarge, parameterType);
+                    }
+
+                    if (((ArrayType)parameterizedType).Rank > 32)
+                    {
+                        ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadRankTooLarge, type);
+                    }
+
+                    if (parameterType.IsByRefLike)
+                    {
+                        // Arrays of byref-like types are not allowed
+                        ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
+                    }
+
+                    // It might seem reasonable to disallow array of void, but the CLR doesn't prevent that too hard.
+                    // E.g. "newarr void" will fail, but "newarr void[]" or "ldtoken void[]" will succeed.
+                }
+            }
+            else if (type.IsFunctionPointer)
+            {
+                ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
+            }
+            else
+            {
+                // Validate classes, structs, enums, interfaces, and delegates
+                Debug.Assert(type.IsDefType);
+
+                // Don't validate generic definitons
+                if (type.IsGenericDefinition)
+                {
+                    return type;
+                }
+
+                // System.__Canon or System.__UniversalCanon
+                if (type.IsCanonicalDefinitionType(CanonicalFormKind.Any))
+                {
+                    return type;
+                }
+
+                // We need to be able to load interfaces
+                foreach (var intf in type.RuntimeInterfaces)
+                {
+                    ((CompilerTypeSystemContext)type.Context).EnsureLoadableType(intf.NormalizeInstantiation());
+                }
+
+                var defType = (DefType)type;
+
+                // Ensure we can compute the type layout
+                defType.ComputeInstanceLayout(InstanceLayoutKind.TypeAndFields);
+                defType.ComputeStaticFieldLayout(StaticLayoutKind.StaticRegionSizesAndFields);
+
+                // Make sure instantiation length matches the expectation
+                if (defType.Instantiation.Length != defType.GetTypeDefinition().Instantiation.Length)
+                {
+                    ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
+                }
+
+                foreach (TypeDesc typeArg in defType.Instantiation)
+                {
+                    // ByRefs, pointers, function pointers, and System.Void are never valid instantiation arguments
+                    if (typeArg.IsByRef
+                        || typeArg.IsPointer
+                        || typeArg.IsFunctionPointer
+                        || typeArg.IsVoid
+                        || typeArg.IsByRefLike)
+                    {
+                        ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
+                    }
+
+                    // TODO: validate constraints
+                }
+
+                // Check the type doesn't have bogus MethodImpls or overrides and we can get the finalizer.
+                defType.GetFinalizer();
+            }
+
+            return type;
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
@@ -19,7 +19,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             _type = type;
 
-            EETypeNode.CheckCanGenerateEEType(factory, type);
+            factory.TypeSystemContext.EnsureLoadableType(type);
         }
 
         public TypeDesc Type => _type;

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Compiler\CompilerTypeSystemContext.Mangling.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.Sorting.cs" />
     <Compile Include="Compiler\CompilerGeneratedInteropStubManager.cs" />
+    <Compile Include="Compiler\CompilerTypeSystemContext.Validation.cs" />
     <Compile Include="Compiler\DebugInformationProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\DefaultConstructorMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\DelegateMarshallingDataNode.cs" />

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -226,7 +226,6 @@ namespace ILCompiler.DependencyAnalysis
             TypeFixupSignature signature;
             if (!perFixupKindMap.TryGetValue(typeDesc, out signature))
             {
-                EETypeNode.CheckCanGenerateEEType(this, typeDesc);
                 signature = new TypeFixupSignature(fixupKind, typeDesc, signatureContext);
                 perFixupKindMap.Add(typeDesc, signature);
             }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1055,7 +1055,13 @@ namespace Internal.JitInterface
             {
                 MethodDesc method = result as MethodDesc;
                 pResolvedToken.hMethod = ObjectToHandle(method);
-                pResolvedToken.hClass = ObjectToHandle(method.OwningType);
+
+                TypeDesc owningClass = method.OwningType;
+                pResolvedToken.hClass = ObjectToHandle(owningClass);
+
+#if !SUPPORT_JIT
+                _compilation.TypeSystemContext.EnsureLoadableType(owningClass);
+#endif
 
 #if READYTORUN
                 if (recordToken)
@@ -1075,7 +1081,13 @@ namespace Internal.JitInterface
                     ThrowHelper.ThrowMissingFieldException(field.OwningType, field.Name);
 
                 pResolvedToken.hField = ObjectToHandle(field);
-                pResolvedToken.hClass = ObjectToHandle(field.OwningType);
+
+                TypeDesc owningClass = field.OwningType;
+                pResolvedToken.hClass = ObjectToHandle(owningClass);
+
+#if !SUPPORT_JIT
+                _compilation.TypeSystemContext.EnsureLoadableType(owningClass);
+#endif
 
 #if READYTORUN
                 if (recordToken)
@@ -1103,6 +1115,10 @@ namespace Internal.JitInterface
                     type = type.MakeArrayType();
                 }
                 pResolvedToken.hClass = ObjectToHandle(type);
+
+#if !SUPPORT_JIT
+                _compilation.TypeSystemContext.EnsureLoadableType(type);
+#endif
             }
 
             pResolvedToken.pTypeSpec = null;


### PR DESCRIPTION
Fixes one of the CPAOT failure buckets for some of the negative generics tests (`Loader\classloader\generics\Instantiation\Negative\param02`).

We should not be able to generate code for a generic type that is instantiated with a wrong arity or CoreCLR will hit internal errors.