### PR TITLE
Tweaks to ContainsTypeLayout

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -132,13 +132,12 @@ namespace ILCompiler
         /// </summary>
         public override bool ContainsTypeLayout(TypeDesc type)
         {
-            bool containsTypeLayout;
-            if (_containsTypeLayoutCache.TryGetValue(type, out containsTypeLayout))
+            if (!_containsTypeLayoutCache.TryGetValue(type, out bool containsTypeLayout))
             {
-                return containsTypeLayout;
+                containsTypeLayout = ContainsTypeLayoutUncached(type);
+                _containsTypeLayoutCache[type] = containsTypeLayout;
             }
-            containsTypeLayout = ContainsTypeLayoutUncached(type);
-            _containsTypeLayoutCache[type] = containsTypeLayout;
+            
             return containsTypeLayout;
         }
 

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -130,7 +130,6 @@ namespace ILCompiler
         /// <summary>
         /// If true, the type is fully contained in the current compilation group.
         /// </summary>
-        /// <returns></returns>
         public override bool ContainsTypeLayout(TypeDesc type)
         {
             bool containsTypeLayout;
@@ -138,65 +137,51 @@ namespace ILCompiler
             {
                 return containsTypeLayout;
             }
-            HashSet<TypeDesc> recursionGuard = new HashSet<TypeDesc>();
-            return ContainsTypeLayout(type, recursionGuard);
+            containsTypeLayout = ContainsTypeLayoutUncached(type);
+            _containsTypeLayoutCache[type] = containsTypeLayout;
+            return containsTypeLayout;
         }
 
-        private bool ContainsTypeLayout(TypeDesc type, HashSet<TypeDesc> recursionGuard)
+        private bool ContainsTypeLayoutUncached(TypeDesc type)
         {
-            if (!recursionGuard.Add(type))
-            {
-                // We've recursively found the same type - no reason to scan it again
-                return true;
-            }
-
-            try
-            {
-                bool containsTypeLayout = ContainsTypeLayoutUncached(type, recursionGuard);
-                _containsTypeLayoutCache[type] = containsTypeLayout;
-                return containsTypeLayout;
-            }
-            finally
-            {
-                recursionGuard.Remove(type);
-            }
-        }
-
-        private bool ContainsTypeLayoutUncached(TypeDesc type, HashSet<TypeDesc> recursionGuard)
-        {
-            if (type.IsValueType || 
-                type.IsObject || 
+            if (type.IsObject || 
                 type.IsPrimitive || 
                 type.IsEnum || 
                 type.IsPointer ||
                 type.IsFunctionPointer ||
-                type.IsByRefLike ||
                 type.IsCanonicalDefinitionType(CanonicalFormKind.Any))
             {
                 return true;
             }
-            DefType defType = type.GetClosestDefType();
-            if (!ContainsType(defType.GetTypeDefinition()))
+            var defType = (MetadataType)type;
+            if (!ContainsType(defType))
             {
-                return false;
-            }
-            if (defType.BaseType != null && !ContainsTypeLayout(defType.BaseType, recursionGuard))
-            {
-                return false;
-            }
-            foreach (TypeDesc genericArg in defType.Instantiation)
-            {
-                if (!ContainsTypeLayout(genericArg, recursionGuard))
+                if (!defType.IsValueType)
+                {
+                    // Eventually, we may respect the non-versionable attribute for reference types too. For now, we are going
+                    // to play is safe and ignore it.
+                    return false;
+                }
+
+                // Valuetypes with non-versionable attribute are candidates for fixed layout. Reject the rest.
+                if (!defType.HasCustomAttribute("System.Runtime.Versioning", "NonVersionableAttribute"))
                 {
                     return false;
                 }
             }
+            if (!defType.IsValueType && !ContainsTypeLayout(defType.BaseType))
+            {
+                return false;
+            }
             foreach (FieldDesc field in defType.GetFields())
             {
-                if (!field.IsLiteral && 
-                    !field.IsStatic && 
-                    !field.HasRva && 
-                    !ContainsTypeLayout(field.FieldType, recursionGuard))
+                if (field.IsStatic)
+                    continue;
+
+                TypeDesc fieldType = field.FieldType;
+
+                if (fieldType.IsValueType && 
+                    !ContainsTypeLayout(fieldType))
                 {
                     return false;
                 }


### PR DESCRIPTION
Fixes a bucket of CPAOT failures related to layout mismatch between the compiler and the runtime. We were incorrectly considering reference typed fields when determining whether type layout crosses version bubble.

Reference types are a single pointer wide and their layout doesn't matter. Switching between type being a reference type and valuetype is an IL-breaking change and as such it's okay to break R2R too.

While I was at this, I saw a couple other bugs I fixed:
* Value types were considered always within the version bubble, no matter what module defines them.
* We were not looking at `NonVersionableAttribute` (needed to get e.g. `Nullable` fields right).
* Type instantiation was taken into account but it's unrelated to layout.
* Deleted the recursion protection. I assume this was only added because we were recursing into reference types.
* Nit: `IsLiteral` and `HasRva` was redundant with the `IsStatic` check, and so was the `IsByRefLike` with `IsValueType`