### PR TITLE
Add .vsconfig and script

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -5,6 +5,7 @@
     "Microsoft.VisualStudio.Workload.CoreEditor",
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.Component.MSBuild",
-    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    "Microsoft.VisualStudio.Component.Windows10SDK.17763"
   ]
 }

--- a/.vsconfig
+++ b/.vsconfig
@@ -3,6 +3,8 @@
   "components": [
     "Microsoft.VisualStudio.Component.CoreEditor",
     "Microsoft.VisualStudio.Workload.CoreEditor",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.Component.MSBuild",
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
   ]
 }

--- a/.vsconfig
+++ b/.vsconfig
@@ -6,6 +6,7 @@
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.Component.MSBuild",
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-    "Microsoft.VisualStudio.Component.Windows10SDK.17763"
+    "Microsoft.VisualStudio.Component.Windows10SDK.17763",
+    "Microsoft.Net.Component.4.6.TargetingPack"
   ]
 }

--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,8 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.CoreEditor",
+    "Microsoft.VisualStudio.Workload.CoreEditor",
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+  ]
+}

--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -3,6 +3,7 @@ The following pre-requisites need to be installed for building the repo:
 # Windows (Windows 7+)
 
 1. Install [Visual Studio 2017](https://visualstudio.microsoft.com/vs/community/) or [Visual Studio 2019 Preview](https://visualstudio.microsoft.com/vs/preview/), including Visual C++ support.
+ - For an existing Visual Studio 2019 Preview installation, `buildscripts/install-reqs-vs2019preview.cmd` is provided.
 2. Install [CMake](http://www.cmake.org/download/) 3.8.0 or later (3.14.0-rc1 or later is required for VS2019). Make sure you add it to the PATH in the setup wizard.
 3. (Windows 7 only) Install PowerShell 3.0. It's part of [Windows Management Framework 3.0](http://go.microsoft.com/fwlink/?LinkID=240290). Windows 8 or later comes with the right version inbox.
 

--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -3,7 +3,7 @@ The following pre-requisites need to be installed for building the repo:
 # Windows (Windows 7+)
 
 1. Install [Visual Studio 2017](https://visualstudio.microsoft.com/vs/community/) or [Visual Studio 2019 Preview](https://visualstudio.microsoft.com/vs/preview/), including Visual C++ support.
- - For an existing Visual Studio 2019 Preview installation, `buildscripts/install-reqs-vs2019preview.cmd` is provided.
+ - For an existing Visual Studio 2019 installation, `buildscripts/install-reqs-vs2019.cmd` is provided.
 2. Install [CMake](http://www.cmake.org/download/) 3.8.0 or later (3.14.0-rc1 or later is required for VS2019). Make sure you add it to the PATH in the setup wizard.
 3. (Windows 7 only) Install PowerShell 3.0. It's part of [Windows Management Framework 3.0](http://go.microsoft.com/fwlink/?LinkID=240290). Windows 8 or later comes with the right version inbox.
 

--- a/buildscripts/install-reqs-vs2019.cmd
+++ b/buildscripts/install-reqs-vs2019.cmd
@@ -5,9 +5,12 @@ set _VSINSTALLER="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_insta
 if not exist %_VSINSTALLER% (
 echo Visual Studio installer not found. && echo Expected at %_VSINSTALLER% && exit /b 1
 )
-set _VSPATH="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview"
+set _VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if exist %_VSWHERE% (
+ for /f "usebackq tokens=*" %%i in (`%_VSWHERE% -latest -prerelease -property installationPath -products *`) do set _VSPATH="%%i"
+)
 if not exist %_VSPATH% (
-echo Visual Studio 2019 Preview not found. && echo Expected at %_VSPATH% && exit /b 2
+echo Visual Studio installation not found. && exit /b 2
 )
 
 %_VSINSTALLER% modify %* --installPath %_VSPATH% --config "%~dp0..\.vsconfig"

--- a/buildscripts/install-reqs-vs2019preview.cmd
+++ b/buildscripts/install-reqs-vs2019preview.cmd
@@ -1,0 +1,13 @@
+@if not defined _echo @echo off
+setlocal
+
+set _VSINSTALLER="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe"
+if not exist %_VSINSTALLER% (
+echo Visual Studio installer not found. && echo Expected at %_VSINSTALLER% && exit /b 1
+)
+set _VSPATH="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview"
+if not exist %_VSPATH% (
+echo Visual Studio 2019 Preview not found. && echo Expected at %_VSPATH% && exit /b 2
+)
+
+%_VSINSTALLER% modify %* --installPath %_VSPATH% --config "%~dp0..\.vsconfig"

--- a/src/ILCompiler/reproNative/reproNative.vcxproj
+++ b/src/ILCompiler/reproNative/reproNative.vcxproj
@@ -13,19 +13,19 @@
     <ProjectGuid>{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>reproNative</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/ILCompiler/reproNative/reproNativeCpp.vcxproj
+++ b/src/ILCompiler/reproNative/reproNativeCpp.vcxproj
@@ -13,19 +13,19 @@
     <ProjectGuid>{ECB5D162-A31B-45FF-87C7-2E92BD445F5A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>reproNative</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
Added a .vsconfig file with dependencies for Visual Studio 2019 Preview (Windows 10 SDK, MSBuild with its dependencies, and `MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.22)` aka `Microsoft.VisualStudio.Component.VC.Tools.x86.x64`), minimum requirement for building with `buildscripts/build.cmd`.
Added a script at `buildscripts/install-reqs-vs2019preview.cmd` that depends on Visual Studio 2019 Preview and vs_installer.exe being installed at `%ProgramFiles(x86)%\Microsoft Visual Studio`.
Closes #7417 