### PR TITLE
Extend token remapping

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/IL/ReadyToRunILProvider.cs
+++ b/src/ILCompiler.ReadyToRun/src/IL/ReadyToRunILProvider.cs
@@ -59,6 +59,11 @@ namespace Internal.IL
                 return VolatileIntrinsics.EmitIL(method);
             }
 
+            if (mdType.Name == "Interlocked" && mdType.Namespace == "System.Threading")
+            {
+                return InterlockedIntrinsics.EmitIL(method);
+            }
+
             return null;
         }
 
@@ -76,11 +81,6 @@ namespace Internal.IL
             if (mdType.Name == "RuntimeHelpers" && mdType.Namespace == "System.Runtime.CompilerServices")
             {
                 return RuntimeHelpersIntrinsics.EmitIL(method);
-            }
-
-            if (mdType.Name == "Interlocked" && mdType.Namespace == "System.Threading")
-            {
-                return InterlockedIntrinsics.EmitIL(method);
             }
 
             if (mdType.Name == "Activator" && mdType.Namespace == "System")


### PR DESCRIPTION
I missed that `resolveToken` is not the only place where we record tokens in CPAOT. We also do it in other places.

I moved the logic that does token remapping for synthetic method bodies to `HandleModuleToken` to have it in a central location and made sure that I got all the places that touch `.token` this time.

`constructStringLiteral` might end up needing token remapping too at some point so for now I just put an assert in place so that we don't end up chasing wild tokens if/when that happens.

Unrelated, I also fixed the Interlocked intrinsics not to be per instantiation (they don't need anything special for their `T`). 