### PR TITLE
CPAOT support for inlined PInvokes

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/FixupConstants.cs
@@ -122,6 +122,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         READYTORUN_FIXUP_DelegateCtor = 0x2C, /* optimized delegate ctor */
         READYTORUN_FIXUP_DeclaringTypeHandle = 0x2D,
 
+        READYTORUN_FIXUP_IndirectPInvokeTarget = 0x2E, /* Target of an inlined pinvoke */
+
         READYTORUN_FIXUP_ModuleOverride = 0x80,
         // followed by sig-encoded UInt with assemblyref index into either the assemblyref
         // table of the MSIL metadata of the master context module for the signature or

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -604,7 +604,7 @@ namespace ILCompiler.DependencyAnalysis
             return node;
         }
 
-        Dictionary<int, RVAFieldNode> _rvaFieldSymbols = new Dictionary<int, RVAFieldNode>();
+        private Dictionary<int, RVAFieldNode> _rvaFieldSymbols = new Dictionary<int, RVAFieldNode>();
 
         public ISymbolNode GetRvaFieldNode(FieldDesc fieldDesc)
         {
@@ -649,6 +649,29 @@ namespace ILCompiler.DependencyAnalysis
                 _rvaFieldSymbols.Add(rva, rvaFieldNode);
             }
             return rvaFieldNode;
+        }
+
+        private Dictionary<MethodWithToken, ISymbolNode> _indirectPInvokeTargetNodes = new Dictionary<MethodWithToken, ISymbolNode>();
+
+        public ISymbolNode GetIndirectPInvokeTargetNode(MethodWithToken methodWithToken, SignatureContext signatureContext)
+        {
+            ISymbolNode result;
+
+            if (!_indirectPInvokeTargetNodes.TryGetValue(methodWithToken, out result))
+            {
+                result = new PrecodeHelperImport(
+                    _codegenNodeFactory,
+                    _codegenNodeFactory.MethodSignature(
+                        ReadyToRunFixupKind.READYTORUN_FIXUP_IndirectPInvokeTarget,
+                        methodWithToken,
+                        signatureContext: signatureContext,
+                        isUnboxingStub: false,
+                        isInstantiatingStub: false));
+
+                _indirectPInvokeTargetNodes.Add(methodWithToken, result);
+            }
+
+            return result;
         }
     }
 }

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1751,7 +1751,7 @@ namespace Internal.JitInterface
                     {
                         return true;
                     }
-                    if (isReturnType && !type.UnderlyingType.IsPrimitive)
+                    if (isReturnType && !type.IsPrimitive)
                     {
                         return true;
                     }

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1541,5 +1541,30 @@ namespace Internal.JitInterface
                 throw new NotImplementedException("getGSCookie");
             }
         }
+
+        private bool pInvokeMarshalingRequired(CORINFO_METHOD_STRUCT_* handle, CORINFO_SIG_INFO* callSiteSig)
+        {
+            // calli is covered by convertPInvokeCalliToCall
+            if (handle == null)
+            {
+#if DEBUG
+                MethodSignature methodSignature = (MethodSignature)HandleToObject((IntPtr)callSiteSig->pSig);
+
+                MethodDesc stub = _compilation.PInvokeILProvider.GetCalliStub(methodSignature);
+                Debug.Assert(!IsPInvokeStubRequired(stub));
+#endif
+
+                return false;
+            }
+
+            MethodDesc method = HandleToObject(handle);
+
+            if (method.IsRawPInvoke())
+                return false;
+
+            // We could have given back the PInvoke stub IL to the JIT and let it inline it, without
+            // checking whether there is any stub required. Save the JIT from doing the inlining by checking upfront.
+            return IsPInvokeStubRequired(method);
+        }
     }
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -872,11 +872,6 @@ namespace Internal.JitInterface
             return (CorInfoUnmanagedCallConv)unmanagedCallConv;
         }
 
-        private bool IsPInvokeStubRequired(MethodDesc method)
-        {
-            return ((Internal.IL.Stubs.PInvokeILStubMethodIL)_compilation.GetMethodIL(method))?.IsStubRequired ?? false;
-        }
-
         private bool satisfiesMethodConstraints(CORINFO_CLASS_STRUCT_* parent, CORINFO_METHOD_STRUCT_* method)
         { throw new NotImplementedException("satisfiesMethodConstraints"); }
         private bool isCompatibleDelegate(CORINFO_CLASS_STRUCT_* objCls, CORINFO_CLASS_STRUCT_* methodParentCls, CORINFO_METHOD_STRUCT_* method, CORINFO_CLASS_STRUCT_* delegateCls, ref bool pfIsOpenDelegate)
@@ -2690,34 +2685,6 @@ namespace Internal.JitInterface
             // Slow tailcalls are not supported yet
             // https://github.com/dotnet/corert/issues/1683
             return null;
-        }
-
-        private bool convertPInvokeCalliToCall(ref CORINFO_RESOLVED_TOKEN pResolvedToken, bool mustConvert)
-        {
-            var methodIL = (MethodIL)HandleToObject((IntPtr)pResolvedToken.tokenScope);
-            if (methodIL.OwningMethod.IsPInvoke)
-            {
-                return false;
-            }
-
-            MethodSignature signature = (MethodSignature)methodIL.GetObject((int)pResolvedToken.token);
-
-            CorInfoCallConv callConv = (CorInfoCallConv)(signature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask);
-            if (callConv != CorInfoCallConv.CORINFO_CALLCONV_C &&
-                callConv != CorInfoCallConv.CORINFO_CALLCONV_STDCALL &&
-                callConv != CorInfoCallConv.CORINFO_CALLCONV_THISCALL &&
-                callConv != CorInfoCallConv.CORINFO_CALLCONV_FASTCALL)
-            {
-                return false;
-            }
-
-            MethodDesc stub = _compilation.PInvokeILProvider.GetCalliStub(signature);
-            if (!mustConvert && !IsPInvokeStubRequired(stub))
-                return false;
-
-            pResolvedToken.hMethod = ObjectToHandle(stub);
-            pResolvedToken.hClass = ObjectToHandle(stub.OwningType);
-            return true;
         }
 
         private void* getMemoryManager()

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -877,31 +877,6 @@ namespace Internal.JitInterface
             return ((Internal.IL.Stubs.PInvokeILStubMethodIL)_compilation.GetMethodIL(method))?.IsStubRequired ?? false;
         }
 
-        private bool pInvokeMarshalingRequired(CORINFO_METHOD_STRUCT_* handle, CORINFO_SIG_INFO* callSiteSig)
-        {
-            // calli is covered by convertPInvokeCalliToCall
-            if (handle == null)
-            {
-#if DEBUG
-                MethodSignature methodSignature = (MethodSignature)HandleToObject((IntPtr)callSiteSig->pSig);
-
-                MethodDesc stub = _compilation.PInvokeILProvider.GetCalliStub(methodSignature);
-                Debug.Assert(!IsPInvokeStubRequired(stub));
-#endif
-
-                return false;
-            }
-
-            MethodDesc method = HandleToObject(handle);
-
-            if (method.IsRawPInvoke())
-                return false;
-
-            // We could have given back the PInvoke stub IL to the JIT and let it inline it, without
-            // checking whether there is any stub required. Save the JIT from doing the inlining by checking upfront.
-            return IsPInvokeStubRequired(method);
-        }
-
         private bool satisfiesMethodConstraints(CORINFO_CLASS_STRUCT_* parent, CORINFO_METHOD_STRUCT_* method)
         { throw new NotImplementedException("satisfiesMethodConstraints"); }
         private bool isCompatibleDelegate(CORINFO_CLASS_STRUCT_* objCls, CORINFO_CLASS_STRUCT_* methodParentCls, CORINFO_METHOD_STRUCT_* method, CORINFO_CLASS_STRUCT_* delegateCls, ref bool pfIsOpenDelegate)


### PR DESCRIPTION
This change adds previously missing implementation of two JIT
interface methods dealing with inlined PInvokes -
getAddressOfPinvokeTarget and pInvokeMarshalingRequired.

For the MethodRequiresMarshaling check I used the same technique
JanK recommended before for IsManagedSequential - I added an extra
instrumentation to Crossgen and CPAOT to capture PInvoke methods
and the result of the marshaling check; with this change there are
0 differences in the Pri#1 CoreCLR test suite.

Thanks

Tomas