### PR TITLE
Use DebugType to decide whether to generate debug info

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -194,7 +194,7 @@ See the LICENSE file in the project root for more information.
       <IlcArg Condition="$(NativeCodeGen) != ''" Include="--$(NativeCodeGen)" />
       <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
       <IlcArg Condition="$(Optimize) == 'true'" Include="-O" />
-      <IlcArg Condition="$(DebugSymbols) == 'true'" Include="-g" />
+      <IlcArg Condition="$(DebugSymbols) == 'true' or ($(DebugType) != 'none' and $(DebugType) != '')" Include="-g" />
       <IlcArg Condition="$(IlcGenerateMapFile) == 'true'" Include="--map:$(NativeIntermediateOutputPath)$(ManagedBinaryFilename).map.xml" />
       <IlcArg Include="@(RdXmlFile->'--rdxml:%(Identity)')" />
       <IlcArg Condition="$(OutputType) == 'Library' and $(NativeLib) != ''" Include="--nativelib" />

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -773,7 +773,17 @@ namespace Internal.JitInterface
                     IEnumerable<ILSequencePoint> ilSequencePoints = debugInfo.GetSequencePoints();
                     if (ilSequencePoints != null)
                     {
-                        SetSequencePoints(ilSequencePoints);
+                        try
+                        {
+                            SetSequencePoints(ilSequencePoints);
+                        }
+                        catch (BadImageFormatException)
+                        {
+                            // Roslyn had a bug where it was generating bad sequence points:
+                            // https://github.com/dotnet/roslyn/issues/20118
+                            // Do not crash the compiler.
+                            _compilation.Logger.Writer.WriteLine($"Warning: ignoring debug info for {methodCodeNodeNeedingCode.Method.ToString()}");
+                        }
                     }
                 }
 


### PR DESCRIPTION
Seems like both `DebugSymbols` and `DebugType` play a role. `DebugSymbols` is not defined in release builds for some SDKs.