### PR TITLE
Use BIT64 instead of WIN64

### DIFF
--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Assignability.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Assignability.cs
@@ -271,7 +271,7 @@ namespace System.Reflection.Runtime.General
 
             if (t.Equals(CommonRuntimeTypes.UIntPtr) || t.Equals(CommonRuntimeTypes.IntPtr))
             {
-#if WIN64
+#if BIT64
                 return CommonRuntimeTypes.Int64;
 #else
                 return CommonRuntimeTypes.Int32;

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -854,7 +854,7 @@ namespace Internal.Runtime.TypeLoader
 
             void** baseOffsetPtr = (void**)gcdesc - 1;
 
-#if WIN64
+#if BIT64
             int* ptr = (int*)baseOffsetPtr - 1;
 #else
             short* ptr = (short*)baseOffsetPtr - 1;


### PR DESCRIPTION
We don't define WIN64.

The EETypeCreator occurence was fun to debug. Kind of wish I hit it for the Assignability occurence instead...