### PR TITLE
Delete unnecessary using Internal.Runtime.Augments

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.GateThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.GateThread.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using Internal.Runtime.Augments;
 
 namespace System.Threading
 {

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.HillClimbing.Complex.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.HillClimbing.Complex.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 namespace System.Threading
 {
     internal partial class ClrThreadPool

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WaitThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WaitThread.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using Internal.Runtime.Augments;
 using System.Runtime.InteropServices;
 
 namespace System.Threading

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-using Internal.Runtime.Augments;
 
 namespace System.Threading
 {

--- a/src/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics;
 using System.Runtime;
 using System.Runtime.CompilerServices;
-using Internal.Runtime.Augments;
 
 namespace System.Threading
 {

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using Internal.Runtime.Augments;
 
 namespace System.Threading
 {

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelLock.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using Internal.Runtime.Augments;
 
 namespace System.Threading
 {

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Unix.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using Internal.Runtime.Augments;
 
 namespace System.Threading
 {

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.Windows.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using Internal.Runtime.Augments;
 
 namespace System.Threading
 {

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelMonitor.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using Internal.Runtime.Augments;
 
 namespace System.Threading
 {

--- a/src/System.Private.CoreLib/src/System/Threading/LowLevelSpinWaiter.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/LowLevelSpinWaiter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using Internal.Runtime.Augments;
 
 namespace System.Threading
 {

--- a/src/System.Private.CoreLib/src/System/Threading/ManagedThreadId.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ManagedThreadId.cs
@@ -9,7 +9,6 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using Internal.Runtime.Augments;
 using System.Diagnostics;
 
 namespace System.Threading

--- a/src/System.Private.CoreLib/src/System/Threading/SynchronizationContext.WinRT.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/SynchronizationContext.WinRT.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
-using Internal.Runtime.Augments;
 
 namespace System.Threading
 {

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPoolCallbackWrapper.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPoolCallbackWrapper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.Runtime.Augments;
-
 namespace System.Threading
 {
     /// <summary>

--- a/src/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.Runtime.Augments;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Threading

--- a/src/System.Private.CoreLib/src/System/Threading/WaitHandle.Windows.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/WaitHandle.Windows.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime;
 using System.Runtime.InteropServices;
-using Internal.Runtime.Augments;
 
 namespace System.Threading
 {


### PR DESCRIPTION
Helps with potential sharing with CoreCLR - Internal.Runtime.Augments namespace does not exist in CoreCLR.