### PR TITLE
Fix method token resolution for unboxing thunks

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DevirtualizationManager.cs
@@ -17,18 +17,18 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override bool IsEffectivelySealed(TypeDesc type)
         {
-            return _compilationModuleGroup.ContainsType(type) && base.IsEffectivelySealed(type);
+            return _compilationModuleGroup.VersionsWithType(type) && base.IsEffectivelySealed(type);
         }
 
         public override bool IsEffectivelySealed(MethodDesc method)
         {
-            return _compilationModuleGroup.ContainsMethodBody(method, unboxingStub: false) && base.IsEffectivelySealed(method);
+            return _compilationModuleGroup.VersionsWithMethodBody(method) && base.IsEffectivelySealed(method);
         }
 
         protected override MethodDesc ResolveVirtualMethod(MethodDesc declMethod, DefType implType)
         {
-            if (_compilationModuleGroup.ContainsMethodBody(declMethod, unboxingStub: false) &&
-                _compilationModuleGroup.ContainsType(implType))
+            if (_compilationModuleGroup.VersionsWithMethodBody(declMethod) &&
+                _compilationModuleGroup.VersionsWithType(implType))
             {
                 return base.ResolveVirtualMethod(declMethod, implType);
             }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -2413,6 +2413,12 @@ namespace Internal.JitInterface
         private mdToken getMethodDefFromMethod(CORINFO_METHOD_STRUCT_* hMethod)
         {
             MethodDesc method = HandleToObject(hMethod);
+#if READYTORUN
+            if (method is UnboxingMethodDesc unboxingMethodDesc)
+            {
+                method = unboxingMethodDesc.Target;
+            }
+#endif
             MethodDesc methodDefinition = method.GetTypicalMethodDefinition();
 
             // Need to cast down to EcmaMethod. Do not use this as a precedent that casting to Ecma*


### PR DESCRIPTION
This change fixes the largest compilation failure bucket caused by
JIT passing 0 as the "pResolvedToken.token" to the JIT interface.
The problem was caused by the fact that, when in release mode we
devirtualized a method on a value type, we emitted an unboxing thunk
as part of the process. When JIT later called
getMethodDefFromMethod to get the token for the method, we returned
0 because the method was not properly handling unboxing thunks.

While I was there, I also fixed an imprecision in
DevirtualizationManager I noticed while reviewing Michal's
preparatory change for porting CPAOT code to the CoreCLR repo: in
large version bubble mode, we should generally query "VersionsWith"
rather than "Contains", otherwise we lose perf benefits of
cross-module devirtualization within the large version bubble.

Thanks

Tomas