### PR TITLE
Fix RhpCallFilterFunclet stack alignment on ARM

### DIFF
--- a/src/Native/Runtime/arm/ExceptionHandling.S
+++ b/src/Native/Runtime/arm/ExceptionHandling.S
@@ -475,7 +475,7 @@ NESTED_END RhpCallFinallyFunclet, _TEXT
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 NESTED_ENTRY RhpCallFilterFunclet, _TEXT, NoHandler
 
-        PROLOG_PUSH "{r4-r11,lr}"
+        PROLOG_PUSH "{r2,r4-r11,lr}"
         PROLOG_VPUSH {d8-d15}
 
         ldr         r12, [r2, #OFFSETOF__REGDISPLAY__pR11]
@@ -496,6 +496,6 @@ NESTED_ENTRY RhpCallFilterFunclet, _TEXT, NoHandler
         // R0 contains the result of the filter execution
 
         EPILOG_VPOP {d8-d15}
-        EPILOG_POP  "{r4-r11,pc}"
+        EPILOG_POP  "{r2,r4-r11,pc}"
 
 NESTED_END RhpCallFilterFunclet, _TEXT

--- a/src/Native/Runtime/arm/ExceptionHandling.asm
+++ b/src/Native/Runtime/arm/ExceptionHandling.asm
@@ -534,7 +534,7 @@ SetSuccess
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     NESTED_ENTRY RhpCallFilterFunclet
 
-        PROLOG_PUSH     {r4-r11,lr}
+        PROLOG_PUSH     {r2,r4-r11,lr}
         PROLOG_VPUSH    {d8-d15}
 
         ldr         r12, [r2, #OFFSETOF__REGDISPLAY__pR7]
@@ -549,7 +549,7 @@ SetSuccess
         EXPORT_POINTER_TO_ADDRESS PointerToRhpCallFilterFunclet2
 
         EPILOG_VPOP {d8-d15}
-        EPILOG_POP {r4-r11,pc}
+        EPILOG_POP {r2,r4-r11,pc}
 
     NESTED_END RhpCallFilterFunclet
 


### PR DESCRIPTION
The number of registers pushed to the stack in the RhpCallFilterFunclet prolog on ARM made the stack misaligned (it needs to be aligned on 8 bytes), so the filter funclet and its transitive callees all had misaligned stack. While in many cases this doesn't cause issues, there are cases where it can cause runtime failures or crashes. For example, when the exception filter call chain invokes a varargs function with certain combination of parameter sizes when some of the arguments are supposed to be 8 byte aligned.

This change fixes the problem by pushing one more register as a padding in the RhpCallFilterFunclet (and popping it in the epilog).