### PR TITLE
Minor reliability improvements in SuperILC

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/BuildFolderSet.cs
@@ -829,7 +829,7 @@ namespace ReadyToRun.SuperIlc
                         {
                             cpaotSize = new FileInfo(cpaotCompilation.Parameters.OutputFileName).Length;
                         }
-                        catch (Exception ex)
+                        catch (Exception)
                         {
                             Console.Error.WriteLine("Cannot find CPAOT output file '{0}', ignoring in size stats", cpaotCompilation.Parameters.OutputFileName);
                             continue;
@@ -840,7 +840,7 @@ namespace ReadyToRun.SuperIlc
                         {
                             crossgenSize = new FileInfo(crossgenCompilation.Parameters.OutputFileName).Length;
                         }
-                        catch (Exception ex)
+                        catch (Exception)
                         {
                             Console.Error.WriteLine("Cannot find Crossgen output file '{0}', ignoring in size stats", crossgenCompilation.Parameters.OutputFileName);
                             continue;


### PR DESCRIPTION
In the Pri1 test file, some of the hung tests ignore KillProcess.
Some time ago I proposed leveraging Mark Russinovich's pskill tool
which is known to have better success rate in killing weirdly hung
processes thanks to leveraging intimage kernel knowledge by
explicitly closing various handles and such; Michal and JanK were
however not too enthusiastic about making test build depend on
such a technically 'external' tool. For now I have at least hotfixed
the code to drop the Process in question and move on.

On top of that, it turns out that my implementation of process
exit signaling using an AutoResetEvent was subject to a race
condition - as the MSDN page for AutoResetEvent explicitly states,
when two threads set such an event close to each other, the master
thread only gets signaled once. I fixed this by calling WaitOne
with an explicit timeout so that we don't hang the parallel runner
loop due to a lost signal.

I have also improved ParallelRunner to show the number of failures
as part of the progress message during each build step. The aim is
to improve turnaround when running large test suites - one of
SuperIlc downsides is that the various analytic and statistic
summaries only get produced at the very end of its execution. The
number of failures in the progress message can be used for early
monitoring as to whether everything proceeds as expected and we're
not wasting two hours waiting on a completely broken test run.

Thanks

Tomas