### PR TITLE
[CPAOT] SkipAggressiveMethod - Avoid compiling code marked with MethodImplOptions.AggressiveOptimization

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunLibraryRootProvider.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunLibraryRootProvider.cs
@@ -52,6 +52,9 @@ namespace ILCompiler
                 if (method.IsInternalCall)
                     continue;
 
+                if (method.IsAggressiveOptimization)
+                    continue;
+
                 try
                 {
                     CheckCanGenerateMethod(method);


### PR DESCRIPTION
Crossgen is currently skipping these methods [here](https://github.com/dotnet/coreclr/blob/f07c13cadc378649f10d024bb8a40a3878fa661f/src/zap/zapinfo.cpp#L448), perhaps we should do the same.
