### PR TITLE
Fix path separator on Linux

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/CrossgenRunner.cs
@@ -47,10 +47,9 @@ namespace ReadyToRun.SuperIlc
 
             yield return "/platform_assemblies_paths";
 
-            StringBuilder sb = new StringBuilder();
-            sb.Append(Path.GetDirectoryName(assemblyFileName) + (_referenceFolders.Any() ? ";" : ""));
-            sb.AppendJoin(';', _referenceFolders);
-            yield return sb.ToString();
+            IEnumerable<string> paths = new string[] { Path.GetDirectoryName(assemblyFileName) }.Concat(_referenceFolders);
+
+            yield return paths.ConcatenatePaths();
         }
     }
 }

--- a/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
@@ -31,6 +31,8 @@ static class PathExtensions
 
     internal static string OSExeSuffix(this string path) => (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? path + ".exe" : path);
 
+    internal static char OSPathSeparator => (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ';' : ':');
+
     internal static string ToAbsolutePath(this string argValue) => Path.GetFullPath(argValue);
 
     internal static string ToAbsoluteDirectoryPath(this string argValue) => argValue.ToAbsolutePath().StripTrailingDirectorySeparators();
@@ -48,6 +50,11 @@ static class PathExtensions
         }
 
         return str;
+    }
+
+    internal static string ConcatenatePaths(this IEnumerable<string> paths)
+    {
+        return string.Join(OSPathSeparator, paths);
     }
 
     // TODO: this assumes we're running tests from the CoreRT root

--- a/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/PathHelpers.cs
@@ -31,8 +31,6 @@ static class PathExtensions
 
     internal static string OSExeSuffix(this string path) => (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? path + ".exe" : path);
 
-    internal static char OSPathSeparator => (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ';' : ':');
-
     internal static string ToAbsolutePath(this string argValue) => Path.GetFullPath(argValue);
 
     internal static string ToAbsoluteDirectoryPath(this string argValue) => argValue.ToAbsolutePath().StripTrailingDirectorySeparators();
@@ -54,7 +52,7 @@ static class PathExtensions
 
     internal static string ConcatenatePaths(this IEnumerable<string> paths)
     {
-        return string.Join(OSPathSeparator, paths);
+        return string.Join(Path.PathSeparator, paths);
     }
 
     // TODO: this assumes we're running tests from the CoreRT root


### PR DESCRIPTION
As Jan Vorlicek found out in his local testing, SuperIlc always
used semicolon as path separator when emitting the list of reference
paths for Crossgen. This is incorrect on Linux - colon should be
use as the path separator instead.

Thanks

Tomas