### PR TITLE
Fix subtle bug in token context module resolution

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -577,6 +577,8 @@ namespace Internal.JitInterface
             // that we cannot express in C# right now).
             MethodIL methodILDef = methodIL.GetMethodILDefinition();
             bool isFauxMethodIL = !(methodILDef is EcmaMethodIL);
+            MethodDesc contextMethod;
+
             if (isFauxMethodIL)
             {
                 object resultDef = methodILDef.GetObject((int)pResolvedToken.token);
@@ -606,9 +608,15 @@ namespace Internal.JitInterface
                         token = FindGenericMethodArgTypeSpec((EcmaModule)((MetadataType)methodILDef.OwningMethod.OwningType).Module);
                     }
                 }
+
+                contextMethod = methodIL.OwningMethod;
+            }
+            else
+            {
+                contextMethod = (MethodDesc)HandleToObject((IntPtr)pResolvedToken.tokenContext);
             }
 
-            return new ModuleToken(((EcmaMethod)methodIL.OwningMethod.GetTypicalMethodDefinition()).Module, token);
+            return new ModuleToken(((EcmaMethod)contextMethod.GetTypicalMethodDefinition()).Module, token);
         }
 
         private InfoAccessType constructStringLiteral(CORINFO_MODULE_STRUCT_* module, mdToken metaTok, ref void* ppValue)

--- a/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/ILCompiler.ReadyToRun/src/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -614,6 +614,10 @@ namespace Internal.JitInterface
             else
             {
                 contextMethod = (MethodDesc)HandleToObject((IntPtr)pResolvedToken.tokenContext);
+                if (contextMethod is UnboxingMethodDesc unboxingMethodDesc)
+                {
+                    contextMethod = unboxingMethodDesc.Target;
+                }
             }
 
             return new ModuleToken(((EcmaMethod)contextMethod.GetTypicalMethodDefinition()).Module, token);


### PR DESCRIPTION
I found out that my recent relaxation of DevirtualizationManager
to allow devirtualization across modules within the large version
bubble uncovered a pre-existing bug in token module context
resolution causing about 10% execution failure rate in Pri#1 tests
in release large-bubble mode.

My original implementation (that Michal later expanded to also
cover generated IL thunks) used "pResolvedToken.tokenScope" to
determine the token context. This is however incorrect in the
presence of devirtualization - in such case, JIT only updates
the tokenContext in pResolvedToken to refer to the devirtualized
method, not tokenScope (which continues pointing at the original
method in which we devirtualized a method call). Due to this the
reference module and token value went out of sync, causing a
wrong function to be called.

Thanks

Tomas