### PR TITLE
Preparatory change to fix JIT tokenScope during devirtualization

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -65,6 +65,11 @@ namespace ILCompiler
 
         public virtual MethodIL GetMethodIL(MethodDesc method)
         {
+            if (method is UnboxingMethodDesc unboxingMethodDesc)
+            {
+                method = unboxingMethodDesc.Target;
+            }
+ 
             // Flush the cache when it grows too big
             if (_methodILCache.Count > 1000)
                 _methodILCache = new ILCache(_methodILCache.ILProvider);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/ReadyToRunCodegenCompilation.cs
@@ -65,11 +65,6 @@ namespace ILCompiler
 
         public virtual MethodIL GetMethodIL(MethodDesc method)
         {
-            if (method is UnboxingMethodDesc unboxingMethodDesc)
-            {
-                method = unboxingMethodDesc.Target;
-            }
- 
             // Flush the cache when it grows too big
             if (_methodILCache.Count > 1000)
                 _methodILCache = new ILCache(_methodILCache.ILProvider);

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -773,6 +773,11 @@ namespace Internal.JitInterface
         private CORINFO_MODULE_STRUCT_* getMethodModule(CORINFO_METHOD_STRUCT_* method)
         {
             MethodDesc m = HandleToObject(method);
+            if (m is UnboxingMethodDesc unboxingMethodDesc)
+            {
+                m = unboxingMethodDesc.Target;
+            }
+
             MethodIL methodIL = _compilation.GetMethodIL(m);
             if (methodIL == null)
             {

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -771,7 +771,15 @@ namespace Internal.JitInterface
         }
 
         private CORINFO_MODULE_STRUCT_* getMethodModule(CORINFO_METHOD_STRUCT_* method)
-        { throw new NotImplementedException("getMethodModule"); }
+        {
+            MethodDesc m = HandleToObject(method);
+            MethodIL methodIL = _compilation.GetMethodIL(m);
+            if (methodIL == null)
+            {
+                return null;
+            }
+            return (CORINFO_MODULE_STRUCT_*)ObjectToHandle(methodIL);
+        }
 
         private CORINFO_METHOD_STRUCT_* resolveVirtualMethod(CORINFO_METHOD_STRUCT_* baseMethod, CORINFO_CLASS_STRUCT_* derivedClass, CORINFO_CONTEXT_STRUCT* ownerType)
         {


### PR DESCRIPTION
Based on Andy's advice I investigated fixing tokenScope in JIT
to work correctly even in the presence of devirtualization by
basically calling getMethodModule for the resolved virtual method
to update the token scope. To make that work end to end, I had
to actually implement the [previously unused] helper in CoreRT.

Thanks

Tomas

P.S. Based on Michal's offline advice I have locally verified that
the Generics CoreRT test works in release mode with the updated
JIT.
