### PR TITLE
Consider method referenced with LDTOKEN called

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
@@ -320,6 +320,18 @@ namespace ILCompiler
                 dependencies = dependencies ?? new DependencyList();
                 dependencies.Add(factory.MethodMetadata(method.GetTypicalMethodDefinition()), "LDTOKEN method");
             }
+
+            // Since this is typically used for LINQ expressions, let's also make sure there's runnable code
+            // for this available, unless this is ldtoken of something we can't generate code for
+            // (ldtoken of an uninstantiated generic method - F# makes this).
+            if (!method.IsGenericMethodDefinition)
+            {
+                var deps = dependencies ?? new DependencyList();
+                RootingHelpers.TryRootMethod(
+                    new RootingServiceProvider(
+                        factory, (o, reason) => deps.Add((DependencyNodeCore<NodeFactory>)o, reason)), method, "LDTOKEN method");
+                dependencies = deps;
+            }
         }
 
         protected override void GetDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)


### PR DESCRIPTION
When usage based metadata manager is enabled, we'll consider methods referenced with LDTOKEN as called. They pretty much have to be to make LINQ expressions work.