### PR TITLE
Remove MetadataManager.SupportsReflection

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -62,25 +62,9 @@ namespace ILCompiler.DependencyAnalysis
         {
             factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencies, factory, method);
 
-            if (method.HasInstantiation)
-            {
-                ExactMethodInstantiationsNode.GetExactMethodInstantiationDependenciesForMethod(ref dependencies, factory, method);
-                GenericMethodsTemplateMap.GetTemplateMethodDependencies(ref dependencies, factory, method);
-            }
-            else
-            {
-                TypeDesc owningTemplateType = method.OwningType;
-
-                // Unboxing and Instantiating stubs use a different type as their template
-                if (factory.TypeSystemContext.IsSpecialUnboxingThunk(method))
-                    owningTemplateType = factory.TypeSystemContext.GetTargetOfSpecialUnboxingThunk(method).OwningType;
-
-                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, owningTemplateType);
-            }
-
             factory.InteropStubManager.AddDependeciesDueToPInvoke(ref dependencies, factory, method);
 
-            if (method.IsIntrinsic && factory.MetadataManager.SupportsReflection)
+            if (method.IsIntrinsic)
             {
                 if (method.OwningType is MetadataType owningType)
                 {

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -102,19 +102,6 @@ namespace ILCompiler.DependencyAnalysis
 
             dependencyList.Add(factory.VTable(closestDefType), "VTable");
 
-            if (closestDefType.HasInstantiation && factory.MetadataManager.SupportsReflection)
-            {
-                TypeDesc canonType = _type.ConvertToCanonForm(CanonicalFormKind.Specific);
-                TypeDesc canonClosestDefType = closestDefType.ConvertToCanonForm(CanonicalFormKind.Specific);
-
-                // Add a dependency on the template for this type, if the canonical type should be generated into this binary.
-                // If the type is an array type, the check should be on its underlying Array<T> type. This is because a copy of
-                // an array type gets placed into each module but the Array<T> type only exists in the defining module and only 
-                // one template is needed for the Array<T> type by the dynamic type loader.
-                if (canonType.IsCanonicalSubtype(CanonicalFormKind.Any) && !factory.NecessaryTypeSymbol(canonClosestDefType).RepresentsIndirectionCell)
-                    dependencyList.Add(factory.NativeLayout.TemplateTypeLayout(canonType), "Template Type Layout");
-            }
-
             if (factory.TypeSystemContext.SupportsUniversalCanon)
             {
                 foreach (var instantiationType in _type.Instantiation)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DictionaryLayoutNode.cs
@@ -145,19 +145,6 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
-            if (factory.MetadataManager.SupportsReflection)
-            {
-                // Root the template for the type. In the future, we may want to control this via type reflectability instead.
-                if (_owningMethodOrType is MethodDesc)
-                {
-                    yield return new DependencyListEntry(factory.NativeLayout.TemplateMethodLayout((MethodDesc)_owningMethodOrType), "Type loader template");
-                }
-                else
-                {
-                    yield return new DependencyListEntry(factory.NativeLayout.TemplateTypeLayout((TypeDesc)_owningMethodOrType), "Type loader template");
-                }
-            }
-
             if (HasFixedSlots)
             {
                 foreach (GenericLookupResult lookupResult in FixedEntries)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -378,6 +378,7 @@ namespace ILCompiler.DependencyAnalysis
             // emitting it.
             dependencies.Add(new DependencyListEntry(_optionalFieldsNode, "Optional fields"));
 
+            // TODO-SIZE: We probably don't need to add these for all EETypes
             StaticsInfoHashtableNode.AddStaticsInfoDependencies(ref dependencies, factory, _type);
 
             if (EmitVirtualSlotsAndInterfaces)
@@ -1064,9 +1065,9 @@ namespace ILCompiler.DependencyAnalysis
             // if a type may be reflectable, and it is generic, if a canonical instantiation of reflection
             // can exist which can refer to the associated type of this static base, ensure that type
             // has an EEType. (Which will allow the static field lookup logic to find the right type)
-            if (type.HasInstantiation && factory.MetadataManager.SupportsReflection && !factory.MetadataManager.IsReflectionBlocked(type))
+            if (type.HasInstantiation && !factory.MetadataManager.IsReflectionBlocked(type))
             {
-                // This current implementation is slightly generous, as it does not attempt to restrict
+                // TODO-SIZE: This current implementation is slightly generous, as it does not attempt to restrict
                 // the created types to the maximum extent by investigating reflection data and such. Here we just
                 // check if we support use of a canonically equivalent type to perform reflection.
                 // We don't check to see if reflection is enabled on the type.

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExactMethodInstantiationsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExactMethodInstantiationsNode.cs
@@ -110,9 +110,6 @@ namespace ILCompiler.DependencyAnalysis
             if (!IsMethodEligibleForTracking(method))
                 return;
 
-            if (!factory.MetadataManager.SupportsReflection)
-                return;
-
             dependencies = dependencies ?? new DependencyList();
 
             // Method entry point dependency

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -84,6 +84,8 @@ namespace ILCompiler.DependencyAnalysis
                         }
 
                         dependencies.Add(context.MethodGenericDictionary(instantiatedMethod), "GVM Dependency - Dictionary");
+                        dependencies.Add(context.NativeLayout.TemplateMethodEntry(canonMethodTarget), "GVM Dependency - Template entry");
+                        dependencies.Add(context.NativeLayout.TemplateMethodLayout(canonMethodTarget), "GVM Dependency - Template");
                     }
                 }
             }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -208,6 +208,7 @@ namespace ILCompiler.DependencyAnalysis
             if (factory.CompilationModuleGroup.ContainsMethodBody(canonicalTarget, false))
                 dependencies.Add(GetDictionaryLayout(factory), "Layout");
 
+            // TODO-SIZE: We probably don't need to add these for all dictionaries
             GenericMethodsHashtableNode.GetGenericMethodsHashtableDependenciesForMethod(ref dependencies, factory, _owningMethod);
 
             factory.InteropStubManager.AddMarshalAPIsGenericDependencies(ref dependencies, factory, _owningMethod);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsHashtableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsHashtableNode.cs
@@ -100,9 +100,6 @@ namespace ILCompiler.DependencyAnalysis
 
         public static void GetGenericMethodsHashtableDependenciesForMethod(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
-            if (!factory.MetadataManager.SupportsReflection)
-                return;
-
             Debug.Assert(method.HasInstantiation && !method.IsCanonicalMethod(CanonicalFormKind.Any));
             
             // Method's containing type

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsTemplateMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericMethodsTemplateMap.cs
@@ -57,8 +57,13 @@ namespace ILCompiler.DependencyAnalysis
                 if (!IsEligibleToBeATemplate(method))
                     continue;
 
+                var methodEntryNode = factory.NativeLayout.TemplateMethodEntry(method);
+
+                if (!methodEntryNode.Marked)
+                    continue;
+
                 // Method entry
-                Vertex methodEntry = factory.NativeLayout.TemplateMethodEntry(method).SavedVertex;
+                Vertex methodEntry = methodEntryNode.SavedVertex;
 
                 // Method's native layout info
                 Vertex nativeLayout = factory.NativeLayout.TemplateMethodLayout(method).SavedVertex;
@@ -83,9 +88,6 @@ namespace ILCompiler.DependencyAnalysis
         public static void GetTemplateMethodDependencies(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
             if (!IsEligibleToBeATemplate(method))
-                return;
-
-            if (!factory.MetadataManager.SupportsReflection)
                 return;
 
             dependencies = dependencies ?? new DependencyList();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericTypesTemplateMap.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericTypesTemplateMap.cs
@@ -84,9 +84,6 @@ namespace ILCompiler.DependencyAnalysis
         
         public static void GetTemplateTypeDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
         {
-            if (!factory.MetadataManager.SupportsReflection)
-                return;
-
             TypeDesc templateType = ConvertArrayOfTToRegularArray(factory, type);
 
             if (!IsEligibleToHaveATemplate(templateType))

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericVirtualMethodTableNode.cs
@@ -51,9 +51,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             Debug.Assert(!callingMethod.OwningType.IsInterface);
 
-            if (!factory.MetadataManager.SupportsReflection)
-                return;
-
             // Compute the open method signatures
             MethodDesc openCallingMethod = callingMethod.GetTypicalMethodDefinition();
             MethodDesc openImplementationMethod = implementationMethod.GetTypicalMethodDefinition();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceGenericVirtualMethodTableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/InterfaceGenericVirtualMethodTableNode.cs
@@ -52,9 +52,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             Debug.Assert(callingMethod.OwningType.IsInterface);
 
-            if (!factory.MetadataManager.SupportsReflection)
-                return;
-
             // Compute the open method signatures
             MethodDesc openCallingMethod = callingMethod.GetTypicalMethodDefinition();
             MethodDesc openImplementationMethod = implementationMethod.GetTypicalMethodDefinition();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -186,9 +186,6 @@ namespace ILCompiler.DependencyAnalysis
         public override bool HasConditionalStaticDependencies => true;
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
-            if (!factory.MetadataManager.SupportsReflection)
-                return Array.Empty<CombinedDependencyListEntry>();
-
             List<CombinedDependencyListEntry> conditionalDependencies = new List<CombinedDependencyListEntry>();
             NativeLayoutSavedVertexNode templateLayout;
             if (_dictionaryOwner is MethodDesc)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
@@ -88,9 +88,6 @@ namespace ILCompiler.DependencyAnalysis
 
         public static void GetVirtualInvokeMapDependencies(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
-            if (!factory.MetadataManager.SupportsReflection)
-                return;
-
             if (NeedsVirtualInvokeInfo(method))
             {
                 dependencies = dependencies ?? new DependencyList();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeFieldHandleNode.cs
@@ -59,15 +59,8 @@ namespace ILCompiler.DependencyAnalysis
             objData.RequireInitialPointerAlignment();
             objData.AddSymbol(this);
 
-            if (factory.MetadataManager.SupportsReflection)
-            {
-                NativeLayoutFieldLdTokenVertexNode ldtokenSigNode = factory.NativeLayout.FieldLdTokenVertex(_targetField);
-                objData.EmitPointerReloc(factory.NativeLayout.NativeLayoutSignature(ldtokenSigNode, s_NativeLayoutSignaturePrefix, _targetField));
-            }
-            else
-            {
-                objData.EmitZeroPointer();
-            }
+            NativeLayoutFieldLdTokenVertexNode ldtokenSigNode = factory.NativeLayout.FieldLdTokenVertex(_targetField);
+            objData.EmitPointerReloc(factory.NativeLayout.NativeLayoutSignature(ldtokenSigNode, s_NativeLayoutSignaturePrefix, _targetField));
 
             return objData.ToObjectData();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs
@@ -74,15 +74,8 @@ namespace ILCompiler.DependencyAnalysis
             objData.RequireInitialPointerAlignment();
             objData.AddSymbol(this);
 
-            if (factory.MetadataManager.SupportsReflection)
-            {
-                NativeLayoutMethodLdTokenVertexNode ldtokenSigNode = factory.NativeLayout.MethodLdTokenVertex(_targetMethod);
-                objData.EmitPointerReloc(factory.NativeLayout.NativeLayoutSignature(ldtokenSigNode, s_NativeLayoutSignaturePrefix, _targetMethod));
-            }
-            else
-            {
-                objData.EmitZeroPointer();
-            }
+            NativeLayoutMethodLdTokenVertexNode ldtokenSigNode = factory.NativeLayout.MethodLdTokenVertex(_targetMethod);
+            objData.EmitPointerReloc(factory.NativeLayout.NativeLayoutSignature(ldtokenSigNode, s_NativeLayoutSignaturePrefix, _targetMethod));
 
             return objData.ToObjectData();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StaticsInfoHashtableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/StaticsInfoHashtableNode.cs
@@ -48,9 +48,6 @@ namespace ILCompiler.DependencyAnalysis
         /// </summary>
         public static void AddStaticsInfoDependencies(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
         {
-            if (!factory.MetadataManager.SupportsReflection)
-                return;
-
             if (type is MetadataType && type.HasInstantiation && !type.IsCanonicalSubtype(CanonicalFormKind.Any))
             {
                 MetadataType metadataType = (MetadataType)type;

--- a/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/EmptyMetadataManager.cs
@@ -21,8 +21,6 @@ namespace ILCompiler
     {
         private readonly StackTraceEmissionPolicy _stackTraceEmissionPolicy;
 
-        public override bool SupportsReflection => false;
-
         public EmptyMetadataManager(CompilerTypeSystemContext typeSystemContext)
             : this(typeSystemContext, new NoStackTraceEmissionPolicy())
         {
@@ -32,15 +30,6 @@ namespace ILCompiler
             : base(typeSystemContext, new FullyBlockedMetadataPolicy(), new FullyBlockedManifestResourcePolicy(), new NoDynamicInvokeThunkGenerationPolicy())
         {
             _stackTraceEmissionPolicy = stackTraceEmissionPolicy;
-        }
-
-        public override void AddToReadyToRunHeader(ReadyToRunHeaderNode header, NodeFactory nodeFactory, ExternalReferencesTableNode commonFixupsTableNode)
-        {
-            var metadataNode = new MetadataNode();
-            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.EmbeddedMetadata), metadataNode, metadataNode, metadataNode.EndSymbol);
-
-            var stackTraceMethodMappingNode = new StackTraceMethodMappingNode();
-            header.Add(BlobIdToReadyToRunSection(ReflectionMapBlob.BlobIdStackTraceMethodRvaToTokenMapping), stackTraceMethodMappingNode, stackTraceMethodMappingNode, stackTraceMethodMappingNode.EndSymbol);
         }
 
         public override IEnumerable<ModuleDesc> GetCompilationModulesWithMetadata()

--- a/src/ILCompiler.Compiler/src/Compiler/GeneratingMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/GeneratingMetadataManager.cs
@@ -14,6 +14,8 @@ using Internal.Metadata.NativeFormat.Writer;
 using ILCompiler.Metadata;
 using ILCompiler.DependencyAnalysis;
 
+using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+
 namespace ILCompiler
 {
     /// <summary>
@@ -202,6 +204,62 @@ namespace ILCompiler
             MethodDesc thunk = _typeSystemContext.GetDynamicInvokeThunk(lookupSig);
 
             return InstantiateCanonicalDynamicInvokeMethodForMethod(thunk, method);
+        }
+
+        protected sealed override void GetDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            GetDependenciesDueToTemplateTypeLoader(ref dependencies, factory, method);
+            GetDependenciesDueToMethodCodePresenceInternal(ref dependencies, factory, method);
+        }
+
+        protected virtual void GetDependenciesDueToMethodCodePresenceInternal(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+        }
+
+        protected virtual void GetDependenciesDueToTemplateTypeLoader(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            // TODO-SIZE: this is overly generous in the templates we create
+
+            if (method.HasInstantiation)
+            {
+                GenericMethodsTemplateMap.GetTemplateMethodDependencies(ref dependencies, factory, method);
+            }
+            else
+            {
+                TypeDesc owningTemplateType = method.OwningType;
+
+                // Unboxing and Instantiating stubs use a different type as their template
+                if (factory.TypeSystemContext.IsSpecialUnboxingThunk(method))
+                    owningTemplateType = factory.TypeSystemContext.GetTargetOfSpecialUnboxingThunk(method).OwningType;
+
+                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, owningTemplateType);
+            }
+        }
+
+        protected override void GetDependenciesDueToEETypePresence(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
+        {
+            if (!ConstructedEETypeNode.CreationAllowed(type))
+            {
+                // Both EETypeNode and ConstructedEETypeNode call into this logic. EETypeNode will only call for unconstructable
+                // EETypes. We don't have templates for those.
+                return;
+            }
+
+            DefType closestDefType = type.GetClosestDefType();
+
+            // TODO-SIZE: this is overly generous in the templates we create
+            if (closestDefType.HasInstantiation)
+            {
+                TypeDesc canonType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
+                TypeDesc canonClosestDefType = closestDefType.ConvertToCanonForm(CanonicalFormKind.Specific);
+
+                // Add a dependency on the template for this type, if the canonical type should be generated into this binary.
+                // If the type is an array type, the check should be on its underlying Array<T> type. This is because a copy of
+                // an array type gets placed into each module but the Array<T> type only exists in the defining module and only 
+                // one template is needed for the Array<T> type by the dynamic type loader.
+                if (canonType.IsCanonicalSubtype(CanonicalFormKind.Any) && !factory.NecessaryTypeSymbol(canonClosestDefType).RepresentsIndirectionCell)
+                    dependencies.Add(factory.NativeLayout.TemplateTypeLayout(canonType), "Template Type Layout");
+            }
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -57,7 +57,6 @@ namespace ILCompiler
 
         internal NativeLayoutInfoNode NativeLayoutInfo { get; private set; }
         internal DynamicInvokeTemplateDataNode DynamicInvokeTemplateData { get; private set; }
-        public virtual bool SupportsReflection => true;
 
         public MetadataManager(CompilerTypeSystemContext typeSystemContext, MetadataBlockingPolicy blockingPolicy,
             ManifestResourceBlockingPolicy resourceBlockingPolicy, DynamicInvokeThunkGenerationPolicy dynamicInvokeThunkGenerationPolicy)
@@ -295,6 +294,11 @@ namespace ILCompiler
         /// </summary>
         public void GetDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
+            if (method.HasInstantiation)
+            {
+                ExactMethodInstantiationsNode.GetExactMethodInstantiationDependenciesForMethod(ref dependencies, factory, method);
+            }
+
             GetDependenciesDueToMethodCodePresence(ref dependencies, factory, method);
 
             MetadataCategory category = GetMetadataCategory(method);
@@ -356,6 +360,8 @@ namespace ILCompiler
                 // have one, since we got this callback). But check if a child wants to do something extra.
                 GetRuntimeMappingDependenciesDueToReflectability(ref dependencies, factory, type);
             }
+
+            GetDependenciesDueToEETypePresence(ref dependencies, factory, type);
         }
 
         protected virtual void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
@@ -369,6 +375,11 @@ namespace ILCompiler
         {
             // MetadataManagers can override this to provide additional dependencies caused by the emission of a runtime
             // mapping for a type.
+        }
+
+        protected virtual void GetDependenciesDueToEETypePresence(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)
+        {
+            // MetadataManagers can override this to provide additional dependencies caused by the emission of an EEType.
         }
 
         /// <summary>

--- a/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/UsageBasedMetadataManager.cs
@@ -334,7 +334,7 @@ namespace ILCompiler
             }
         }
 
-        protected override void GetDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        protected override void GetDependenciesDueToMethodCodePresenceInternal(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
             if ((_generationOptions & UsageBasedMetadataGenerationOptions.ILScanning) != 0)
             {


### PR DESCRIPTION
The property was added when we started compiling ProjectN mrt100_app.dll. It was problematic because it didn't actually mean reflection - it meant "is this something non-essential that we can skip". We actually need what it was doing at a finer graunlarity. This commit starts with that.

With this, generic virtual methods work in the reflection disabled mode.

A couple notes:
* Some of the SupportsReflection calls were redundant (they were in a code path that is already related to reflection). Those disappeared without replacement.
* CodeBaseDependencyAlgorithm references moved to the metadata manager. Hopefully we can get better control of generated templates in the future. (Not all types/generic methods need templates.)
* DictionaryLayoutNode references were redundant with the references from code/EETypes. Removed without replacement.
* Method template table emission needs to check whether the template was marked. This mirrors what we do for type templates. Eventually, we should make this for loop to go over all generated method templates instead of all methods (just keep track of the templates themselves).
* GVMs were implicitly relying on getting templates because we make templates for everything. Added explicit template generation.