### PR TITLE
Wasm: fixes loading int16 and SBytes from the stack where they were previously not sign extended

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -184,7 +184,7 @@ namespace Internal.IL
 
         public LLVMValueRef ValueAsType(LLVMTypeRef type, LLVMBuilderRef builder)
         {
-            return ValueAsTypeInternal(type, builder, false);
+            return ValueAsTypeInternal(type, builder, Type != null && (Type.IsWellKnownType(WellKnownType.SByte) || Type.IsWellKnownType(WellKnownType.Int16)));
         }
 
         public LLVMValueRef ValueAsType(TypeDesc type, LLVMBuilderRef builder)

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -300,7 +300,7 @@ internal static class Program
             FailTest();
         }
 
-        TestSvyteExtend();
+        TestSByteExtend();
 
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
@@ -992,9 +992,9 @@ internal static class Program
         EndTest(strt.DoubleField == 0d);
     }
 
-    private static void TestSbyteExtend()
+    private static void TestSByteExtend()
     {
-        StartTest("sbyte extend")
+        StartTest("SByte extend");
         sbyte s = -1;
         int x = (int)s;
         sbyte s2 = 1;
@@ -1005,7 +1005,7 @@ internal static class Program
         }
         else
         {
-            FailTest("Expected -1 and 1 but got " + x.ToString() + " " + x2.ToString());
+            FailTest("Expected -1 and 1 but got " + x.ToString() + " and " + x2.ToString());
         }
     }
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -300,6 +300,8 @@ internal static class Program
             FailTest();
         }
 
+        TestSvyteExtend();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -988,6 +990,23 @@ internal static class Program
         StartTest("Init struct with double field test");
         StructWithDouble strt = new StructWithDouble();
         EndTest(strt.DoubleField == 0d);
+    }
+
+    private static void TestSbyteExtend()
+    {
+        StartTest("sbyte extend")
+        sbyte s = -1;
+        int x = (int)s;
+        sbyte s2 = 1;
+        int x2 = (int)s2;
+        if (x == -1 && x2 == 1)
+        {
+            PassTest();
+        }
+        else
+        {
+            FailTest("Expected -1 and 1 but got " + x.ToString() + " " + x2.ToString());
+        }
     }
 
     [DllImport("*")]


### PR DESCRIPTION
Previously loading SBytes from the stack did not sign extend causing problems in the NativeFormatReader.  This adds a test and fixes that scenario.