### PR TITLE
Minor triage improvement in SuperIlc

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/Buckets.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/Buckets.cs
@@ -153,13 +153,22 @@ namespace ReadyToRun.SuperIlc
                         }
                         return line;
                     }
-                    else if (line.StartsWith("Unhandled Exception:"))
+                    else if (line.StartsWith("Unhandled exception", StringComparison.OrdinalIgnoreCase))
                     {
                         int leftBracket = line.IndexOf('[');
                         int rightBracket = line.IndexOf(']', leftBracket + 1);
                         if (leftBracket >= 0 && rightBracket > leftBracket)
                         {
                             line = line.Substring(0, leftBracket) + line.Substring(rightBracket + 1);
+                        }
+                        for (int detailLineIndex = lineIndex + 1; detailLineIndex < lines.Length; detailLineIndex++)
+                        {
+                            string detailLine = lines[detailLineIndex].TrimStart();
+                            if (!detailLine.StartsWith("--->"))
+                            {
+                                break;
+                            }
+                            line += " " + detailLine;
                         }
                         return line;
                     }


### PR DESCRIPTION
For tests with unhandled runtime exceptions, we can improve SuperIlc
triage by using the exception as the triage string instead of just
reporting a non-zero exit code. Part of the logic already existed
but it apparently had a typo in the exception message check due to
which it failed to kick in.

Thanks

Tomas