### PR TITLE
Compile cross-module generics in the same version bubble.

### DIFF
--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -50,6 +50,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 builder.EmitMethodSignature(
                     new MethodWithToken(_targetMethod.Method, _methodToken, constrainedType: null),
                     enforceDefEncoding: false,
+                    enforceOwningType: false,
                     innerContext,
                     isUnboxingStub: false,
                     isInstantiatingStub: false);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -114,6 +114,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 dataBuilder.EmitMethodSignature(
                     _methodArgument,
                     enforceDefEncoding: false,
+                    enforceOwningType: false,
                     context: innerContext,
                     isUnboxingStub: false,
                     isInstantiatingStub: true);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
@@ -53,17 +53,18 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 {
                     int methodIndex = r2rFactory.RuntimeFunctionsTable.GetIndex(method);
 
+                    bool enforceOwningType = false;
                     ModuleToken moduleToken = method.SignatureContext.GetModuleTokenForMethod(method.Method.GetTypicalMethodDefinition());
                     if (moduleToken.Module != r2rFactory.InputModuleContext.GlobalContext)
                     {
-                        // TODO: encoding of instance methods relative to other modules within the version bubble
-                        continue;
+                        enforceOwningType = true;
                     }
 
                     ArraySignatureBuilder signatureBuilder = new ArraySignatureBuilder();
                     signatureBuilder.EmitMethodSignature(
                         new MethodWithToken(method.Method, moduleToken, constrainedType: null),
                         enforceDefEncoding: true,
+                        enforceOwningType,
                         method.SignatureContext,
                         isUnboxingStub: false, 
                         isInstantiatingStub: false);

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -84,7 +84,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
             else
             {
-                dataBuilder.EmitMethodSignature(_method, enforceDefEncoding: false, innerContext, _isUnboxingStub, _isInstantiatingStub);
+                dataBuilder.EmitMethodSignature(_method, enforceDefEncoding: false, enforceOwningType: false, innerContext, _isUnboxingStub, _isInstantiatingStub);
             }
 
             return dataBuilder.ToObjectData();

--- a/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/ILCompiler.ReadyToRun/src/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -403,7 +403,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 flags |= (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_Constrained;
             }
-            if(enforceOwningType)
+            if (enforceOwningType)
             {
                 flags |= (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType;
             }

--- a/src/crossgen2/src/Program.cs
+++ b/src/crossgen2/src/Program.cs
@@ -149,7 +149,7 @@ namespace ILCompiler
                 Console.ReadLine();
             }
 
-            if(_includeGenericsFromVersionBubble)
+            if (_includeGenericsFromVersionBubble)
             {
                 if (!_isInputVersionBubble)
                 {

--- a/src/crossgen2/src/Program.cs
+++ b/src/crossgen2/src/Program.cs
@@ -27,6 +27,7 @@ namespace ILCompiler
 
         private string _outputFilePath;
         private bool _isInputVersionBubble;
+        private bool _includeGenericsFromVersionBubble;
         private bool _isVerbose;
 
         private string _dgmlLogFileName;
@@ -125,6 +126,7 @@ namespace ILCompiler
                 syntax.DefineOption("Os", ref optimizeSpace, "Enable optimizations, favor code space");
                 syntax.DefineOption("Ot", ref optimizeTime, "Enable optimizations, favor code speed");
                 syntax.DefineOption("inputbubble", ref _isInputVersionBubble, "True when the entire input forms a version bubble (default = per-assembly bubble)");
+                syntax.DefineOption("compilebubblegenerics", ref _includeGenericsFromVersionBubble, "Compile instantiations from reference modules used in the current module");
                 syntax.DefineOption("dgmllog", ref _dgmlLogFileName, "Save result of dependency analysis as DGML");
                 syntax.DefineOption("fulllog", ref _generateFullDgmlLog, "Save detailed log of dependency analysis");
                 syntax.DefineOption("verbose", ref _isVerbose, "Enable verbose logging");
@@ -145,6 +147,15 @@ namespace ILCompiler
             {
                 Console.WriteLine("Waiting for debugger to attach. Press ENTER to continue");
                 Console.ReadLine();
+            }
+
+            if(_includeGenericsFromVersionBubble)
+            {
+                if (!_isInputVersionBubble)
+                {
+                    Console.WriteLine("Warning: ignoring --compilebubblegenerics because --inputbubble was not specified");
+                    _includeGenericsFromVersionBubble = false;
+                }
             }
 
             _optimizationMode = OptimizationMode.None;
@@ -319,7 +330,7 @@ namespace ILCompiler
                 }
 
                 compilationGroup = new ReadyToRunSingleAssemblyCompilationModuleGroup(
-                    typeSystemContext, inputModules, versionBubbleModules);
+                    typeSystemContext, inputModules, versionBubbleModules, _includeGenericsFromVersionBubble);
             }
 
             //


### PR DESCRIPTION
This work is related to the single-exe prototype, but after discussing with @davidwrighton, these are changes that we can have in master as well.

Compiling generics from external modules in the version bubble is enabled using a command line switch.

Other changes: Changing signatures in hashtable of instantiations to include owning type as a way of encoding the module override info
