### PR TITLE
Get jitwrapper building on x86

### DIFF
--- a/src/Native/jitinterface/dllexport.h
+++ b/src/Native/jitinterface/dllexport.h
@@ -16,8 +16,8 @@
 // ***
 // Define default call conventions
 // ***
-#if _X86_ && !PLATFORM_UNIX
+#if defined(_X86_) && !defined(PLATFORM_UNIX)
 #define STDMETHODCALLTYPE  __stdcall
 #else
 #define STDMETHODCALLTYPE
-#endif // _X86_ && !PLATFORM_UNIX
+#endif //  defined(_X86_) && !defined(PLATFORM_UNIX)

--- a/src/Native/jitinterface/dllexport.h
+++ b/src/Native/jitinterface/dllexport.h
@@ -16,25 +16,12 @@
 // ***
 // Define default call conventions
 // ***
-#ifndef _X86_
-
-#define DEFAULT_CALL_CONV
-#define __cdecl
-#define __stdcall
-
-#else // _X86_
-
-#ifndef __stdcall
-#define __stdcall          __attribute__((stdcall))
-#endif
-
+#if _X86_
 #ifdef PLATFORM_UNIX
-#define DEFAULT_CALL_CONV
+#define STDMETHODCALLTYPE  __attribute__((stdcall))
 #else
-#define DEFAULT_CALL_CONV  __stdcall
-#endif
-
+#define STDMETHODCALLTYPE  __stdcall
+#endif // PLATFORM_UNIX
+#else
+#define STDMETHODCALLTYPE
 #endif // _X86_
-
-
-#define STDMETHODCALLTYPE  DEFAULT_CALL_CONV

--- a/src/Native/jitinterface/dllexport.h
+++ b/src/Native/jitinterface/dllexport.h
@@ -16,12 +16,8 @@
 // ***
 // Define default call conventions
 // ***
-#if _X86_
-#ifdef PLATFORM_UNIX
-#define STDMETHODCALLTYPE  __attribute__((stdcall))
-#else
+#if _X86_ && !PLATFORM_UNIX
 #define STDMETHODCALLTYPE  __stdcall
-#endif // PLATFORM_UNIX
 #else
 #define STDMETHODCALLTYPE
-#endif // _X86_
+#endif // _X86_ && !PLATFORM_UNIX

--- a/src/Native/jitinterface/jitwrapper.cpp
+++ b/src/Native/jitinterface/jitwrapper.cpp
@@ -37,7 +37,7 @@ static const GUID JITEEVersionIdentifier = { /* d609bed1-7831-49fc-bd49-b6f054dd
 class Jit
 {
 public:
-    virtual int __stdcall compileMethod(
+    virtual int STDMETHODCALLTYPE compileMethod(
         void* compHnd,
         void* methodInfo,
         unsigned flags,


### PR DESCRIPTION
CoreCLR repo is going to build it that way. I could exclude that outside x64, but it's just better to fix it...