### PR TITLE
Output raw test lists for the individual outcomes from SuperIlc

### DIFF
--- a/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
+++ b/tests/src/tools/ReadyToRun.SuperIlc/ProcessRunner.cs
@@ -57,6 +57,8 @@ public class ProcessInfo
     public int ExitCode;
     public Dictionary<string, HashSet<string>> JittedMethods;
 
+    public bool Crashed => ExitCode < -1000 * 1000;
+
     public ProcessInfo(ProcessConstructor constructor)
     {
         Constructor = constructor;


### PR DESCRIPTION
This change tweaks SuperIlc to emit simple line-oriented test lists
for the various compilation and execution outcomes. I found this
quite useful for comparing various runs. I have also deleted a bit
of dead code I noticed.

Thanks

Tomas