### PR TITLE
Mark unsafe intrinsics as reflection blocked

### DIFF
--- a/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/System.Private.CoreLib/shared/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -39,7 +39,7 @@ namespace Internal.Runtime.CompilerServices
     /// For internal use only. Contains generic, low-level functionality for manipulating pointers.
     /// </summary>
     [CLSCompliant(false)]
-    public static unsafe class Unsafe
+    public static unsafe partial class Unsafe
     {
         /// <summary>
         /// Returns a pointer to the given by-ref parameter.

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Internal.Runtime.CompilerServices
+{
+    [ReflectionBlocked]
+    partial class Unsafe
+    {
+    }
+}

--- a/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Internal\IntrinsicSupport\EqualityComparerHelpers.cs" />
     <Compile Include="Internal\Reflection\Augments\ReflectionAugments.cs" />
     <Compile Include="Internal\Runtime\CompilerServices\HasEmbeddedStringResourcesAttribute.cs" />
+    <Compile Include="Internal\Runtime\CompilerServices\Unsafe.cs" />
     <Compile Include="Internal\Runtime\EEType.Runtime.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\ThrowHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\MathHelpers.cs" />


### PR DESCRIPTION
Keeping these reflection enabled pulls in quite a bit of junk (generic dictionaries, standalone method bodies, bookkeeping) that adds up to 1.5% of the size of Hello World...