### PR TITLE
Fix casting to pointers

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -230,9 +230,9 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISymbolNode GetTarget(NodeFactory factory, GenericLookupResultContext dictionary)
         {
-            // We are getting a constructed type symbol because this might be something passed to newobj.
+            // We are getting a maximally constructable type symbol because this might be something passed to newobj.
             TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(dictionary.TypeInstantiation, dictionary.MethodInstantiation);
-            return factory.ConstructedTypeSymbol(instantiatedType);
+            return factory.MaximallyConstructableType(instantiatedType);
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/JitHelper.cs
@@ -326,7 +326,11 @@ namespace ILCompiler
             if (type.IsInterface)
                 return throwing ? "RhTypeCast_CheckCastInterface" : "RhTypeCast_IsInstanceOfInterface";
 
-            return throwing ? "RhTypeCast_CheckCastClass" : "RhTypeCast_IsInstanceOfClass";
+            if (type.IsDefType)
+                return throwing ? "RhTypeCast_CheckCastClass" : "RhTypeCast_IsInstanceOfClass";
+
+            // No specialized helper for the rest of the types because they don't make much sense anyway.
+            return throwing ? "RhTypeCast_CheckCast" : "RhTypeCast_IsInstanceOf";
         }
     }
 }

--- a/src/Native/Runtime/RuntimeInstance.cpp
+++ b/src/Native/Runtime/RuntimeInstance.cpp
@@ -832,6 +832,8 @@ DECLARE_INDIRECTION(RhpNewFinalizable);
 
 DECLARE_INDIRECTION(RhpNewArray);
 
+DECLARE_INDIRECTION(RhTypeCast_IsInstanceOf);
+DECLARE_INDIRECTION(RhTypeCast_CheckCast);
 DECLARE_INDIRECTION(RhTypeCast_IsInstanceOfClass);
 DECLARE_INDIRECTION(RhTypeCast_CheckCastClass);
 DECLARE_INDIRECTION(RhTypeCast_IsInstanceOfArray);
@@ -878,15 +880,18 @@ COOP_PINVOKE_HELPER(PTR_VOID, RhGetRuntimeHelperForType, (EEType * pEEType, int 
             return INDIRECTION(RhTypeCast_IsInstanceOfArray);
         else if (pEEType->IsInterface())
             return INDIRECTION(RhTypeCast_IsInstanceOfInterface);
+        else if (pEEType->IsParameterizedType())
+            return INDIRECTION(RhTypeCast_IsInstanceOf); // Array handled above; pointers and byrefs handled here
         else
             return INDIRECTION(RhTypeCast_IsInstanceOfClass);
 
     case RuntimeHelperKind::CastClass:
         if (pEEType->IsArray())
             return INDIRECTION(RhTypeCast_CheckCastArray);
-
         else if (pEEType->IsInterface())
             return INDIRECTION(RhTypeCast_CheckCastInterface);
+        else if (pEEType->IsParameterizedType())
+            return INDIRECTION(RhTypeCast_CheckCast); // Array handled above; pointers and byrefs handled here
         else
             return INDIRECTION(RhTypeCast_CheckCastClass);
 

--- a/src/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -968,6 +968,8 @@ namespace System.Runtime
                 return IsInstanceOfArray(pvTargetType, obj);
             else if (pTargetType->IsInterface)
                 return IsInstanceOfInterface(pvTargetType, obj);
+            else if (pTargetType->IsParameterizedType)
+                return null; // We handled arrays above so this is for pointers and byrefs only.
             else
                 return IsInstanceOfClass(pvTargetType, obj);
         }
@@ -981,8 +983,22 @@ namespace System.Runtime
                 return CheckCastArray(pvTargetType, obj);
             else if (pTargetType->IsInterface)
                 return CheckCastInterface(pvTargetType, obj);
+            else if (pTargetType->IsParameterizedType)
+                return CheckCastNonArrayParameterizedType(pvTargetType, obj);
             else
                 return CheckCastClass(pvTargetType, obj);
+        }
+
+        private static unsafe object CheckCastNonArrayParameterizedType(void* pvTargetType, object obj)
+        {
+            // a null value can be cast to anything
+            if (obj == null)
+            {
+                return null;
+            }
+
+            // Parameterized types are not boxable, so nothing can be an instance of these.
+            throw ((EEType*)pvTargetType)->GetClasslibException(ExceptionIDs.InvalidCast);
         }
 
         // Returns true of the two types are equivalent primitive types. Used by array casts.


### PR DESCRIPTION
Porting a fix made for .NET Native.

A popular game engine has a `castclass void*` IL instruction in one of the generated files it ships with. This construct is weird enough that it crashes the .NET Native compiler. It doesn't crash the CoreRT compiler, but we still want the runtime side of the fix.