### PR TITLE
Fix Windows debug information for classes

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/WindowsNodeMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/WindowsNodeMangler.cs
@@ -32,7 +32,11 @@ namespace ILCompiler
                 mangledJustTypeName = MangledBoxedTypeName(type);
             else
                 mangledJustTypeName = NameMangler.GetMangledTypeName(type);
-            return "const " + mangledJustTypeName + "::`vftable'";
+
+            // "??_7TypeName@@6B@" is the C++ mangling for "const TypeName::`vftable'"
+            // This, along with LF_VTSHAPE debug records added by the object writer
+            // is the debugger magic that allows debuggers to vcast types to their bases.
+            return "??_7" + mangledJustTypeName + "@@6B@";
         }
 
         public sealed override string GCStatics(TypeDesc type)

--- a/src/Native/ObjWriter/debugInfo/codeView/codeViewTypeBuilder.h
+++ b/src/Native/ObjWriter/debugInfo/codeView/codeViewTypeBuilder.h
@@ -70,4 +70,5 @@ private:
 
   ArrayDimensionsDescriptor ArrayDimentions;
   TypeIndex ClassVTableTypeIndex;
+  TypeIndex VFuncTabTypeIndex;
 };


### PR DESCRIPTION
Fixes a longstanding issue where we were emitting erroneous vfptr debug entries and incorrectly mangling class names. One could only inspect things as they were statically typed in the source (so if a variable was typed as `object` in the sources, you wouldn't see any fields in the native debugger, no matter what was assigned to it).

It wasn't too terrible, so I sort of just lived with it, but this should work.

With this, casting to base classes in the debugger works.

## Before

![before](https://user-images.githubusercontent.com/13110571/65817093-98550a00-e203-11e9-88ce-efd8109ae303.gif)


## After

![after](https://user-images.githubusercontent.com/13110571/65817095-9d19be00-e203-11e9-9ec7-73ffe4587b62.gif)
