### PR TITLE
Remove global state tracking in DynamicInvokeTemplateDataNode

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -30,8 +30,7 @@ namespace ILCompiler.DependencyAnalysis
                     MethodDesc canonInvokeStub = factory.MetadataManager.GetCanonicalReflectionInvokeStub(method);
                     if (canonInvokeStub.IsSharedByGenericInstantiations)
                     {
-                        dependencies.Add(new DependencyListEntry(factory.MetadataManager.DynamicInvokeTemplateData, "Reflection invoke template data"));
-                        factory.MetadataManager.DynamicInvokeTemplateData.AddDependenciesDueToInvokeTemplatePresence(ref dependencies, factory, canonInvokeStub);
+                        dependencies.Add(new DependencyListEntry(factory.DynamicInvokeTemplate(canonInvokeStub), "Reflection invoke"));
                     }
                     else
                         dependencies.Add(new DependencyListEntry(factory.MethodEntrypoint(canonInvokeStub), "Reflection invoke"));

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DynamicInvokeTemplateNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/DynamicInvokeTemplateNode.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+using ILCompiler.DependencyAnalysisFramework;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Models dependencies of the dynamic invoke methods that aid in reflection invoking methods.
+    /// Dynamic invoke methods are shared method bodies that perform calling convention conversion
+    /// from object[] to the expected signature of the called method.
+    /// </summary>
+    internal class DynamicInvokeTemplateNode : DependencyNodeCore<NodeFactory>
+    {
+        public MethodDesc Method { get; }
+
+        public DynamicInvokeTemplateNode(MethodDesc method)
+        {
+            Debug.Assert(method.IsSharedByGenericInstantiations);
+            Method = method;
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            return DynamicInvokeTemplateDataNode.GetDependenciesDueToInvokeTemplatePresence(factory, Method);
+        }
+
+        protected override string GetName(NodeFactory factory)
+        {
+            return "DynamicInvokeTemplate: " + factory.NameMangler.GetMangledMethodName(Method);
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
+    }
+}

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -269,6 +269,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new TypeGVMEntriesNode(type);
             });
 
+            _dynamicInvokeTemplates = new NodeCache<MethodDesc, DynamicInvokeTemplateNode>(method =>
+            {
+                return new DynamicInvokeTemplateNode(method);
+            });
+
             _reflectableMethods = new NodeCache<MethodDesc, ReflectableMethodNode>(method =>
             {
                 return new ReflectableMethodNode(method);
@@ -792,6 +797,12 @@ namespace ILCompiler.DependencyAnalysis
         public ReflectableMethodNode ReflectableMethod(MethodDesc method)
         {
             return _reflectableMethods.GetOrAdd(method);
+        }
+
+        private NodeCache<MethodDesc, DynamicInvokeTemplateNode> _dynamicInvokeTemplates;
+        internal DynamicInvokeTemplateNode DynamicInvokeTemplate(MethodDesc method)
+        {
+            return _dynamicInvokeTemplates.GetOrAdd(method);
         }
 
         private NodeCache<MethodKey, IMethodNode> _shadowConcreteMethods;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReflectionInvokeMapNode.cs
@@ -144,7 +144,7 @@ namespace ILCompiler.DependencyAnalysis
                     if (canonInvokeStubMethod.IsSharedByGenericInstantiations)
                     {
                         vertex = writer.GetTuple(vertex,
-                            writer.GetUnsignedConstant(((uint)factory.MetadataManager.DynamicInvokeTemplateData.GetIdForMethod(canonInvokeStubMethod) << 1) | 1));
+                            writer.GetUnsignedConstant(((uint)factory.MetadataManager.DynamicInvokeTemplateData.GetIdForMethod(canonInvokeStubMethod, factory) << 1) | 1));
                     }
                     else
                     {

--- a/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/MetadataManager.cs
@@ -54,6 +54,7 @@ namespace ILCompiler
         private List<TypeGVMEntriesNode> _typeGVMEntries = new List<TypeGVMEntriesNode>();
         private HashSet<DefType> _typesWithDelegateMarshalling = new HashSet<DefType>();
         private HashSet<DefType> _typesWithStructMarshalling = new HashSet<DefType>();
+        private HashSet<MethodDesc> _dynamicInvokeTemplates = new HashSet<MethodDesc>();
 
         internal NativeLayoutInfoNode NativeLayoutInfo { get; private set; }
         internal DynamicInvokeTemplateDataNode DynamicInvokeTemplateData { get; private set; }
@@ -219,6 +220,11 @@ namespace ILCompiler
             if (obj is DelegateMarshallingDataNode delegateMarshallingDataNode)
             {
                 _typesWithDelegateMarshalling.Add(delegateMarshallingDataNode.Type);
+            }
+
+            if (obj is DynamicInvokeTemplateNode dynamicInvokeTemplate)
+            {
+                _dynamicInvokeTemplates.Add(dynamicInvokeTemplate.Method);
             }
         }
 
@@ -634,6 +640,11 @@ namespace ILCompiler
         internal IEnumerable<TypeDesc> GetTypesWithConstructedEETypes()
         {
             return _typesWithConstructedEETypesGenerated;
+        }
+
+        internal IEnumerable<MethodDesc> GetDynamicInvokeTemplateMethods()
+        {
+            return _dynamicInvokeTemplates;
         }
 
         public bool IsReflectionBlocked(TypeDesc type)

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Compiler\DebugInformationProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\DefaultConstructorMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\DelegateMarshallingDataNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\DynamicInvokeTemplateNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolsImportedNodeProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternSymbolsWithIndirectionImportedNodeProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\IndirectionExtensions.cs" />


### PR DESCRIPTION
DynamicInvokeTemplateDataNode populated _methodToTemplateIndex in `GetIdForMethod` which is pretty bad from multithreading perspective (non-concurrent dictionary + ID that depends on ordering).

I've moved this tracking into a separate node so that this is more explicit and properly sortable.