### PR TITLE
Cache helpers used in IL scanner

### DIFF
--- a/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
+++ b/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs
@@ -176,18 +176,7 @@ namespace Internal.IL
 
         private ISymbolNode GetHelperEntrypoint(ReadyToRunHelper helper)
         {
-            string mangledName;
-            MethodDesc methodDesc;
-            JitHelper.GetEntryPoint(_compilation.TypeSystemContext, helper, out mangledName, out methodDesc);
-            Debug.Assert(mangledName != null || methodDesc != null);
-
-            ISymbolNode entryPoint;
-            if (mangledName != null)
-                entryPoint = _compilation.NodeFactory.ExternSymbol(mangledName);
-            else
-                entryPoint = _compilation.NodeFactory.MethodEntrypoint(methodDesc);
-
-            return entryPoint;
+            return _compilation.GetHelperEntrypoint(helper);
         }
 
         private void MarkInstructionBoundary() { }


### PR DESCRIPTION
We have a cache for these in CorInfoImpl (when compiling), but there's no cache in the scanner. This means we're re-resolving various named helpers in CoreLib. It's a bit of a waste of CPU time. Noticed this when running the compiler under a profiler.