### PR TITLE
Add support for multithreaded compilation to ILC

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -36,6 +36,17 @@
     </PackageReference>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <NuGetTargetMoniker>.NETStandard,Version=v1.6</NuGetTargetMoniker>
+    <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.6</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="NETStandard.Library">
+      <Version>2.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
   <!-- Set default references for netstandard2.0 -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <NuGetTargetMoniker>.NETStandard,Version=v2.0</NuGetTargetMoniker>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -205,6 +205,7 @@ See the LICENSE file in the project root for more information.
       <IlcArg Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) == 'Size'" Include="--Os" />
       <IlcArg Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) == 'Speed'" Include="--Ot" />
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--disablereflection" />
+      <IlcArg Condition="$(IlcSingleThreaded) == 'true'" Include="--singlethreaded" />
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--removefeature:EventSource" />
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--removefeature:FrameworkStrings" />
       <IlcArg Condition="$(IlcInvariantGlobalization) == 'true'" Include="--removefeature:Globalization" />

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.Aot.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.Aot.cs
@@ -15,6 +15,7 @@ namespace ILCompiler
         protected DebugInformationProvider _debugInformationProvider = new DebugInformationProvider();
         protected DevirtualizationManager _devirtualizationManager = new DevirtualizationManager();
         protected bool _methodBodyFolding;
+        protected bool _singleThreaded;
 
         partial void InitializePartial()
         {
@@ -60,6 +61,12 @@ namespace ILCompiler
         public CompilationBuilder UseMethodBodyFolding(bool enable)
         {
             _methodBodyFolding = enable;
+            return this;
+        }
+
+        public CompilationBuilder UseSingleThread(bool enable)
+        {
+            _singleThreaded = enable;
             return this;
         }
 

--- a/src/ILCompiler.Compiler/src/Compiler/ILScannerBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ILScannerBuilder.cs
@@ -27,6 +27,7 @@ namespace ILCompiler
         private IEnumerable<ICompilationRootProvider> _compilationRoots = Array.Empty<ICompilationRootProvider>();
         private MetadataManager _metadataManager;
         private InteropStubManager _interopStubManager = new EmptyInteropStubManager();
+        private bool _singleThreaded;
 
         internal ILScannerBuilder(CompilerTypeSystemContext context, CompilationModuleGroup compilationGroup, NameMangler mangler, ILProvider ilProvider)
         {
@@ -61,12 +62,18 @@ namespace ILCompiler
             return this;
         }
 
+        public ILScannerBuilder UseSingleThread(bool enable)
+        {
+            _singleThreaded = enable;
+            return this;
+        }
+
         public IILScanner ToILScanner()
         {
             var nodeFactory = new ILScanNodeFactory(_context, _compilationGroup, _metadataManager, _interopStubManager, _nameMangler);
             DependencyAnalyzerBase<NodeFactory> graph = _dependencyTrackingLevel.CreateDependencyGraph(nodeFactory);
 
-            return new ILScanner(graph, nodeFactory, _compilationRoots, _ilProvider, new NullDebugInformationProvider(), _logger);
+            return new ILScanner(graph, nodeFactory, _compilationRoots, _ilProvider, new NullDebugInformationProvider(), _logger, _singleThreaded);
         }
     }
 }

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -11,6 +11,9 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
       <Version>4.3.0</Version>
     </PackageReference>
+    <PackageReference Include="System.Threading.ThreadPool">
+      <Version>4.0.10</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\ILCompiler.DependencyAnalysisFramework\src\ILCompiler.DependencyAnalysisFramework.csproj" />

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>ILCompiler.Compiler</RootNamespace>
     <AssemblyName>ILCompiler.Compiler</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">

--- a/src/ILCompiler.CppCodeGen/src/ILCompiler.CppCodeGen.csproj
+++ b/src/ILCompiler.CppCodeGen/src/ILCompiler.CppCodeGen.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>ILCompiler</RootNamespace>
     <AssemblyName>ILCompiler.CppCodeGen</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\ILCompiler.DependencyAnalysisFramework\src\ILCompiler.DependencyAnalysisFramework.csproj" />

--- a/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilation.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilation.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
@@ -17,10 +19,11 @@ namespace ILCompiler
 {
     public sealed class RyuJitCompilation : Compilation
     {
-        private CorInfoImpl _corInfo;
-        private JitConfigProvider _jitConfigProvider;
+        private readonly ConditionalWeakTable<Thread, CorInfoImpl> _corinfos = new ConditionalWeakTable<Thread, CorInfoImpl>();
+        private readonly JitConfigProvider _jitConfigProvider;
         internal readonly RyuJitCompilationOptions _compilationOptions;
         private readonly ExternSymbolMappedField _hardwareIntrinsicFlags;
+        private CountdownEvent _compilationCountdown;
 
         internal RyuJitCompilation(
             DependencyAnalyzerBase<NodeFactory> dependencyGraph,
@@ -41,8 +44,6 @@ namespace ILCompiler
 
         protected override void CompileInternal(string outputFile, ObjectDumper dumper)
         {
-            _corInfo = new CorInfoImpl(this, _jitConfigProvider);
-
             _dependencyGraph.ComputeMarkedNodes();
             var nodes = _dependencyGraph.MarkedNodeList;
 
@@ -52,6 +53,10 @@ namespace ILCompiler
 
         protected override void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj)
         {
+            // Determine the list of method we actually need to compile
+            var methodsToCompile = new List<MethodCodeNode>();
+            var canonicalMethodsToCompile = new HashSet<MethodDesc>();
+
             foreach (DependencyNodeCore<NodeFactory> dependency in obj)
             {
                 var methodCodeNodeNeedingCode = dependency as MethodCodeNode;
@@ -63,35 +68,93 @@ namespace ILCompiler
                     methodCodeNodeNeedingCode = (MethodCodeNode)dependencyMethod.CanonicalMethodNode;
                 }
 
-                // We might have already compiled this method.
-                if (methodCodeNodeNeedingCode.StaticDependenciesAreComputed)
-                    continue;
-
+                // We might have already queued this method for compilation
                 MethodDesc method = methodCodeNodeNeedingCode.Method;
+                if (method.IsCanonicalMethod(CanonicalFormKind.Any)
+                    && !canonicalMethodsToCompile.Add(method))
+                {
+                    continue;
+                }
 
+                methodsToCompile.Add(methodCodeNodeNeedingCode);
+            }
+
+            if ((_compilationOptions & RyuJitCompilationOptions.SingleThreadedCompilation) != 0)
+            {
+                CompileSingleThreaded(methodsToCompile);
+            }
+            else
+            {
+                CompileMultiThreaded(methodsToCompile);
+            }
+        }
+        private void CompileMultiThreaded(List<MethodCodeNode> methodsToCompile)
+        {
+            if (Logger.IsVerbose)
+            {
+                Logger.Writer.WriteLine($"Compiling {methodsToCompile.Count} methods...");
+            }
+
+            WaitCallback compileSingleMethodDelegate = m =>
+            {
+                CorInfoImpl corInfo = _corinfos.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this, _jitConfigProvider));
+                CompileSingleMethod(corInfo, (MethodCodeNode)m);
+            };
+
+            using (_compilationCountdown = new CountdownEvent(methodsToCompile.Count))
+            {
+
+                foreach (MethodCodeNode methodCodeNodeNeedingCode in methodsToCompile)
+                {
+                    ThreadPool.QueueUserWorkItem(compileSingleMethodDelegate, methodCodeNodeNeedingCode);
+                }
+
+                _compilationCountdown.Wait();
+                _compilationCountdown = null;
+            }
+        }
+
+
+        private void CompileSingleThreaded(List<MethodCodeNode> methodsToCompile)
+        {
+            CorInfoImpl corInfo = _corinfos.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this, _jitConfigProvider));
+
+            foreach (MethodCodeNode methodCodeNodeNeedingCode in methodsToCompile)
+            {
                 if (Logger.IsVerbose)
                 {
-                    string methodName = method.ToString();
-                    Logger.Writer.WriteLine("Compiling " + methodName);
+                    Logger.Writer.WriteLine($"Compiling {methodCodeNodeNeedingCode.Method}...");
                 }
 
-                try
-                {
-                    _corInfo.CompileMethod(methodCodeNodeNeedingCode);
-                }
-                catch (TypeSystemException ex)
-                {
-                    // TODO: fail compilation if a switch was passed
+                CompileSingleMethod(corInfo, methodCodeNodeNeedingCode);
+            }
+        }
 
-                    // Try to compile the method again, but with a throwing method body this time.
-                    MethodIL throwingIL = TypeSystemThrowingILEmitter.EmitIL(method, ex);
-                    _corInfo.CompileMethod(methodCodeNodeNeedingCode, throwingIL);
+        private void CompileSingleMethod(CorInfoImpl corInfo, MethodCodeNode methodCodeNodeNeedingCode)
+        {
+            MethodDesc method = methodCodeNodeNeedingCode.Method;
 
-                    // TODO: Log as a warning. For now, just log to the logger; but this needs to
-                    // have an error code, be supressible, the method name/sig needs to be properly formatted, etc.
-                    // https://github.com/dotnet/corert/issues/72
-                    Logger.Writer.WriteLine($"Warning: Method `{method}` will always throw because: {ex.Message}");
-                }
+            try
+            {
+                corInfo.CompileMethod(methodCodeNodeNeedingCode);
+            }
+            catch (TypeSystemException ex)
+            {
+                // TODO: fail compilation if a switch was passed
+
+                // Try to compile the method again, but with a throwing method body this time.
+                MethodIL throwingIL = TypeSystemThrowingILEmitter.EmitIL(method, ex);
+                corInfo.CompileMethod(methodCodeNodeNeedingCode, throwingIL);
+
+                // TODO: Log as a warning. For now, just log to the logger; but this needs to
+                // have an error code, be supressible, the method name/sig needs to be properly formatted, etc.
+                // https://github.com/dotnet/corert/issues/72
+                Logger.Writer.WriteLine($"Warning: Method `{method}` will always throw because: {ex.Message}");
+            }
+            finally
+            {
+                if (_compilationCountdown != null)
+                    _compilationCountdown.Signal();
             }
         }
 
@@ -113,5 +176,6 @@ namespace ILCompiler
     public enum RyuJitCompilationOptions
     {
         MethodBodyFolding = 0x1,
+        SingleThreadedCompilation = 0x2,
     }
 }

--- a/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilationBuilder.cs
@@ -103,6 +103,9 @@ namespace ILCompiler
             if (_methodBodyFolding)
                 options |= RyuJitCompilationOptions.MethodBodyFolding;
 
+            if (_singleThreaded)
+                options |= RyuJitCompilationOptions.SingleThreadedCompilation;
+
             var factory = new RyuJitNodeFactory(_context, _compilationGroup, _metadataManager, _interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
 
             var jitConfig = new JitConfigProvider(jitFlagBuilder.ToArray(), _ryujitOptions);

--- a/src/ILCompiler.RyuJit/src/ILCompiler.RyuJit.csproj
+++ b/src/ILCompiler.RyuJit/src/ILCompiler.RyuJit.csproj
@@ -20,6 +20,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Threading.ThreadPool">
+      <Version>4.0.10</Version>
+    </PackageReference>
+    <PackageReference Include="System.Threading.Thread">
+      <Version>4.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="Compiler\DependencyAnalysis\MethodCodeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RyuJitNodeFactory.cs" />
     <Compile Include="Compiler\RyuJitCompilation.cs" />

--- a/src/ILCompiler.RyuJit/src/ILCompiler.RyuJit.csproj
+++ b/src/ILCompiler.RyuJit/src/ILCompiler.RyuJit.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>ILCompiler</RootNamespace>
     <AssemblyName>ILCompiler.RyuJit</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
     <NoWarn>8002</NoWarn>
     <OutputPath>$(BaseOutputPath)$(OSPlatformConfig)/tools</OutputPath>
   </PropertyGroup>

--- a/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
+++ b/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
@@ -6,9 +6,8 @@
     <RootNamespace>ILCompiler</RootNamespace>
     <AssemblyName>ILCompiler.WebAssembly</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
     <NoWarn>8002</NoWarn>
-    <OutputPath>$(BaseOutputPath)$(OSPlatformConfig)/tools</OutputPath>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/ILCompiler/desktop/desktop.csproj
+++ b/src/ILCompiler/desktop/desktop.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>desktop</RootNamespace>
     <AssemblyName>desktop</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/src/ILCompiler/src/ILCompiler.csproj
+++ b/src/ILCompiler/src/ILCompiler.csproj
@@ -32,6 +32,15 @@
     <PackageReference Include="System.CommandLine">
       <Version>0.1.0-e160909-1</Version>
     </PackageReference>
+    <PackageReference Include="System.Xml.XDocument">
+      <Version>4.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Console">
+      <Version>4.3.1</Version>
+    </PackageReference>
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation">
+      <Version>4.3.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigurablePInvokePolicy.cs" />

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -57,6 +57,7 @@ namespace ILCompiler
         private bool _completeTypesMetadata;
         private bool _scanReflection;
         private bool _methodBodyFolding;
+        private bool _singleThreaded;
 
         private string _singleMethodTypeName;
         private string _singleMethodName;
@@ -187,6 +188,7 @@ namespace ILCompiler
                 syntax.DefineOptionList("appcontextswitch", ref _appContextSwitches, "System.AppContext switches to set");
                 syntax.DefineOptionList("runtimeopt", ref _runtimeOptions, "Runtime options to set");
                 syntax.DefineOptionList("removefeature", ref _removedFeatures, "Framework features to remove");
+                syntax.DefineOption("singlethreaded", ref _singleThreaded, "Run compilation on a single thread");
 
                 syntax.DefineOption("targetarch", ref _targetArchitectureStr, "Target architecture for cross compilation");
                 syntax.DefineOption("targetos", ref _targetOSStr, "Target OS for cross compilation");
@@ -538,6 +540,7 @@ namespace ILCompiler
                 ILScannerBuilder scannerBuilder = builder.GetILScannerBuilder()
                     .UseCompilationRoots(compilationRoots)
                     .UseMetadataManager(metadataManager)
+                    .UseSingleThread(enable: _singleThreaded)
                     .UseInteropStubManager(interopStubManager);
 
                 if (_scanDgmlLogFileName != null)
@@ -575,7 +578,8 @@ namespace ILCompiler
 
             builder
                 .UseBackendOptions(_codegenOptions)
-                .UseMethodBodyFolding(_methodBodyFolding)
+                .UseMethodBodyFolding(enable: _methodBodyFolding)
+                .UseSingleThread(enable: _singleThreaded)
                 .UseMetadataManager(metadataManager)
                 .UseInteropStubManager(interopStubManager)
                 .UseLogger(logger)

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -347,6 +347,9 @@ namespace Internal.JitInterface
 #if !READYTORUN
             _sequencePoints = null;
             _variableToTypeDesc = null;
+
+            _parameterIndexToNameMap = null;
+            _localSlotToInfoMap = null;
 #endif
             _debugLocInfos = null;
             _debugVarInfos = null;


### PR DESCRIPTION
Improves native compilation throughput by about 33%.

Validated that the output with multithreading enabled (the new default) is byte-by-byte identical with the output produced by `--singlethreaded` (new command line option to ILC that disables multithreading).

We still can do a lot more in terms of compilation throughput (virtual method resolution is really slow and runs in one of the single threaded phases, and the object writing phase is pretty slow too and is fully single threaded too).

Contributes to #3925 (what's left is the extra-credit stuff).