### PR TITLE
Fix exit code of build-native.sh

### DIFF
--- a/buildscripts/build-native.sh
+++ b/buildscripts/build-native.sh
@@ -83,10 +83,11 @@ build_native_corert()
     else
         make install -j $NumProc $__UnprocessedBuildArgs
     fi
-    if [ $? != 0 ]; then
+    EXITCODE=$?
+    if [ $EXITCODE != 0 ]; then
         echo "Failed to build corert native components."
         popd
-        exit $?
+        exit $EXITCODE
     fi
 
     echo "CoreRT native components successfully built."


### PR DESCRIPTION
I noticed it in the docker container, that the failed build was successfully committing the container (false positive).