### PR TITLE
Clean up portable thread pool for nullability and comment warnings

### DIFF
--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.ThreadCounts.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.ThreadCounts.cs
@@ -63,7 +63,7 @@ namespace System.Threading
 
             public static bool operator !=(ThreadCounts lhs, ThreadCounts rhs) => lhs._asLong != rhs._asLong;
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return obj is ThreadCounts counts && this._asLong == counts._asLong;
             }

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WaitThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WaitThread.cs
@@ -336,9 +336,9 @@ namespace System.Threading
             /// Process the completion of a user-registered wait (call the callback).
             /// </summary>
             /// <param name="state">A <see cref="CompletedWaitHandle"/> object representing the wait completion.</param>
-            private void CompleteWait(object state)
+            private void CompleteWait(object? state)
             {
-                CompletedWaitHandle handle = (CompletedWaitHandle)state;
+                CompletedWaitHandle handle = (CompletedWaitHandle)state!;
                 handle.CompletedHandle.PerformCallback(handle.TimedOut);
             }
 

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.WorkerThread.cs
@@ -195,13 +195,13 @@ namespace System.Threading
                 ThreadCounts counts = ThreadCounts.VolatileReadCounts(ref ThreadPoolInstance._separated.counts);
                 while (true)
                 {
-                    /// When there are more threads processing work than the thread count goal, hill climbing must have decided
-                    /// to decrease the number of threads. Stop processing if the counts can be updated. We may have more
-                    /// threads existing than the thread count goal and that is ok, the cold ones will eventually time out if
-                    /// the thread count goal is not increased again. This logic is a bit different from the original CoreCLR
-                    /// code from which this implementation was ported, which turns a processing thread into a retired thread
-                    /// and checks for pending requests like <see cref="RemoveWorkingWorker"/>. In this implementation there are
-                    /// no retired threads, so only the count of threads processing work is considered.
+                    // When there are more threads processing work than the thread count goal, hill climbing must have decided
+                    // to decrease the number of threads. Stop processing if the counts can be updated. We may have more
+                    // threads existing than the thread count goal and that is ok, the cold ones will eventually time out if
+                    // the thread count goal is not increased again. This logic is a bit different from the original CoreCLR
+                    // code from which this implementation was ported, which turns a processing thread into a retired thread
+                    // and checks for pending requests like RemoveWorkingWorker. In this implementation there are
+                    // no retired threads, so only the count of threads processing work is considered.
                     if (counts.numProcessingWork <= counts.numThreadsGoal)
                     {
                         return false;

--- a/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ClrThreadPool.cs
@@ -284,13 +284,13 @@ namespace System.Threading
             int elapsedInterval = Environment.TickCount - priorTime;
             if(elapsedInterval >= requiredInterval)
             {
-                /// Avoid trying to adjust the thread count goal if there are already more threads than the thread count goal.
-                /// In that situation, hill climbing must have previously decided to decrease the thread count goal, so let's
-                /// wait until the system responds to that change before calling into hill climbing again. This condition should
-                /// be the opposite of the condition in <see cref="WorkerThread.ShouldStopProcessingWorkNow"/> that causes
-                /// threads processing work to stop in response to a decreased thread count goal. The logic here is a bit
-                /// different from the original CoreCLR code from which this implementation was ported because in this
-                /// implementation there are no retired threads, so only the count of threads processing work is considered.
+                // Avoid trying to adjust the thread count goal if there are already more threads than the thread count goal.
+                // In that situation, hill climbing must have previously decided to decrease the thread count goal, so let's
+                // wait until the system responds to that change before calling into hill climbing again. This condition should
+                // be the opposite of the condition in WorkerThread.ShouldStopProcessingWorkNow that causes
+                // threads processing work to stop in response to a decreased thread count goal. The logic here is a bit
+                // different from the original CoreCLR code from which this implementation was ported because in this
+                // implementation there are no retired threads, so only the count of threads processing work is considered.
                 ThreadCounts counts = ThreadCounts.VolatileReadCounts(ref _separated.counts);
                 return counts.numProcessingWork <= counts.numThreadsGoal;
             }

--- a/src/System.Private.CoreLib/src/System/Threading/ThreadPool.Portable.cs
+++ b/src/System.Private.CoreLib/src/System/Threading/ThreadPool.Portable.cs
@@ -141,8 +141,7 @@ namespace System.Threading
                 }
 
                 UserUnregisterWaitHandle = waitObject?.SafeWaitHandle;
-                UserUnregisterWaitHandle?.DangerousAddRef();
-                needToRollBackRefCountOnException = true;
+                UserUnregisterWaitHandle?.DangerousAddRef(ref needToRollBackRefCountOnException);
 
                 UserUnregisterWaitHandleValue = UserUnregisterWaitHandle?.DangerousGetHandle() ?? IntPtr.Zero;
 
@@ -207,11 +206,7 @@ namespace System.Threading
                 if (handleValue != IntPtr.Zero && handleValue != (IntPtr)(-1))
                 {
                     Debug.Assert(handleValue == handle.DangerousGetHandle());
-#if PLATFORM_WINDOWS
-                    Interop.Kernel32.SetEvent(handle);
-#else
-                    WaitSubsystem.SetEvent(handleValue);
-#endif
+                    EventWaitHandle.Set(handle);
                 }
             }
             finally


### PR DESCRIPTION
Also, use `EventWaitHandle.Set` instead of `WaitSubsystem.SetEvent`/`Interop.Kernel32.SetEvent` to make it easier to port.