### PR TITLE
Add AppContext switch to not throw for Type.Name

### DIFF
--- a/Documentation/using-corert/reflection-free-mode.md
+++ b/Documentation/using-corert/reflection-free-mode.md
@@ -51,3 +51,15 @@ We might be able to add support for the following APIs without sacrificing too m
 * APIs that require dynamic code generation: `Reflection.Emit`, `Assembly.Load` and friends
 * Obvious program introspection APIs: APIs on `Type` and `Assembly` not mentioned above, `MethodBase`, `MethodInfo`, `ConstructorInfo`, `FieldInfo`, `PropertyInfo`, `EventInfo`. These APIs will throw at runtime.
 * APIs building on top of reflection APIs. Too many to enumerate.
+
+## Shimming
+
+Sometimes reflection is used in non-critical paths to retreive type names. In reflection-free mode, accessing type names throws an exception. To help moving such code to reflection-free mode, we have an AppContext switch to generate fake names and namespaces for types. With this mode enabled, accessing the `Name` and `Namespace` property will not throw, but won't return the actual name either.
+
+To enable this mode, add following item to an `ItemGroup` in your project file:
+
+```xml
+  <ItemGroup>
+    <AppContextSwitchOverrides Include="Switch.System.Reflection.Disabled.DoNotThrowForNames" />
+  </ItemGroup>
+```

--- a/Documentation/using-corert/reflection-free-mode.md
+++ b/Documentation/using-corert/reflection-free-mode.md
@@ -54,7 +54,7 @@ We might be able to add support for the following APIs without sacrificing too m
 
 ## Shimming
 
-Sometimes reflection is used in non-critical paths to retreive type names. In reflection-free mode, accessing type names throws an exception. To help moving such code to reflection-free mode, we have an AppContext switch to generate fake names and namespaces for types. With this mode enabled, accessing the `Name` and `Namespace` property will not throw, but won't return the actual name either.
+Sometimes reflection is used in non-critical paths to retrieve type names. In reflection-free mode, accessing type names throws an exception. To help moving such code to reflection-free mode, we have an AppContext switch to generate fake names and namespaces for types. With this mode enabled, accessing the `Name` and `Namespace` property will not throw, but won't return the actual name either.
 
 To enable this mode, add following item to an `ItemGroup` in your project file:
 

--- a/src/System.Private.DisabledReflection/src/Internal/Reflection/RuntimeTypeInfo.cs
+++ b/src/System.Private.DisabledReflection/src/Internal/Reflection/RuntimeTypeInfo.cs
@@ -22,12 +22,17 @@ namespace Internal.Reflection
             _typeHandle = typeHandle;
         }
 
+        private bool DoNotThrowForNames => AppContext.TryGetSwitch("Switch.System.Reflection.Disabled.DoNotThrowForNames", out bool doNotThrow) && doNotThrow;
+
         public override RuntimeTypeHandle TypeHandle => _typeHandle;
-        public override string Namespace => throw new NotSupportedException(SR.Reflection_Disabled);
+
+        public override string Name => DoNotThrowForNames ? RuntimeAugments.GetLastResortString(_typeHandle) : throw new NotSupportedException(SR.Reflection_Disabled);
+
+        public override string Namespace => DoNotThrowForNames ? "" : throw new NotSupportedException(SR.Reflection_Disabled);
+
+        public override string FullName => Name;
 
         public override string AssemblyQualifiedName => throw new NotSupportedException(SR.Reflection_Disabled);
-
-        public override string FullName => throw new NotSupportedException(SR.Reflection_Disabled);
 
         public override Assembly Assembly => throw new NotSupportedException(SR.Reflection_Disabled);
 
@@ -49,8 +54,6 @@ namespace Internal.Reflection
                 return null;
             }
         }
-
-        public override string Name => throw new NotSupportedException(SR.Reflection_Disabled);
 
         public override bool IsByRefLike => RuntimeAugments.IsByRefLike(_typeHandle);
 


### PR DESCRIPTION
Makes simple WinForms apps work in reflection-free mode without crashing.

https://github.com/dotnet/winforms/blob/5df2ebfe70f2eaa2733c7f21e7e9e20f0be7e766/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs#L4013