### PR TITLE
Scan for Marshal.SizeOf in reflection-disabled mode

### DIFF
--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -516,7 +516,7 @@ namespace ILCompiler
             }
             else
             {
-                metadataManager = new EmptyMetadataManager(typeSystemContext, stackTracePolicy);
+                metadataManager = new EmptyMetadataManager(typeSystemContext, stackTracePolicy, ilProvider);
             }
 
             InteropStateManager interopStateManager = new InteropStateManager(typeSystemContext.GeneratedAssembly);
@@ -558,7 +558,7 @@ namespace ILCompiler
                 {
                     // MetadataManager collects a bunch of state (e.g. list of compiled method bodies) that we need to reset.
                     Debug.Assert(metadataManager is EmptyMetadataManager);
-                    metadataManager = new EmptyMetadataManager(typeSystemContext, stackTracePolicy);
+                    metadataManager = new EmptyMetadataManager(typeSystemContext, stackTracePolicy, ilProvider);
                 }
 
                 interopStubManager = scanResults.GetInteropStubManager(interopStateManager, pinvokePolicy);


### PR DESCRIPTION
I tacked scanning for `Marshal.SizeOf(typeof(SomeType))` on the reflection method body scanner. It felt a bit dirty, but it worked and we no longer had to worry about not having interop marshalling data for these types at runtime if we saw the pattern at compile time.

But we would like to scan for this even in the reflection disabled mode, which makes this whole business a bit messier.

We'll probably want to plug this into the RyuJIT scanner at some point, but we'll need to think about scanning some more (whether scanning is just an optimization, or whether scanning is needed for correctness, how/whether would RyuJIT report parameters, etc.).