### PR TITLE
Only set dependency package versions if they're empty

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -1,16 +1,16 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RyuJITVersion>5.0.0-alpha1.19453.1</RyuJITVersion>
-    <ObjectWriterVersion>1.0.0-alpha-28204-03</ObjectWriterVersion>
-    <CoreFxVersion>5.0.0-alpha1.19457.4</CoreFxVersion>
-    <CoreFxUapVersion>4.7.0-preview6.19265.2</CoreFxUapVersion>
-    <MicrosoftNETCoreNativeVersion>5.0.0-alpha1.19453.1</MicrosoftNETCoreNativeVersion>
-    <MicrosoftNETCoreAppPackageVersion>2.1.11</MicrosoftNETCoreAppPackageVersion>
-    <MicrosoftDotNetTestSdkVersion>15.8.0</MicrosoftDotNetTestSdkVersion>
-    <XUnitPackageVersion>2.4.1-pre.build.4059</XUnitPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>2.4.0-beta.18420.4</MicrosoftDotNetXUnitExtensionsVersion>
-    <SystemReflectionMetadataVersion>1.4.3</SystemReflectionMetadataVersion>
-    <FeedTasksPackage>Microsoft.DotNet.Build.Tasks.Feed</FeedTasksPackage>
-    <FeedTasksPackageVersion>2.1.0-rc1-03905-01</FeedTasksPackageVersion>
+    <RyuJITVersion Condition="'$(RyuJITVersion)' == ''">5.0.0-alpha1.19453.1</RyuJITVersion>
+    <ObjectWriterVersion Condition="'$(ObjectWriterVersion)' == ''">1.0.0-alpha-28204-03</ObjectWriterVersion>
+    <CoreFxVersion Condition="'$(CoreFxVersion)' == ''">5.0.0-alpha1.19457.4</CoreFxVersion>
+    <CoreFxUapVersion Condition="'$(CoreFxUapVersion)' == ''">4.7.0-preview6.19265.2</CoreFxUapVersion>
+    <MicrosoftNETCoreNativeVersion Condition="'$(MicrosoftNETCoreNativeVersion)' == ''">5.0.0-alpha1.19453.1</MicrosoftNETCoreNativeVersion>
+    <MicrosoftNETCoreAppPackageVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)' == ''">2.1.11</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftDotNetTestSdkVersion Condition="'$(MicrosoftDotNetTestSdkVersion)' == ''">15.8.0</MicrosoftDotNetTestSdkVersion>
+    <XUnitPackageVersion Condition="'$(XUnitPackageVersion)' == ''">2.4.1-pre.build.4059</XUnitPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion Condition="'$(MicrosoftDotNetXUnitExtensionsVersion)' == ''">2.4.0-beta.18420.4</MicrosoftDotNetXUnitExtensionsVersion>
+    <SystemReflectionMetadataVersion Condition="'$(SystemReflectionMetadataVersion)' == ''">1.4.3</SystemReflectionMetadataVersion>
+    <FeedTasksPackage Condition="'$(FeedTasksPackage)' == ''">Microsoft.DotNet.Build.Tasks.Feed</FeedTasksPackage>
+    <FeedTasksPackageVersion Condition="'$(FeedTasksPackageVersion)' == ''">2.1.0-rc1-03905-01</FeedTasksPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hi! :wave:

This may not be a change you're interested in taking, but lately I've been playing with using local builds of various pieces of the .NET toolchain and have been having trouble finding a reasonable way to pull in my own build of `objwriter` based on a build of LLVM I've done previously.

By making these package versions conditionally set it becomes possible to specify them as environment variables when building `corert` without having to touch any of the other build scripts.