### PR TITLE
Wasm: Adds a test and a box for callvirt on value types where TryResolveCon…

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1979,7 +1979,6 @@ namespace Internal.IL
                         opcode = ILOpcode.call;
                         resolvedConstraint = true;
                     }
-                    //TODO can we switch to an ILOpcode.call as cpp does?
                 }
             }
 

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1964,8 +1964,7 @@ namespace Internal.IL
                     if (directMethod == null)
                     {
                         TypeDesc objectType = thisByRef.Type;
-                        var eeTypeDesc =
-                            _compilation.TypeSystemContext.SystemModule.GetKnownType("System", "EETypePtr");
+                        var eeTypeDesc = _compilation.TypeSystemContext.SystemModule.GetKnownType("System", "EETypePtr");
                         argumentValues[0] = CallRuntime(_compilation.TypeSystemContext, RuntimeExport, "RhBox",
                             new StackEntry[]
                             {

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -258,6 +258,8 @@ internal static class Program
         }
 
         TestConstrainedClassCalls();
+        
+        TestConstrainedStructCalls();
 
         TestValueTypeElementIndexing();
 
@@ -554,6 +556,21 @@ internal static class Program
         StartTest("Generic GetHashCode for unsealed class test");
         EndTest(hashCodeOfUnsealedViaGeneric == 82);
     }
+
+    static void TestConstrainedStructCalls()
+    {
+        StartTest("Constrained struct callvirt test");
+        EndTest("Program+ConstrainedStructTest" == new ConstrainedStructTest().ThisToString());
+    }
+
+    struct ConstrainedStructTest
+    {
+        internal string ThisToString()
+        {
+            return this.ToString();
+        }
+    }
+
 
     static uint GenericGetData<T>(T obj) where T : MyBase
     {


### PR DESCRIPTION
…straintMethodApprox does not return a method.

Constrained calls on value types to methods like ToString were not boxing the struct and hence failing.