### PR TITLE
Get System.Text.Json to work

### DIFF
--- a/src/Framework/Framework-uapaot.depproj
+++ b/src/Framework/Framework-uapaot.depproj
@@ -16,6 +16,11 @@
     <PackageReference Include="Microsoft.Private.CoreFx.UAP">
       <Version>$(CoreFxUapVersion)</Version>
     </PackageReference>
+
+    <!-- Grab UAP System.Text.Json because it doesn't rely on Reflection.Emit -->
+    <PackageReference Include="System.Text.Json">
+      <Version>4.6.0</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +35,9 @@
     <FileToInclude Include="System.Linq" />
 
     <FileToInclude Include="System.Private.Reflection.Metadata.Ecma335" />
+
+    <!-- Grab UAP System.Text.Json because it doesn't rely on Reflection.Emit -->
+    <FileToInclude Include="System.Text.Json" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Framework/Framework.depproj
+++ b/src/Framework/Framework.depproj
@@ -26,6 +26,11 @@
     <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp">
       <Version>$(CoreFxVersion)</Version>
     </PackageReference>
+
+    <!-- Needed by UAP System.Text.Json we grab in Framework-uapaot.depproj -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
+      <Version>1.0.0</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -37,6 +42,9 @@
 
     <!-- System.Linq in the aot-specific package is optimized for size -->
     <FileToExclude Include="System.Linq" />
+
+    <!-- Relies on Reflection.Emit - we take S.T.Json from UAP -->
+    <FileToExclude Include="System.Text.Json" />
 
     <!-- TODO: WinRT -->
     <FileToExclude Include="System.Runtime.InteropServices.WindowsRuntime" />


### PR DESCRIPTION
The System.Text.Json that ships with the .NET Core 3.0+ uses Reflection.Emit - we should grab the NetStandard 2.0 version instead.