### PR TITLE
Wasm: fix unsigned extend to uint64 and add test

### DIFF
--- a/Documentation/how-to-build-WebAssembly.md
+++ b/Documentation/how-to-build-WebAssembly.md
@@ -3,7 +3,7 @@
 ## Build WebAssembly on Windows ##
 
 1. Install Emscripten by following the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html). 
-2. Follow the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#updating-the-sdk) to update Emscripten to the latest version.
+2. Follow the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#updating-the-sdk) to update Emscripten to fastcomp 1.38.45 ```./emsdk install 1.38.45-fastcomp``` followed by ```./emsdk activate 1.38.45-fastcomp```
 3. Install [Firefox](https://www.getfirefox.com) (for testing).
 3. Get CoreRT set up by following the [Visual Studio instructions](how-to-build-and-run-ilcompiler-in-visual-studio.md).
 4. Build the WebAssembly runtime by running ```build.cmd wasm``` from the repo root.
@@ -37,7 +37,5 @@ This is Windows only for now.
 
 # Useful tips #
 * To manually make ILC compile to WebAssembly, add ```--wasm``` to the command line.
-* To debug C# source, add ```-g4``` to the emcc command line and change ```-s WASM=1``` to ```-s WASM=0```. This will generate a JavaScript source map that browser debuggers and Visual Studio Code can work with. Using Visual Studio Code's Chrome debugger works particularly well.
 * Add ```-g3``` to the emcc command line to generate more debuggable output and a .wast file with the text form of the WebAssembly.
-* Change ```-s WASM=1``` to ```-s WASM=0``` in the emcc command line to generate asm.js. Browser debuggers currently work better with asm.js and it's often a bit more readable than wast.
 * Add ```-O2 --llvm-lto 2``` to the emcc command line to enable optimizations. This makes the generated WebAssembly as much as 75% smaller as well as more efficient.

--- a/buildscripts/buildvars-setup.cmd
+++ b/buildscripts/buildvars-setup.cmd
@@ -94,7 +94,7 @@ if "%__BuildArch%"=="wasm" (
 )
 
 :CheckPrereqsEmscripten
-if not defined EMSCRIPTEN (
+if not defined EMSDK (
     echo Emscripten is a prerequisite to build for WebAssembly.
     echo See: https://github.com/dotnet/corert/blob/master/Documentation/how-to-build-WebAssembly.md
     exit /b 1

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -310,10 +310,10 @@ See the LICENSE file in the project root for more information.
       <EmccArgs Condition="'$(Configuration)'=='Debug'">$(EmccArgs) -g3</EmccArgs>
     </PropertyGroup>
     
-    <Exec Command="&quot;$(EMSCRIPTEN)\emcc.bat&quot; $(EmccArgs)" Condition="'$(NativeCodeGen)' == 'wasm' and '$(EMSCRIPTEN)' != '' and '$(OS)' == 'Windows_NT'" />
-    <Exec Command="&quot;$(EMSCRIPTEN)/emcc&quot; $(EmccArgs)" Condition="'$(NativeCodeGen)' == 'wasm' and '$(EMSCRIPTEN)' != '' and '$(OS)' != 'Windows_NT'" />
-    <Message Text="Emscripten not found, not linking WebAssembly. To enable WebAssembly linking, install Emscripten and ensure the EMSCRIPTEN environment variable points to the directory containing emcc.bat"
-             Condition="'$(NativeCodeGen)' == 'wasm' and '$(EMSCRIPTEN)' == ''" />
+    <Exec Command="&quot;$(EMSDK)/fastcomp/emscripten/emcc.bat&quot; $(EmccArgs)" Condition="'$(NativeCodeGen)' == 'wasm' and '$(EMSDK)' != '' and '$(OS)' == 'Windows_NT'" />
+    <Exec Command="&quot;$(EMSDK)/fastcomp/emscripten/emcc&quot; $(EmccArgs)" Condition="'$(NativeCodeGen)' == 'wasm' and '$(EMSDK)' != '' and '$(OS)' != 'Windows_NT'" />
+    <Message Text="Emscripten not found, not linking WebAssembly. To enable WebAssembly linking, install Emscripten and ensure the EMSDK environment variable points to the directory containing fastcomp/emscripten/emcc.bat"
+             Condition="'$(NativeCodeGen)' == 'wasm' and '$(EMSDK)' == ''" />
   </Target>
 
   <Target Name="CreateLib"

--- a/src/Native/gen-buildsys-win.bat
+++ b/src/Native/gen-buildsys-win.bat
@@ -25,7 +25,7 @@ for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& %~dp0
 
 :DoGen
 if "%3" == "wasm" (
-  emcmake "%CMakePath%" "-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=1" "-DCMAKE_TOOLCHAIN_FILE=%EMSCRIPTEN%/cmake/Modules/Platform/Emscripten.cmake" "-DCLR_CMAKE_TARGET_ARCH=%3" "-DCMAKE_BUILD_TYPE=%4" -G "NMake Makefiles" %1
+  emcmake "%CMakePath%" "-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=1" "-DCMAKE_TOOLCHAIN_FILE=%EMSDK%/fastcomp/emscripten/cmake/Modules/Platform/Emscripten.cmake" "-DCLR_CMAKE_TARGET_ARCH=%3" "-DCMAKE_BUILD_TYPE=%4" -G "NMake Makefiles" %1
 ) else (
   "%CMakePath%" "-DCLR_CMAKE_TARGET_ARCH=%3" "-DOBJWRITER_BUILD=%__ObjWriterBuild%" %__ExtraCmakeParams% -G "%__CmakeGenerator%" %1
 )

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -304,6 +304,8 @@ internal static class Program
 
         TestSByteExtend();
 
+        TestUlongUintMultiply();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -1049,6 +1051,15 @@ internal static class Program
 
         StartTest("Negative SByte br"); 
         EndTest(ILHelpers.ILHelpersTest.BneSbyteExtend());
+    }
+
+    internal static void TestUlongUintMultiply()
+    {
+        StartTest("Test ulong/int multiplication");
+        uint a = 0x80000000;
+        uint b = 2;
+        ulong f = ((ulong)a * b);
+        EndTest(f == 0x100000000);
     }
 
     [DllImport("*")]


### PR DESCRIPTION
This widening cast was failing, particular causing a problem in https://github.com/dotnet/corert/blob/8d81b96c2561fe00a0ac95a40e2dd19642971a5a/src/System.Private.CoreLib/shared/System/Number.DiyFp.cs#L77-L103.  

Added a test that failed previously and zext instead of sext for unsigned widening.  There is a parameter that I thought to use, but it is passed false here: https://github.com/dotnet/corert/blob/master/src/Common/src/TypeSystem/IL/ILImporter.cs#L574-L578.  Maybe that is wrong?

Also I updated emscripten, this wasn't necessary to fix this, but I got sidetracked with a build error and upgraded.  Its not a bad idea anyway as they changed the build tooling to allow for either the fastcomp or llvm backend and we will need to upgrade at some point.  If you just `git pull` emscripten you will hit a problem with the current scripts due to these changes.  Changed a bit of documentation to fit today's reality.