### PR TITLE
Fix `out string` arguments in reverse p/invoke

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
@@ -1434,7 +1434,7 @@ namespace Internal.TypeSystem.Interop
                                 Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemFree")));
         }
 
-        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        protected override void TransformManagedToNative(ILCodeStream codeStream)
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
 
@@ -1529,7 +1529,7 @@ namespace Internal.TypeSystem.Interop
                                 Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemFree")));
         }
 
-        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        protected override void TransformManagedToNative(ILCodeStream codeStream)
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
 
@@ -1616,7 +1616,7 @@ namespace Internal.TypeSystem.Interop
                                 Context.GetHelperEntryPoint("InteropHelpers", "CoTaskMemFree")));
         }
 
-        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        protected override void TransformManagedToNative(ILCodeStream codeStream)
         {
             ILEmitter emitter = _ilCodeStreams.Emitter;
 

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -146,6 +146,11 @@ namespace PInvokeTests
         static extern bool ReversePInvoke_String(Delegate_String del);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
+        delegate bool Delegate_OutString([MarshalAs(0x30)] out string s);
+        [DllImport("*", CallingConvention = CallingConvention.StdCall)]
+        static extern bool ReversePInvoke_OutString(Delegate_OutString del);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Ansi)]
         delegate bool Delegate_Array([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] int[] array, IntPtr sz);
         [DllImport("*", CallingConvention = CallingConvention.StdCall)]
         static extern bool ReversePInvoke_Array(Delegate_Array del);
@@ -592,6 +597,13 @@ namespace PInvokeTests
 
             Delegate_String ds = new Delegate_String((new ClosedDelegateCLass()).GetString);
             ThrowIfNotEquals(true, ReversePInvoke_String(ds), "Delegate marshalling failed.");
+
+            Delegate_OutString dos = new Delegate_OutString((out string x) =>
+            {
+                x = "Hello there!";
+                return true;
+            });
+            ThrowIfNotEquals(true, ReversePInvoke_OutString(dos), "Delegate string out marshalling failed.");
 
             Delegate_Array da = new Delegate_Array((new ClosedDelegateCLass()).CheckArray);
             ThrowIfNotEquals(true, ReversePInvoke_Array(da), "Delegate array marshalling failed.");

--- a/tests/src/Simple/PInvoke/PInvokeNative.cpp
+++ b/tests/src/Simple/PInvoke/PInvokeNative.cpp
@@ -336,6 +336,14 @@ DLL_EXPORT bool __stdcall ReversePInvoke_String(StringFuncPtr fnPtr)
     return fnPtr(str);
 }
 
+typedef bool(__stdcall *OutStringFuncPtr) (char **);
+DLL_EXPORT bool __stdcall ReversePInvoke_OutString(OutStringFuncPtr fnPtr)
+{
+    char *pResult;
+    fnPtr(&pResult);
+    return strcmp(pResult, "Hello there!") == 0;
+}
+
 typedef bool(__stdcall *ArrayFuncPtr) (int *, size_t sz);
 DLL_EXPORT bool __stdcall ReversePInvoke_Array(ArrayFuncPtr fnPtr)
 {


### PR DESCRIPTION
`EmitMarshalArgumentNativeToManaged` bypasses `AllocAndTransformManagedToNative` and calls `Alloc/TransformManagedToNative` directly. Those are no-ops for the string marshallers, leading to bad marshalling code.

I think doing allocation+transform in the "transform" part is what CoreCLR does as well (`EmitConvertContentsCLRToNative` is where allocation+transform happens for string marshallers in CoreCLR, as opposed to `EmitConvertSpaceAndContentsCLRToNative` which would be the right place based on its name).