### PR TITLE
Workaround use of internal reflection in Process.Start

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -60,8 +60,6 @@ See the LICENSE file in the project root for more information.
     </ItemGroup>
 
     <ItemGroup>
-      <!-- Workaround for https://github.com/dotnet/corert/issues/7000 -->
-      <IlcArg Include="--removefeature:CurlHandler" />
       <!-- libicu loader in System.Globalization.Native is not compatible with static linking -->
       <IlcArg Include="--removefeature:Globalization" Condition="'$(StaticallyLinked)' == 'true'" />
     </ItemGroup>

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -212,9 +212,6 @@ See the LICENSE file in the project root for more information.
 
       <!-- Workaround for https://github.com/dotnet/corefx/issues/36723 -->
       <IlcArg Include="--removefeature:SerializationGuard" />
-
-      <!-- Hitting a race conditions somewhere: https://github.com/dotnet/corert/issues/7852 -->
-      <IlcArg Include="--singlethreaded" />
       
       <!-- Comparers don't currently work with reflection disabled. https://github.com/dotnet/corert/pull/7208 -->
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--removefeature:Comparers" />

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -210,6 +210,9 @@ See the LICENSE file in the project root for more information.
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--removefeature:FrameworkStrings" />
       <IlcArg Condition="$(IlcInvariantGlobalization) == 'true'" Include="--removefeature:Globalization" />
 
+      <!-- Workaround for https://github.com/dotnet/corefx/issues/36723 -->
+      <IlcArg Include="--removefeature:SerializationGuard" />
+
       <!-- Hitting a race conditions somewhere: https://github.com/dotnet/corert/issues/7852 -->
       <IlcArg Include="--singlethreaded" />
       

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -471,8 +471,8 @@ namespace ILCompiler
                     removedFeatures |= RemovedFeature.Globalization;
                 else if (feature == "Comparers")
                     removedFeatures |= RemovedFeature.Comparers;
-                else if (feature == "CurlHandler")
-                    removedFeatures |= RemovedFeature.CurlHandler;
+                else if (feature == "SerializationGuard")
+                    removedFeatures |= RemovedFeature.SerializationGuard;
             }
 
             ILProvider ilProvider = new CoreRTILProvider();

--- a/src/ILCompiler/src/RemovingILProvider.cs
+++ b/src/ILCompiler/src/RemovingILProvider.cs
@@ -184,14 +184,14 @@ namespace ILCompiler
                 }
             }
 
-            if ((_removedFeature & RemovedFeature.CurlHandler) != 0)
-            {
-                if (owningType is Internal.TypeSystem.Ecma.EcmaType mdType
-                    && mdType.Module.Assembly.GetName().Name == "System.Net.Http"
-                    && mdType.Name == "CurlHandler"
-                    && mdType.Namespace == "System.Net.Http")
+            if ((_removedFeature & RemovedFeature.SerializationGuard) != 0)
+            {               
+                if (method.Name == "ThrowIfDeserializationInProgress" &&
+                    owningType is Internal.TypeSystem.Ecma.EcmaType mdType &&
+                    mdType.Namespace == "System.Runtime.Serialization" &&
+                    (mdType.Name == ((mdType.Module != method.Context.SystemModule) ? "SerializationGuard" : "SerializationInfo")))
                 {
-                    return RemoveAction.ConvertToThrow;
+                    return RemoveAction.ConvertToStub;
                 }
             }
 
@@ -246,6 +246,6 @@ namespace ILCompiler
         FrameworkResources = 0x2,
         Globalization = 0x4,
         Comparers = 0x8,
-        CurlHandler = 0x10,
+        SerializationGuard = 0x10,
     }
 }


### PR DESCRIPTION
- Add SerializationGuard removed feature and enabled it by default.
- Removed CurlHandler removed feature. CurlHandler was removed from the framework and it is no longer needed.