### PR TITLE
Port diff from dotnet/runtime#777

### DIFF
--- a/src/Common/src/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
@@ -31,11 +31,11 @@ namespace Internal.TypeSystem
         /// Sentinel value used to represent that a slot in the hashtable is reserved
         /// for use by a writer thread. Readers must treat discovery of a sentinel as
         /// not finding an entry, and other writer threads must do so as well, and the
-        /// Expand thread (if active) must treat discovery of a sentinel as a reason to 
+        /// Expand thread (if active) must treat discovery of a sentinel as a reason to
         /// yield execution until the sentinel is either written over with a null (indicating
         /// that the write is aborted), or over with a non-sentinel value (indicating
         /// the new value to be copied to the expanded hash table)
-        /// 
+        ///
         /// In addition to serving as the sentinel, it is also the first item added, to
         /// avoid needing to have a unique valid sentinel value
         /// </summary>
@@ -288,6 +288,9 @@ namespace Internal.TypeSystem
                 // Work in a local variable to avoid lots of unnecessary volatile reads of _newHashTable since only this method can
                 // change it and we're under a lock
                 TValue[] newHashTable = new TValue[newSize];
+                // This is a rare "read-after-write" case where even x64/x86 needs fences.
+                // We must ensure that the publishing of _newHashTable happens before we read the first table
+                // entry from the pov of an external observer
                 Interlocked.Exchange(ref _newHashTable, newHashTable);
                 // Due to the volatile write above, any adds on other threads after this point will
                 // fail and be redone, thus writing to the new hash table.
@@ -490,7 +493,7 @@ namespace Internal.TypeSystem
 
             // Now that we've written to the local array, find out if that array has been
             // replaced by expansion. If it has, we need to restart and write to the new array.
-            if (Interlocked.CompareExchange(ref _newHashTable, hashTableLocal, hashTableLocal) != hashTableLocal)
+            if (_newHashTable != hashTableLocal)
             {
                 WriteAbortNullToLocation(hashTableLocal, tableIndex);
 

--- a/src/Common/src/TypeSystem/Common/Utilities/LockFreeReaderHashtableOfPointers.cs
+++ b/src/Common/src/TypeSystem/Common/Utilities/LockFreeReaderHashtableOfPointers.cs
@@ -445,7 +445,7 @@ namespace Internal.TypeSystem
 
             // Now that we've written to the local array, find out if that array has been
             // replaced by expansion. If it has, we need to restart and write to the new array.
-            if (Interlocked.CompareExchange(ref _newHashTable, hashTableLocal, hashTableLocal) != hashTableLocal)
+            if (_newHashTable != hashTableLocal)
             {
                 WriteAbortNullToLocation(hashTableLocal, tableIndex);
                 // Pulse the lock so we don't spin during an expansion


### PR DESCRIPTION
dotnet/runtime#777 and #7906 did not check in identical diffs.

Making sure the change to HashtableOfPointer doesn't get lost since that file doesn't exist in the runtime repo.