### PR TITLE
Allow shimming Assembly.GetCallingAssembly

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreRT.cs
@@ -18,7 +18,13 @@ namespace System.Reflection
         [System.Runtime.CompilerServices.Intrinsic]
         public static Assembly GetExecutingAssembly() { throw NotImplemented.ByDesign; } //Implemented by toolchain. 
 
-        public static Assembly GetCallingAssembly() { throw new PlatformNotSupportedException(); }
+        public static Assembly GetCallingAssembly()
+        {
+            if (AppContext.TryGetSwitch("Switch.System.Reflection.Assembly.SimulatedCallingAssembly", out bool isSimulated) && isSimulated)
+                return GetEntryAssembly();
+
+            throw new PlatformNotSupportedException();
+        }
 
         public static Assembly Load(AssemblyName assemblyRef) => ReflectionAugments.ReflectionCoreCallbacks.Load(assemblyRef, throwOnFileNotFound: true);
 


### PR DESCRIPTION
For EXE-style projects this will make it look like we have a super advanced inliner that inlined the entire app. Not sure what to return when compiling as a library.

Hit in WPF that uses this API for dumb reasons (it goes to assembly Location next and then goes sniffing on the file system).