### PR TITLE
Wasm:support initialization of md arrays

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1488,8 +1488,7 @@ namespace Internal.IL
                 _stack.Pop()
             };
 
-            TypeDesc stackType = type.IsValueType ? type.MakePointerType() : type;
-            _stack.Push(CallRuntime(_compilation.TypeSystemContext, TypeCast, function, arguments, stackType));
+            _stack.Push(CallRuntime(_compilation.TypeSystemContext, TypeCast, function, arguments, GetWellKnownType(WellKnownType.Object)));
         }
 
         private void ImportLoadNull()

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1474,13 +1474,13 @@ namespace Internal.IL
             
             //TODO: call GetCastingHelperNameForType from JitHelper.cs (needs refactoring)
             string function;
-            bool throwing = opcode == ILOpcode.castclass;
+            bool isCastClass = opcode == ILOpcode.castclass;
             if (type.IsArray)
-                function = throwing ? "CheckCastArray" : "IsInstanceOfArray";
+                function = isCastClass ? "CheckCastArray" : "IsInstanceOfArray";
             else if (type.IsInterface)
-                function = throwing ? "CheckCastInterface" : "IsInstanceOfInterface";
+                function = isCastClass ? "CheckCastInterface" : "IsInstanceOfInterface";
             else
-                function = throwing ? "CheckCastClass" : "IsInstanceOfClass";
+                function = isCastClass ? "CheckCastClass" : "IsInstanceOfClass";
 
             var arguments = new StackEntry[]
             {
@@ -1488,7 +1488,8 @@ namespace Internal.IL
                 _stack.Pop()
             };
 
-            _stack.Push(CallRuntime(_compilation.TypeSystemContext, TypeCast, function, arguments, type));
+            // don't force the return type fo isinst.  If the type is a struct and the argument a boxed struct, then it would not be correct.
+            _stack.Push(CallRuntime(_compilation.TypeSystemContext, TypeCast, function, arguments, isCastClass ? type : null));
         }
 
         private void ImportLoadNull()
@@ -1852,38 +1853,44 @@ namespace Internal.IL
 
                         LLVMValueRef src = LoadAddressOfSymbolNode(fieldNode);
                         _dependencies.Add(fieldNode);
-                        int srcLength = fieldNode.GetData(_compilation.NodeFactory, false).Data.Length;
+                        var fieldData = fieldNode.GetData(_compilation.NodeFactory, false).Data;
+                        int srcLength = fieldData.Length;
 
-                        if (arraySlot.Type.IsSzArray)
+                        if (arraySlot.Type.IsSzArray || arraySlot.Type.IsMdArray)
                         {
-                            // Handle single dimensional arrays (vectors).
+                            // Handle single dimensional arrays (vectors) and multidimensional.
                             LLVMValueRef arrayObjPtr = arraySlot.ValueAsType(LLVM.PointerType(LLVM.Int8Type(), 0), _builder);
 
                             var argsType = new LLVMTypeRef[]
                             {
-                            LLVM.PointerType(LLVM.Int8Type(), 0),
-                            LLVM.PointerType(LLVM.Int8Type(), 0),
-                            LLVM.Int32Type(),
-                            LLVM.Int32Type(),
-                            LLVM.Int1Type()
+                                LLVM.PointerType(LLVM.Int8Type(), 0),
+                                LLVM.PointerType(LLVM.Int8Type(), 0),
+                                LLVM.Int32Type(),
+                                LLVM.Int32Type(),
+                                LLVM.Int1Type()
                             };
                             LLVMValueRef memcpyFunction = GetOrCreateLLVMFunction("llvm.memcpy.p0i8.p0i8.i32", LLVM.FunctionType(LLVM.VoidType(), argsType, false));
 
+                            LLVMValueRef offset;
+                            if (arraySlot.Type.IsSzArray)
+                            {
+                                offset = ArrayBaseSizeRef();
+                            }
+                            else
+                            {
+                                ArrayType arrayType = (ArrayType)arraySlot.Type;
+                                offset = BuildConstInt32(ArrayBaseSize() +
+                                                         2 * sizeof(int) * arrayType.Rank);
+                            }
                             var args = new LLVMValueRef[]
                             {
-                            LLVM.BuildGEP(_builder, arrayObjPtr, new LLVMValueRef[] { ArrayBaseSize() }, string.Empty),
-                            LLVM.BuildBitCast(_builder, src, LLVM.PointerType(LLVM.Int8Type(), 0), string.Empty),
-                            BuildConstInt32(srcLength), // TODO: Handle destination array length to avoid runtime overflow.
-                            BuildConstInt32(0), // Assume no alignment
-                            BuildConstInt1(0)
+                                LLVM.BuildGEP(_builder, arrayObjPtr, new LLVMValueRef[] { offset }, string.Empty),
+                                LLVM.BuildBitCast(_builder, src, LLVM.PointerType(LLVM.Int8Type(), 0), string.Empty),
+                                BuildConstInt32(srcLength), // TODO: Handle destination array length to avoid runtime overflow.
+                                BuildConstInt32(0), // Assume no alignment
+                                BuildConstInt1(0)
                             };
                             LLVM.BuildCall(_builder, memcpyFunction, args, string.Empty);
-                        }
-                        else if (arraySlot.Type.IsMdArray)
-                        {
-                            // Handle multidimensional arrays.
-                            // TODO: Add support for multidimensional array.
-                            throw new NotImplementedException();
                         }
                         else
                         {
@@ -2008,10 +2015,11 @@ namespace Internal.IL
 
             bool needsReturnSlot = NeedsReturnStackSlot(signature);
             SpilledExpressionEntry returnSlot = null;
+            var actualReturnType = forcedReturnType ?? returnType;
             if (needsReturnSlot)
             {
                 int returnIndex = _spilledExpressions.Count;
-                returnSlot = new SpilledExpressionEntry(GetStackValueKind(returnType), callee?.Name + "_return", returnType, returnIndex, this);
+                returnSlot = new SpilledExpressionEntry(GetStackValueKind(actualReturnType), callee?.Name + "_return", actualReturnType, returnIndex, this);
                 _spilledExpressions.Add(returnSlot);
                 returnAddress = LoadVarAddress(returnIndex, LocalVarKind.Temp, out TypeDesc unused);
                 castReturnAddress = LLVM.BuildPointerCast(_builder, returnAddress, LLVM.PointerType(LLVM.Int8Type(), 0), callee?.Name + "_castreturn");
@@ -2085,7 +2093,7 @@ namespace Internal.IL
                 }
                 else
                 {
-                    return new ExpressionEntry(GetStackValueKind(returnType), callee?.Name + "_return", llvmReturn, returnType);
+                    return new ExpressionEntry(GetStackValueKind(actualReturnType), callee?.Name + "_return", llvmReturn, actualReturnType);
                 }
             }
             else
@@ -3536,9 +3544,14 @@ namespace Internal.IL
             PushNonNull(CallRuntime(_compilation.TypeSystemContext, InternalCalls, "RhpNewArray", arguments, arrayType));
         }
 
-        private LLVMValueRef ArrayBaseSize()
+        private LLVMValueRef ArrayBaseSizeRef()
         {
-            return BuildConstInt32(2 * _compilation.NodeFactory.Target.PointerSize);
+            return BuildConstInt32(ArrayBaseSize());
+        }
+
+        private int ArrayBaseSize()
+        {
+            return 2 * _compilation.NodeFactory.Target.PointerSize;
         }
 
         private void ImportLoadElement(int token)
@@ -3594,7 +3607,7 @@ namespace Internal.IL
             ThrowIfNull(arrayReference);
             var elementSize = arrayElementType.GetElementSize();
             LLVMValueRef elementOffset = LLVM.BuildMul(_builder, elementPosition, BuildConstInt32(elementSize.AsInt), "elementOffset");
-            LLVMValueRef arrayOffset = LLVM.BuildAdd(_builder, elementOffset, ArrayBaseSize(), "arrayOffset");
+            LLVMValueRef arrayOffset = LLVM.BuildAdd(_builder, elementOffset, ArrayBaseSizeRef(), "arrayOffset");
             return LLVM.BuildGEP(_builder, arrayReference, new LLVMValueRef[] { arrayOffset }, "elementPointer");
         }
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -228,7 +228,7 @@ internal static class Program
         testMdArrayInstantiation[0, 1] = 2;
         testMdArrayInstantiation[1, 0] = 3;
         testMdArrayInstantiation[1, 1] = 4;
-        EndTest(testMdArrayInstantiation[0, 0] == 1 
+        EndTest(testMdArrayInstantiation[0, 0] == 1
                 && testMdArrayInstantiation[0, 1] == 2
                 && testMdArrayInstantiation[1, 0] == 3
                 && testMdArrayInstantiation[1, 1] == 4);
@@ -258,7 +258,7 @@ internal static class Program
         }
 
         TestConstrainedClassCalls();
-        
+
         TestConstrainedStructCalls();
 
         TestValueTypeElementIndexing();
@@ -306,6 +306,8 @@ internal static class Program
 
         TestUlongUintMultiply();
 
+        TestInitializeArray();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -344,7 +346,7 @@ internal static class Program
     }
 
     private static int StaticDelegateTarget()
-    {         
+    {
         return 7;
     }
 
@@ -361,7 +363,7 @@ internal static class Program
             }
         }
     }
-    
+
     public static void PrintLine(string s)
     {
         PrintString(s);
@@ -397,21 +399,21 @@ internal static class Program
     {
         return a >> b;
     }
-    
+
     private static int SwitchOp(int a, int b, int mode)
     {
-        switch(mode)
+        switch (mode)
         {
-          case 0:
-            return a + b;
-          case 1:
-            return a * b;
-          case 2:
-            return a / b;
-          case 3:
-            return a - b;
-          default:
-            return 0;
+            case 0:
+                return a + b;
+            case 1:
+                return a * b;
+            case 2:
+                return a / b;
+            case 3:
+                return a - b;
+            default:
+                return 0;
         }
     }
 
@@ -443,16 +445,16 @@ internal static class Program
         StartTest("ldind test");
         var ldindTarget = new TwoByteStr { first = byte.MaxValue, second = byte.MinValue };
         var ldindField = &ldindTarget.first;
-        if((*ldindField) == byte.MaxValue)
+        if ((*ldindField) == byte.MaxValue)
         {
             ldindTarget.second = byte.MaxValue;
             *ldindField = byte.MinValue;
             //ensure there isnt any overwrite of nearby fields
-            if(ldindTarget.first == byte.MinValue && ldindTarget.second == byte.MaxValue)
+            if (ldindTarget.first == byte.MinValue && ldindTarget.second == byte.MaxValue)
             {
                 PassTest();
             }
-            else if(ldindTarget.first != byte.MinValue)
+            else if (ldindTarget.first != byte.MinValue)
             {
                 FailTest("didnt update target.");
             }
@@ -527,7 +529,7 @@ internal static class Program
             PrintString(stringDirectToString);
             PrintLine("\"");
         }
-       
+
         // Generic calls on methods not defined on object
         uint dataFromBase = GenericGetData<MyBase>(new MyBase(11));
         StartTest("Generic call to base class test");
@@ -723,7 +725,7 @@ internal static class Program
 
         StartTest("Type GetFields length");
         var x = new ClassForMetaTests();
-        var s = x.StringField;  
+        var s = x.StringField;
         var i = x.IntField;
         var classForMetaTestsType = typeof(ClassForMetaTests);
         FieldInfo[] fields = classForMetaTestsType.GetFields();
@@ -771,8 +773,8 @@ internal static class Program
 
         StartTest("Class get+invoke simple method via reflection");
         var mtd = classForMetaTestsType.GetMethod("ReturnTrueIf1");
-        bool shouldBeTrue = (bool)mtd.Invoke(instance, new object[] {1});
-        bool shouldBeFalse = (bool)mtd.Invoke(instance, new object[] {2});
+        bool shouldBeTrue = (bool)mtd.Invoke(instance, new object[] { 1 });
+        bool shouldBeFalse = (bool)mtd.Invoke(instance, new object[] { 2 });
         EndTest(shouldBeTrue && !shouldBeFalse);
 
         StartTest("Class get+invoke method with ref param via reflection");
@@ -1029,7 +1031,7 @@ internal static class Program
 
         StartTest("SByte left shift");
         x = (int)(s << 1);
-        if(x == -2)
+        if (x == -2)
         {
             PassTest();
         }
@@ -1040,7 +1042,7 @@ internal static class Program
 
         sbyte minus1 = -1;
         StartTest("Negative SByte op");
-        if((s & minus1) == -1)
+        if ((s & minus1) == -1)
         {
             PassTest();
         }
@@ -1049,7 +1051,7 @@ internal static class Program
             FailTest();
         }
 
-        StartTest("Negative SByte br"); 
+        StartTest("Negative SByte br");
         EndTest(ILHelpers.ILHelpersTest.BneSbyteExtend());
     }
 
@@ -1060,6 +1062,37 @@ internal static class Program
         uint b = 2;
         ulong f = ((ulong)a * b);
         EndTest(f == 0x100000000);
+    }
+
+    static void TestInitializeArray()
+    {
+        StartTest("Test InitializeArray");
+
+        bool[,] bools = new bool[2, 2] {
+            {  true,                        true},
+            {  false,                       true},
+        };
+
+        if (!(bools[0, 0] && bools[0, 1]
+            && !bools[1, 0] && bools[0, 1]))
+        {
+            FailTest("bool initialisation failed");
+        }
+
+        double[,] doubles = new double[2, 3]
+        {
+            {1.0, 1.1, 1.2 },
+            {2.0, 2.1, 2.2 },
+        };
+
+        if (!(doubles[0, 0] == 1.0 && doubles[0, 1] == 1.1 && doubles[0, 2] == 1.2
+            && doubles[1, 0] == 2.0 && doubles[1, 1] == 2.1 && doubles[1, 2] == 2.2
+            ))
+        {
+            FailTest("double initialisation failed");
+        }
+
+        PassTest();
     }
 
     [DllImport("*")]


### PR DESCRIPTION
Adds a test (previously failing) and support for initializing multidimensional arrays such as
```
        double[,] doubles = new double[2, 3]
        {
            {1.0, 1.1, 1.2 },
            {2.0, 2.1, 2.2 },
        };
```
Fixes #7921 