### PR TITLE
Set TRYRUN_OUTPUT in set_cache_value macro

### DIFF
--- a/cross/tryrun.cmake
+++ b/cross/tryrun.cmake
@@ -2,6 +2,7 @@ set(TARGET_ARCH_NAME $ENV{TARGET_BUILD_ARCH})
 
 macro(set_cache_value)
   set(${ARGV0} ${ARGV1} CACHE STRING "Result from TRY_RUN" FORCE)
+  set(${ARGV0}__TRYRUN_OUTPUT "dummy output" CACHE STRING "Output from TRY_RUN" FORCE)
 endmacro()
 
 if(NOT TARGET_ARCH_NAME MATCHES "^(armel|arm|arm64|x86)$")

--- a/src/Native/gen-buildsys-clang.sh
+++ b/src/Native/gen-buildsys-clang.sh
@@ -117,7 +117,11 @@ if [[ -n "$CROSSCOMPILE" ]]; then
     cmake_extra_defines="$cmake_extra_defines -DCMAKE_TOOLCHAIN_FILE=$CONFIG_DIR/toolchain.cmake"
 fi
 
-if [ $build_arch == "wasm" ]; then
+if [ "${__ObjWriterBuild}" = 1 ]; then
+    cmake_extra_defines="$cmake_extra_defines -DOBJWRITER_BUILD=${__ObjWriterBuild} -DCROSS_BUILD=${__CrossBuild}"
+fi
+
+if [ "$build_arch" = "wasm" ]; then
     emcmake $CMAKE \
         "-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=1" \
         "-DCMAKE_TOOLCHAIN_FILE=$EMSCRIPTEN/cmake/Modules/Platform/Emscripten.cmake" \
@@ -133,8 +137,6 @@ else
         "-DCMAKE_RANLIB=$llvm_ranlib" \
         "-DCMAKE_BUILD_TYPE=$build_type" \
         "-DCLR_CMAKE_TARGET_ARCH=$build_arch" \
-        "-DOBJWRITER_BUILD=${__ObjWriterBuild}" \
-        "-DCROSS_BUILD=${__CrossBuild}" \
         $cmake_extra_defines \
         "$1/src/Native"
 fi


### PR DESCRIPTION
Also fix cmake warning about unused variable by conditionally including it.
Warning is appearing in every build for sometime, [e.g.](https://dev.azure.com/dnceng/public/_build/results?buildId=467504&view=logs&j=9d9bed24-aafc-5ca0-72eb-d60e686a8d72&t=a99ab234-d192-591f-6b8f-e2800dd13d29&l=117)

Followup on https://github.com/dotnet/corert/pull/7899#issuecomment-565599126
Contributes to: #4589