### PR TITLE
Implement Windows x86 name mangling

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -791,9 +791,10 @@ namespace ILCompiler.DependencyAnalysis
 
         private void AppendExternCPrefix(Utf8StringBuilder sb)
         {
-            if (_targetPlatform.OperatingSystem == TargetOS.OSX)
+            if (_targetPlatform.IsOSX ||
+                (_targetPlatform.IsWindows && _targetPlatform.Architecture == TargetArchitecture.X86))
             {
-                // On OSX, we need to prefix an extra underscore to account for correct linkage of 
+                // On OSX and Windows x86, we need to prefix an extra underscore to account for correct linkage of
                 // extern "C" functions.
                 sb.Append('_');
             }
@@ -938,7 +939,7 @@ namespace ILCompiler.DependencyAnalysis
             if (_isSingleFileCompilation)
                 return false;
 
-            if (_targetPlatform.OperatingSystem == TargetOS.OSX)
+            if (_targetPlatform.IsOSX)
                 return false;
 
             if (!(node is ISymbolNode))

--- a/src/ILCompiler.Compiler/src/Compiler/NodeMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/NodeMangler.cs
@@ -27,5 +27,10 @@ namespace ILCompiler
         public abstract string ThreadStatics(TypeDesc type);
         public abstract string TypeGenericDictionary(TypeDesc type);
         public abstract string MethodGenericDictionary(MethodDesc method);
+
+        public virtual string ExternMethod(string unmangledName, MethodSignature method)
+        {
+            return unmangledName;
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/WindowsNodeMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/WindowsNodeMangler.cs
@@ -63,5 +63,20 @@ namespace ILCompiler
         {
             return GenericDictionaryNamePrefix + NameMangler.GetMangledMethodName(method);
         }
+
+        public override string ExternMethod(string unmangledName, MethodSignature signature)
+        {
+            TargetDetails target = signature.Context.Target;
+            if (target.Architecture != TargetArchitecture.X86)
+                return unmangledName;
+
+            int signatureBytes = 0;
+            foreach (var p in signature)
+            {
+                signatureBytes += AlignmentHelper.AlignUp(p.GetElementSize().AsInt, target.PointerSize);
+            }
+
+            return string.Concat(unmangledName, "@", signatureBytes.ToString());
+        }
     }
 }

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1550,6 +1550,8 @@ namespace Internal.JitInterface
             string externName = md.GetPInvokeMethodMetadata().Name ?? md.Name;
             Debug.Assert(externName != null);
 
+            externName = _compilation.NodeFactory.NameMangler.NodeMangler.ExternMethod(externName, md.Signature);
+
             pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ExternSymbol(externName));
         }
 


### PR DESCRIPTION
So far CoreRT only had to deal with platforms that have straightforward mangling for `extern "C"` symbols (which is what we shoot for in CoreRT).

Windows x86 stdcall calling convention does the weird thing where `@XXX` is appended to symbol names (where XXX is the number of bytes of arguments to the method).

This pull request implements enough of what's needed to get p/invokes up and running.

I'm marking it as draft because we probably want to make a decision on how to mangle our symbol definitions too (right now this only does something for p/invoke references).