### PR TITLE
Wasm: fix for implicit ext of UInt16 to UInt32

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -446,8 +446,7 @@ namespace Internal.IL
 
         protected override LLVMValueRef ValueAsTypeInternal(LLVMTypeRef type, LLVMBuilderRef builder, bool signExtend)
         {
-            //TODO: deal with sign extension here
-            return ILImporter.CastIfNecessary(builder, RawLLVMValue, type, Name);
+            return ILImporter.CastIfNecessary(builder, RawLLVMValue, type, Name, !signExtend);
         }
     }
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -323,6 +323,8 @@ internal static class Program
 
         TestInitializeArray();
 
+        TestImplicitUShortToUInt();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -1215,6 +1217,18 @@ internal static class Program
         PassTest();
     }
 
+    static void TestImplicitUShortToUInt()
+    {
+        StartTest("test extend of shorts with MSB set");
+        uint start;
+        start = ReadUInt16();
+        EndTest(start == 0x0000828f);
+    }
+
+    static ushort ReadUInt16()
+    {
+        return 0x828f;
+    }
     [DllImport("*")]
     private static unsafe extern int printf(byte* str, byte* unused);
 }

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1227,8 +1227,10 @@ internal static class Program
 
     static ushort ReadUInt16()
     {
+        // something with MSB set
         return 0x828f;
     }
+
     [DllImport("*")]
     private static unsafe extern int printf(byte* str, byte* unused);
 }


### PR DESCRIPTION
Previously this was doing a sext resulting in left filling with the MSB of the UInt16.  This change adds a test for this and fixes it.