### PR TITLE
Disable the "Update versions repository" step

### DIFF
--- a/buildpipeline/DotNet-CoreRT-Publish.json
+++ b/buildpipeline/DotNet-CoreRT-Publish.json
@@ -178,7 +178,7 @@
       }
     },
     {
-      "enabled": true,
+      "enabled": false,
       "continueOnError": false,
       "alwaysRun": false,
       "displayName": "Update versions repository",


### PR DESCRIPTION
This step has been failing for months. It's a nuisance because it also makes the official build show as failed. All we care about is publishing NuGet packages and that happens before this step.