### PR TITLE
Use plain clang by default on Linux

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y install git procps lsb-release
 # ***********************************
 # * Install stuff needed for CoreRT *
 # ***********************************
-RUN apt-get -y install cmake clang-3.9 libicu-dev uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev wget
+RUN apt-get -y install cmake clang libicu-dev uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev wget
 
 # Clean up
 RUN apt-get autoremove -y \

--- a/Documentation/intro-to-corert.md
+++ b/Documentation/intro-to-corert.md
@@ -24,7 +24,7 @@ CoreRT offers great benefits that are critical for many apps.
 These benefits open up some new scenarios for .NET developers
 
 - Copy a single file executable from one machine and run on another (of the same kind) without installing a .NET runtime.
-- Create and run a docker image that contains a single file executable (e.g. one file in addition to Ubuntu 14.04).
+- Create and run a docker image that contains a single file executable (e.g. one file in addition to Ubuntu).
 
 Roadmap
 =======

--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -11,17 +11,8 @@ PowerShell also needs to be available from the PATH environment variable (it's t
 
 # Ubuntu (16.04+)
 
-Install basic dependency packages:
-
-First add a new package source to be able to install clang-3.9:
 ```sh
-echo "deb http://llvm.org/apt/xenial/ llvm-toolchain-xenial-3.9 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-get update
-```
-
-```sh
-sudo apt-get install cmake clang-3.9 libicu-dev uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev libtinfo5
+sudo apt-get install cmake clang libicu-dev uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev libtinfo5
 ```
 
 # macOS (10.12+)
@@ -52,17 +43,17 @@ Make sure you run with Ubuntu 16.04 Xenial userland (this is the default after W
 
 Then follow the Ubuntu 16.04 instructions above.
 
-# clang 3.9 not found on Linux
+# clang not found on Linux
 
 If you encounter this error, CoreRT could not find the clang executable
 ```
-error : Platform linker ('clang-3.9') not found. Try installing clang-3.9 or the appropriate package for your platform to resolve the problem.
+error : Platform linker ('clang') not found. Try installing clang package for your platform to resolve the problem.
 ```
 
-CoreRT expect by default clang-3.9 installed (see above). You can override this by setting an environment variable.
+You can override the default name by setting an environment variable. This is useful when clang executable on your platform has version specific suffix.
 
 ```
-export CppCompilerAndLinker=clang
+export CppCompilerAndLinker=clang-3.9
 ```
 
 This works for building CoreCR itself as well as building with CoreRT.

--- a/buildscripts/buildvars-setup.sh
+++ b/buildscripts/buildvars-setup.sh
@@ -157,9 +157,6 @@ if [ -z "$__ClangMajorVersion" ] || [ -z "$__ClangMinorVersion" ]; then
     if [ -x "$(command -v clang)" ]; then
         export __ClangMajorVersion="$(echo | clang -dM -E - | grep __clang_major__ | cut -f3 -d ' ')"
         export __ClangMinorVersion="$(echo | clang -dM -E - | grep __clang_minor__ | cut -f3 -d ' ')"
-        if [ "${__HostOS}" != "OSX" ]; then
-            export CppCompilerAndLinker=clang
-        fi
     else
         export __ClangMajorVersion=3
         export __ClangMinorVersion=9

--- a/samples/prerequisites.md
+++ b/samples/prerequisites.md
@@ -12,7 +12,7 @@ The following pre-requisites need to be installed for building .NET Core project
 * Install clang and developer packages for libraries that .NET Core depends on.
 
 ```sh
-sudo apt-get install clang-3.9 zlib1g-dev libkrb5-dev libtinfo5
+sudo apt-get install clang zlib1g-dev libkrb5-dev libtinfo5
 ```
 
 # macOS (10.12+)

--- a/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -15,22 +15,12 @@ See the LICENSE file in the project root for more information.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == '' and '$(TargetOS)' == 'OSX'">clang</CppCompilerAndLinker>
-    <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang-3.9</CppCompilerAndLinker>
+    <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang</CppCompilerAndLinker>
     <CppCompiler>$(CppCompilerAndLinker)</CppCompiler>
     <CppLinker>$(CppCompilerAndLinker)</CppLinker>
     <CppLibCreator>ar</CppLibCreator>
   </PropertyGroup>
   
-  <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->
-  <!-- Ensure that runtime-specific paths have already been set -->
-  <PropertyGroup>
-    <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == '' and '$(TargetOS)' == 'OSX'">clang</CppCompilerAndLinker>
-    <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang-3.9</CppCompilerAndLinker>
-    <CppCompiler>$(CppCompilerAndLinker)</CppCompiler>
-    <CppLinker>$(CppCompilerAndLinker)</CppLinker>
-    <CppLibCreator>ar</CppLibCreator>
-  </PropertyGroup>
   <Target Name="SetupOSSpecificProps" DependsOnTargets="$(IlcDynamicBuildPropertyDependencies)">
 
     <PropertyGroup>

--- a/tests/testenv.sh
+++ b/tests/testenv.sh
@@ -92,6 +92,11 @@ if [ "$__BuildArch" == "wasm" ]; then
     export CoreRT_BuildOS=WebAssembly
 fi
 
+# Workardound for CI images without clang alias
+if [ "${CoreRT_BuildOS}" == "Linux" ] && [ -z "$CppCompilerAndLinker" ] && [ ! -x "$(command -v clang)" ]; then
+    export CppCompilerAndLinker=clang-3.9
+fi
+
 export CoreRT_BuildArch
 export CoreRT_BuildType
 export CoreRT_BuildOS


### PR DESCRIPTION
clang-3.9 is not available on recent Linux distros. Typically, there is clang alias setup for a good version of clang so just use that by default.

Fixes #5654