### PR TITLE
Fix sigantures in calli

### DIFF
--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
@@ -43,15 +43,6 @@ namespace System.Runtime.InteropServices
             safeHandle.InitializeHandle(win32Handle);
         }
 
-        // Used for methods in System.Private.Interop.dll that need to work from offsets on boxed structs
-        public static unsafe void PinObjectAndCall(object obj, Action<IntPtr> del)
-        {
-            fixed (IntPtr* pEEType = &obj.m_pEEType)
-            {
-                del((IntPtr)pEEType);
-            }
-        }
-
         public static int GetElementSize(this Array array)
         {
             return array.EETypePtr.ComponentSize;


### PR DESCRIPTION
* The called methods accept a byref, not a pointer.
* The called methods don't return anything.

This is also a slight perf improvement (no longer need to allocate the lambda for `PinObjectAndCall`).

Fixes #7951.