### PR TITLE
Add option to disable printing unhandled exceptions to console

### DIFF
--- a/Documentation/using-corert/optimizing-corert.md
+++ b/Documentation/using-corert/optimizing-corert.md
@@ -34,3 +34,6 @@ By default, the compiler tries to maximize compatibility with existing .NET code
 Debugging symbols (data about your program required for debugging) is by default part of native executable files on Unix-like operating systems. To minimize the size of your CoreRT-compiled executable, you can run the `strip` tool to remove the debugging symbols.
 
 No action is needed on Windows since the platform convention is to generate debug information into a separate file (`*.pdb`).
+
+## Advanced options 
+* `<IlcDisableUnhandledExceptionExperience>true</IlcDisableUnhandledExceptionExperience>`: disables code that prints stack traces for unhandled exceptions to the console.

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -90,7 +90,7 @@ See the LICENSE file in the project root for more information.
 
   <ItemGroup>
     <AutoInitializedAssemblies Include="System.Private.CoreLib" />
-    <AutoInitializedAssemblies Include="System.Private.DeveloperExperience.Console" />
+    <AutoInitializedAssemblies Include="System.Private.DeveloperExperience.Console" Condition="$(IlcDisableUnhandledExceptionExperience) != 'true'"  />
     <AutoInitializedAssemblies Condition="'$(ExperimentalInterpreterSupport)' == 'true'" Include="System.Private.Interpreter" />
     <AutoInitializedAssemblies Condition="'$(ExperimentalJitSupport)' == 'true'" Include="System.Private.Jit" />
   </ItemGroup>

--- a/src/System.Private.CoreLib/src/Internal/DeveloperExperience/DeveloperExperience.cs
+++ b/src/System.Private.CoreLib/src/Internal/DeveloperExperience/DeveloperExperience.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// We want the Debug.WriteLine statements below to actually do something.
+#define DEBUG
+
 using System;
 using System.Text;
 using System.Runtime;


### PR DESCRIPTION
Saves another 100 kB of code in a minimal app.

Mostly helps removing noise in finding big things. I don't expect people to use this which is why it's an Advanced option.

We might still want to do something like this for non-console apps though.