### PR TITLE
Suggestions to prerequisite docs

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -16,11 +16,6 @@ This will result in the following:
 
 ## On Windows
 
-When use VS 2017:
-- When building on windows ensure you are using the `x64 Native Tools Command Prompt for VS 2017`
-    (This is distinct from the `Developer Command Prompt for VS 2017`)
-
-When use VS 2019
 - You should use `Developer Command Prompt for VS 2019`
 
 If you have both stable and preview VS versions installed, open corresponding command prompt where you have C++ tools installed.
@@ -38,7 +33,7 @@ If you have both stable and preview VS versions installed, open corresponding co
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <Import Project="$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\Sdk.targets" />
@@ -96,7 +91,7 @@ If you are seeing errors such as:
 
 ```
 libcpmtd.lib(nothrow.obj) : fatal error LNK1112: module machine type 'X86' conflicts with target machine type 'x64' [C:\Users\[omitted]\nativetest\app\app.csproj]
-C:\Users\[omitted]\nativetest\bin\Windows_NT.x64.Debug\build\Microsoft.NETCore.Native.targets(151,5): error MSB3073: The command "link  @"obj\Debug\netcoreapp2.1\native\link.rsp"" exited with code 1112. [C:\Users\[omitted]\nativetest\app\app.csproj]
+C:\Users\[omitted]\nativetest\bin\Windows_NT.x64.Debug\build\Microsoft.NETCore.Native.targets(151,5): error MSB3073: The command "link  @"obj\Debug\netcoreapp3.1\native\link.rsp"" exited with code 1112. [C:\Users\[omitted]\nativetest\app\app.csproj]
 ```
 
 or 
@@ -111,6 +106,6 @@ or
 Microsoft.NETCore.Native.targets(132,5): error MSB3073: The command "cl @"native\cl.rsp"" exited with code 9009.
 ```
 
-Make sure you run these commands from the `x64 Native Tools Command Prompt for VS 2017` instead of a vanilla command prompt
+Make sure you run these commands from the `Developer Command Prompt for VS 2019` instead of a vanilla command prompt
 
 For more details see discussion in issue #2679

--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -23,7 +23,7 @@ When use VS 2017:
 When use VS 2019
 - You should use `Developer Command Prompt for VS 2019`
 
-If you have both stable and preview VS versions installed, opens corresponding command prompt where you have C++ tools installed.
+If you have both stable and preview VS versions installed, open corresponding command prompt where you have C++ tools installed.
 
 # Compiling source to native code using the ILCompiler you built #
 

--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -16,9 +16,15 @@ This will result in the following:
 
 ## On Windows
 
-- You should use `Developer Command Prompt for VS 2019`
+- You should use `x64 Native Tools Command Prompt for VS 2019`
 
 If you have both stable and preview VS versions installed, open corresponding command prompt where you have C++ tools installed.
+
+# Install .NET Core 3.1 SDK
+
+Download .NET Core 3.1 SDK from [https://www.microsoft.com/net/download/core](https://www.microsoft.com/net/download/core)
+
+You should now be able to use the `dotnet` commands of the CLI tools.
 
 # Compiling source to native code using the ILCompiler you built #
 
@@ -106,6 +112,6 @@ or
 Microsoft.NETCore.Native.targets(132,5): error MSB3073: The command "cl @"native\cl.rsp"" exited with code 9009.
 ```
 
-Make sure you run these commands from the `Developer Command Prompt for VS 2019` instead of a vanilla command prompt
+Make sure you run these commands from the `x64 Native Tools Command Prompt for VS 2019` instead of a vanilla command prompt
 
 For more details see discussion in issue #2679

--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -14,13 +14,16 @@ This will result in the following:
 - Build native and managed components of ILCompiler. The final binaries are placed to `<repo_root>\bin\<OS>.<arch>.<Config>\tools`.
 - Build and run tests
 
-# Install .NET Core 2.1 SDK
+## On Windows
 
-* Download .NET Core 2.1 SDK from [https://www.microsoft.com/net/download/core](https://www.microsoft.com/net/download/core)
-* On windows ensure you are using the 'x64 Native Tools Command Prompt for VS 2017'
-    (This is distinct from the 'Developer Command Prompt for VS 2017')
+When use VS 2017:
+- When building on windows ensure you are using the `x64 Native Tools Command Prompt for VS 2017`
+    (This is distinct from the `Developer Command Prompt for VS 2017`)
 
-You should now be able to use the `dotnet` commands of the CLI tools.
+When use VS 2019
+- You should use `Developer Command Prompt for VS 2019`
+
+If you have both stable and preview VS versions installed, opens corresponding command prompt where you have C++ tools installed.
 
 # Compiling source to native code using the ILCompiler you built #
 

--- a/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-visual-studio.md
@@ -5,7 +5,7 @@ _Note_:
 * Instructions below assume `c:\corert` is the repo root.
 
 
-# Building ILCompiler in Visual Studio 2017 #
+# Building ILCompiler in Visual Studio 2019 #
 
 First, build your repo by issuing the following command at repo root, by default this builds Debug x64:
 

--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -1,5 +1,11 @@
 The following pre-requisites need to be installed for building the repo:
 
+# Install .NET Core 2.1 SDK
+
+Download .NET Core 2.1 SDK from [https://www.microsoft.com/net/download/core](https://www.microsoft.com/net/download/core)
+
+You should now be able to use the `dotnet` commands of the CLI tools.
+
 # Windows (Windows 7+)
 
 1. Install [Visual Studio 2017](https://visualstudio.microsoft.com/vs/community/) or [Visual Studio 2019 Preview](https://visualstudio.microsoft.com/vs/preview/), including Visual C++ support.

--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -1,16 +1,16 @@
 The following pre-requisites need to be installed for building the repo:
 
-# Install .NET Core 2.1 SDK
+# Install .NET Core 3.1 SDK
 
-Download .NET Core 2.1 SDK from [https://www.microsoft.com/net/download/core](https://www.microsoft.com/net/download/core)
+Download .NET Core 3.1 SDK from [https://www.microsoft.com/net/download/core](https://www.microsoft.com/net/download/core)
 
 You should now be able to use the `dotnet` commands of the CLI tools.
 
 # Windows (Windows 7+)
 
-1. Install [Visual Studio 2017](https://visualstudio.microsoft.com/vs/community/) or [Visual Studio 2019 Preview](https://visualstudio.microsoft.com/vs/preview/), including Visual C++ support.
+1. Install [Visual Studio 2019](https://visualstudio.microsoft.com/vs/preview/), including Visual C++ support.
  - For an existing Visual Studio 2019 installation, `buildscripts/install-reqs-vs2019.cmd` is provided.
-2. Install [CMake](http://www.cmake.org/download/) 3.8.0 or later (3.14.0-rc1 or later is required for VS2019). Make sure you add it to the PATH in the setup wizard.
+2. Install [CMake](http://www.cmake.org/download/) 3.14.0 or later. Make sure you add it to the PATH in the setup wizard.
 3. (Windows 7 only) Install PowerShell 3.0. It's part of [Windows Management Framework 3.0](http://go.microsoft.com/fwlink/?LinkID=240290). Windows 8 or later comes with the right version inbox.
 
 PowerShell also needs to be available from the PATH environment variable (it's the default). Typically it should be %SYSTEMROOT%\System32\WindowsPowerShell\v1.0\.

--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -1,11 +1,5 @@
 The following pre-requisites need to be installed for building the repo:
 
-# Install .NET Core 3.1 SDK
-
-Download .NET Core 3.1 SDK from [https://www.microsoft.com/net/download/core](https://www.microsoft.com/net/download/core)
-
-You should now be able to use the `dotnet` commands of the CLI tools.
-
 # Windows (Windows 7+)
 
 1. Install [Visual Studio 2019](https://visualstudio.microsoft.com/vs/community/), including Visual C++ support.

--- a/Documentation/prerequisites-for-building.md
+++ b/Documentation/prerequisites-for-building.md
@@ -8,7 +8,7 @@ You should now be able to use the `dotnet` commands of the CLI tools.
 
 # Windows (Windows 7+)
 
-1. Install [Visual Studio 2019](https://visualstudio.microsoft.com/vs/preview/), including Visual C++ support.
+1. Install [Visual Studio 2019](https://visualstudio.microsoft.com/vs/community/), including Visual C++ support.
  - For an existing Visual Studio 2019 installation, `buildscripts/install-reqs-vs2019.cmd` is provided.
 2. Install [CMake](http://www.cmake.org/download/) 3.14.0 or later. Make sure you add it to the PATH in the setup wizard.
 3. (Windows 7 only) Install PowerShell 3.0. It's part of [Windows Management Framework 3.0](http://go.microsoft.com/fwlink/?LinkID=240290). Windows 8 or later comes with the right version inbox.

--- a/samples/prerequisites.md
+++ b/samples/prerequisites.md
@@ -1,13 +1,13 @@
 If you're new to .NET Core make sure to visit the [official starting page](http://dotnet.github.io). It will guide you through installing pre-requisites and building your first app.
-If you're already familiar with .NET Core make sure you've [downloaded and installed the .NET Core 2 SDK](https://www.microsoft.com/net/download/core).
+If you're already familiar with .NET Core make sure you've [downloaded and installed the .NET Core 3.1 SDK](https://www.microsoft.com/net/download/core).
 
 The following pre-requisites need to be installed for building .NET Core projects with CoreRT:
 
 # Windows
 
-* Install [Visual Studio 2017](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx), including Visual C++ support.
+* Install [Visual Studio 2019](https://visualstudio.microsoft.com/vs/community/), including Visual C++ support.
 
-# Ubuntu (14.04+)
+# Ubuntu (16.04+)
 
 * Install clang and developer packages for libraries that .NET Core depends on.
 


### PR DESCRIPTION
This changes mostly driven by my confusion how to initially start docs. For sure I have to read carefully,
but I miss important pieces since they was in unexpected places
- Move installing .NET Core to prerequiresite docs
   Assuming this is still valid, since seems to be
   build.cmd/.sh pull .NET Core SDK automatically
- Highlight that Developer Command Prompt needed
   and that you can select environment.

This is driven mostly by my confusion in #7965