### PR TITLE
Fix NRE caused by unknown CanonTypesModule

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -118,7 +118,7 @@ namespace ILCompiler
                 if (!ReferenceFilePaths.TryGetValue(simpleName, out filePath))
                 {
                     // We allow the CanonTypesModule to not be an EcmaModule.
-                    if (((IAssemblyDesc)CanonTypesModule)?.GetName()?.Name == simpleName)
+                    if (((IAssemblyDesc)CanonTypesModule).GetName().Name == simpleName)
                         return CanonTypesModule;
 
                     // TODO: the exception is wrong for two reasons: for one, this should be assembly full name, not simple name.

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -118,7 +118,7 @@ namespace ILCompiler
                 if (!ReferenceFilePaths.TryGetValue(simpleName, out filePath))
                 {
                     // We allow the CanonTypesModule to not be an EcmaModule.
-                    if (((IAssemblyDesc)CanonTypesModule).GetName().Name == simpleName)
+                    if (((IAssemblyDesc)CanonTypesModule)?.GetName()?.Name == simpleName)
                         return CanonTypesModule;
 
                     // TODO: the exception is wrong for two reasons: for one, this should be assembly full name, not simple name.

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -345,7 +345,7 @@ namespace ILCompiler
             typeSystemContext.ReferenceFilePaths = _referenceFilePaths;
             if (!typeSystemContext.InputFilePaths.ContainsKey(_systemModuleName)
                 && !typeSystemContext.ReferenceFilePaths.ContainsKey(_systemModuleName))
-                throw new CommandLineException($"System module {_systemModuleName} does not exists. Make sure that you specify --systemmodulename");
+                throw new CommandLineException($"System module {_systemModuleName} does not exists. Make sure that you specify --systemmodule");
 
             typeSystemContext.SetSystemModule(typeSystemContext.GetModuleForSimpleName(_systemModuleName));
 

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -343,6 +343,9 @@ namespace ILCompiler
 
             typeSystemContext.InputFilePaths = inputFilePaths;
             typeSystemContext.ReferenceFilePaths = _referenceFilePaths;
+            if (!typeSystemContext.InputFilePaths.ContainsKey(_systemModuleName)
+                && !typeSystemContext.ReferenceFilePaths.ContainsKey(_systemModuleName))
+                throw new CommandLineException($"System module {_systemModuleName} does not exists. Make sure that you specify --systemmodulename");
 
             typeSystemContext.SetSystemModule(typeSystemContext.GetModuleForSimpleName(_systemModuleName));
 


### PR DESCRIPTION
See #7971

I'm not sure if this is proper diagnositcs, but right now instead of NRE
I have following error message
```
Unhandled Exception: Internal.TypeSystem.TypeSystemException+FileNotFoundException: [TEMPORARY EXCEPTION MESSAGE] FileLoadErrorGeneric: System.Private.CoreLib
     at Internal.TypeSystem.ThrowHelper.ThrowFileNotFoundException(ExceptionStringID id, String fileName)
     at ILCompiler.CompilerTypeSystemContext.GetModuleForSimpleName(String simpleName, Boolean throwIfNotFound)
     at ILCompiler.Program.Run(String[] args)
     at ILCompiler.Program.Main(String[] args)
```
From now on I can understand that specific module does not found.
Probably for that case should be created specific error message, but I'm not sure what this is means, so cannot make proper text.