### PR TITLE
Wasm: TFM to netstandard2.0 to allow upgrade of LLVMSharp

### DIFF
--- a/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
+++ b/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>ILCompiler</RootNamespace>
     <AssemblyName>ILCompiler.WebAssembly</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>8002</NoWarn>
   </PropertyGroup>
   


### PR DESCRIPTION
Changes the TFM from netstandard 1.6 to 2.0 so that we can upgrade LLVMSharp to 9.0.0-beta which supports netstandard2.0 only.  Upgrade to LLVMSharp 9 would allow upgrade to LLVM Wasm backend which is the new default in Emscripten.