### PR TITLE
Match `Type.operator==` with CoreCLR

### DIFF
--- a/src/System.Private.CoreLib/src/System/Type.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Type.CoreRT.cs
@@ -60,6 +60,12 @@ namespace System
             if ((object)left == null || (object)right == null)
                 return false;
 
+            // CLR-compat: runtime types are never equal to non-runtime types
+            // If `left` is a non-runtime type with a weird Equals implementation
+            // this is where operator `==` would differ from `Equals` call.
+            if (left.IsRuntimeImplemented() || right.IsRuntimeImplemented())
+                return false;
+
             return left.Equals(right);
         }
 


### PR DESCRIPTION
Runtime implemented types are never equal to non-runtime implemented types.