### PR TITLE
Provide a way how to project work with local build

### DIFF
--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -42,8 +42,14 @@ You should now be able to use the `dotnet` commands of the CLI tools.
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+     <-- This line allow usage of published alpha packages when local build not available -->
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" Condition="$(IlcPath) == ''" />
+  </ItemGroup>
+
   <Import Project="$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\Sdk.targets" />
-  <Import Project="$(IlcPath)\build\Microsoft.NETCore.Native.targets" />
+  <-- This line allow usage of local CoreRT build when available -->
+  <Import Project="$(IlcPath)\build\Microsoft.NETCore.Native.targets" Condition="$(IlcPath) != ''" />
 </Project>
 ```
 


### PR DESCRIPTION
in additional to published packages.

This change mostly to show a way how customer can use CoreRT and made modifications when needed.
Likely current users of CoreRT would be persons who can and would like to get hand dirty into CoreRT due to it's status.

Other alternative is to have property `UseLocalCoreRT` which will be used to trigger local CoreRT usage.