### PR TITLE
Wasm: Add conservative garbage collection

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2746,7 +2746,7 @@ namespace Internal.IL
                 if (s_shadowStackTop.Handle.Equals(IntPtr.Zero))
                 {
                     s_shadowStackTop = Module.AddGlobal(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "t_pShadowStackTop");
-                    s_shadowStackTop.Linkage = LLVMLinkage.LLVMInternalLinkage;
+                    s_shadowStackTop.Linkage = LLVMLinkage.LLVMExternalLinkage;
                     s_shadowStackTop.Initializer = LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0));
                     s_shadowStackTop.ThreadLocalMode = LLVMThreadLocalMode.LLVMLocalDynamicTLSModel;
                 }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
@@ -255,6 +255,12 @@ namespace ILCompiler.DependencyAnalysis
             var castShadowStack = builder.BuildPointerCast(shadowStack, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), String.Empty);
             builder.BuildStore(castShadowStack, shadowStackTop);
 
+            var shadowStackBottom = Module.AddGlobal(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "t_pShadowStackBottom");
+            shadowStackBottom.Linkage = LLVMLinkage.LLVMExternalLinkage;
+            shadowStackBottom.Initializer = LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0));
+            shadowStackBottom.ThreadLocalMode = LLVMThreadLocalMode.LLVMLocalDynamicTLSModel;
+            builder.BuildStore(castShadowStack, shadowStackBottom);
+
             // Pass on main arguments
             LLVMValueRef argc = mainFunc.GetParam(0);
             LLVMValueRef argv = mainFunc.GetParam(1);

--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -342,7 +342,7 @@ static int InitializeRuntime()
     if (!RhInitialize())
         return -1;
 
-#if defined(CPPCODEGEN)
+#if defined(CPPCODEGEN) || defined(_WASM_)
     RhpEnableConservativeStackReporting();
 #endif // CPPCODEGEN
 
@@ -363,7 +363,7 @@ static int InitializeRuntime()
 #ifndef CPPCODEGEN
     InitializeModules(osModule, __modules_a, (int)((__modules_z - __modules_a)), (void **)&c_classlibFunctions, _countof(c_classlibFunctions));
 #elif defined _WASM_
-    InitializeModules(nullptr, (void**)RtRHeaderWrapper(), 1, nullptr, 0);
+    InitializeModules(nullptr, (void**)RtRHeaderWrapper(), 1, (void **)&c_classlibFunctions, _countof(c_classlibFunctions));
 #else // !CPPCODEGEN
     InitializeModules(nullptr, (void**)RtRHeaderWrapper(), 2, (void **)&c_classlibFunctions, _countof(c_classlibFunctions));
 #endif // !CPPCODEGEN

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -1565,7 +1565,7 @@ bool GCToEEInterface::GetIntConfigValue(const char* key, int64_t* value)
 
     if (strcmp(key, "GCgen0size") == 0)
     {
-#ifdef USE_PORTABLE_HELPERS
+#if defined(USE_PORTABLE_HELPERS) && !defined(_WASM_)
         // CORERT-TODO: remove this
         //              https://github.com/dotnet/corert/issues/2033
         *value = 100 * 1024 * 1024;

--- a/src/Native/Runtime/thread.cpp
+++ b/src/Native/Runtime/thread.cpp
@@ -140,7 +140,9 @@ void Thread::ResetCachedTransitionFrame()
 void Thread::EnablePreemptiveMode()
 {
     ASSERT(ThreadStore::GetCurrentThread() == this);
+#if !defined(_WASM_)
     ASSERT(m_pHackPInvokeTunnel != NULL);
+#endif
 
     Unhijack();
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -343,6 +343,13 @@ internal static class Program
     {
         StartTest("GC");
 
+        var genOfNewObject = GC.GetGeneration(new object());
+        PrintLine("Generation of new object " + genOfNewObject.ToString());
+        if(genOfNewObject != 0)
+        {
+            FailTest("Gen of new object was " + genOfNewObject);
+            return;
+        }
         var weakReference = MethodWithObjectInShadowStack();
         GC.Collect();
         GC.Collect();
@@ -351,14 +358,25 @@ internal static class Program
             FailTest("object alive when has no references");
             return;
         }
+        // create enough arrays to go over 5GB which should force older arrays to get collected
+        // use array of size 1MB, then iterate 5*1024 times
+        for(var i = 0; i < 5 * 1024; i++)
+        {
+            PrintString("i is ");
+            PrintLine(i.ToString());
+            var a = new int[256 * 1024]; // ints are 4 bytes so this is 1MB
+        }
+        for(var i = 0; i < 3; i++)
+        {
+            PrintString("GC Collection Count " + i.ToString() + " ");
+            PrintLine(GC.CollectionCount(i).ToString());
+        }
         EndTest(true);
     }
 
     private static WeakReference MethodWithObjectInShadowStack()
     {
         var o = new object();
-        var gen = GC.GetGeneration(o);
-        PrintLine(gen.ToString());
         var wr = new WeakReference(o);
         if (!wr.IsAlive)
         {


### PR DESCRIPTION
Enables conservative garbage collection in the Wasm backend.  WIP as would like to solicit suggestions for tests.  Naively, I could loop and create some large arrays beyond the memory limit, which should cause a GC and succeed, but anything better/more sophisticated I should add to the tests?  So far the only test is to create and collect an object, testing through a `WeakReference`.

WIP also as depends on #7983 at which point 99% of the diffs should disappear.

Closes #5305 