### PR TITLE
Update references from CoreCLR repo to Runtime

### DIFF
--- a/Documentation/engineering/updating-coreclr-tests.md
+++ b/Documentation/engineering/updating-coreclr-tests.md
@@ -3,7 +3,7 @@
 The set of CoreCLR tests run as part of CoreRT's CI and available via `tests\runtest.cmd /coreclr` download are downloaded as a zip file from the CoreCLR build. We use a specific build number to ensure we're running against a set of tests known to be compatible with CoreRT. Rolling forward to a new set of tests involves these steps:
 
 1. Find a known good tests.zip from the CoreCLR build
-   1. Go to https://github.com/dotnet/coreclr/pulls and open the most-recently passing PR (it should have a green check mark next to it)
+   1. Go to https://github.com/dotnet/runtime/pulls and open the most-recently passing PR (it should have a green check mark next to it)
    2. In the CI checks, open the details for `Windows_NT x64 Debug Build and Test`
    3. Navigate through `Build Artifacts` -> `bin` -> `tests`
    4. Copy the URL to `tests.zip`

--- a/Documentation/engineering/updating-coreclr-tests.md
+++ b/Documentation/engineering/updating-coreclr-tests.md
@@ -6,7 +6,7 @@ The set of CoreCLR tests run as part of CoreRT's CI and available via `tests\run
    1. Go to https://github.com/dotnet/runtime/pulls and open the most-recently passing PR (it should have a green check mark next to it)
    2. In the CI checks, open the details for `Windows_NT x64 Debug Build and Test`
    3. Navigate through `Build Artifacts` -> `bin` -> `tests`
-   4. Copy the URL to `tests.zip`
+   4. Copy the URL to `tests.zip` (**TODO: Zip archive no longer built, has to be retooled at https://github.com/dotnet/runtime side**)
 2. Retain the CI build so Jenkins doesn't delete `tests.zip`
    1. In the PR job page (where you clicked `Build Artifacts` earlier) ensure you're logged in to Jenkins
    2. Click the `Keep this build forever` button at the top-right

--- a/Documentation/engineering/updating-ryujit.md
+++ b/Documentation/engineering/updating-ryujit.md
@@ -2,7 +2,7 @@
 
 Following steps are necessary to pick up a new version of RyuJIT code generation backend from CoreCLR:
 
-1. From the master branch of the Runtime repo, copy header files that are part of the contract with RyuJIT from `src\coreclr\src\inc` on the CoreCLR side, to `src\JitInterface\src\ThunkGenerator` on the CoreRT side.
+1. From the master branch of the https://github.com/dotnet/runtime/ repo, copy header files that are part of the contract with RyuJIT from `src\coreclr\src\inc` on the CoreCLR side, to `src\JitInterface\src\ThunkGenerator` on the CoreRT side.
 2. Inspect the diffs
     1. If an enum was modified, port the change to the managed version of the enum manually.
     2. If a JitInterface method was added or changed, update `src\JitInterface\src\ThunkGenerator\ThunkInput.txt` and run the generation script next to the file to regenerate `CorInfoBase.cs` and `jitinterface.h`. Update the managed implementation of the method in `CorInfoImpl.cs` manually.

--- a/Documentation/engineering/updating-ryujit.md
+++ b/Documentation/engineering/updating-ryujit.md
@@ -7,7 +7,7 @@ Following steps are necessary to pick up a new version of RyuJIT code generation
     1. If an enum was modified, port the change to the managed version of the enum manually.
     2. If a JitInterface method was added or changed, update `src\JitInterface\src\ThunkGenerator\ThunkInput.txt` and run the generation script next to the file to regenerate `CorInfoBase.cs` and `jitinterface.h`. Update the managed implementation of the method in `CorInfoImpl.cs` manually.
     3. If the JitInterface GUID was updated (`JITEEVersionIdentifier` in `corinfo.h`), update it in `src\Native\jitinterface\jitwrapper.cpp`
-3. Determine the latest Microsoft.NETCore.Jit package to use (**TODO: This package is no longer built. Has to be retooled**)
+3. Determine the latest Microsoft.NETCore.App.Runtime package to use
     1. Go to https://dnceng.visualstudio.com/internal/_build?definitionId=244 and select the latest successful *scheduled build* of the master branch. Success is defined by the "Publish to Build Asset Registry Job" succeeding (currently various test legs fail).
     2. Select the "Build Windows_NT x64 release Job" and open its "Publish packages to blob feed" log
     3. On the first page of the log, note the package version of the various .nupkg package files being processed

--- a/Documentation/engineering/updating-ryujit.md
+++ b/Documentation/engineering/updating-ryujit.md
@@ -2,7 +2,7 @@
 
 Following steps are necessary to pick up a new version of RyuJIT code generation backend from CoreCLR:
 
-1. From the master branch of the CoreCLR repo, copy header files that are part of the contract with RyuJIT from `src\inc` on the CoreCLR side, to `src\JitInterface\src\ThunkGenerator` on the CoreRT side.
+1. From the master branch of the Runtime repo, copy header files that are part of the contract with RyuJIT from `src\coreclr\src\inc` on the CoreCLR side, to `src\JitInterface\src\ThunkGenerator` on the CoreRT side.
 2. Inspect the diffs
     1. If an enum was modified, port the change to the managed version of the enum manually.
     2. If a JitInterface method was added or changed, update `src\JitInterface\src\ThunkGenerator\ThunkInput.txt` and run the generation script next to the file to regenerate `CorInfoBase.cs` and `jitinterface.h`. Update the managed implementation of the method in `CorInfoImpl.cs` manually.

--- a/Documentation/engineering/updating-ryujit.md
+++ b/Documentation/engineering/updating-ryujit.md
@@ -7,7 +7,7 @@ Following steps are necessary to pick up a new version of RyuJIT code generation
     1. If an enum was modified, port the change to the managed version of the enum manually.
     2. If a JitInterface method was added or changed, update `src\JitInterface\src\ThunkGenerator\ThunkInput.txt` and run the generation script next to the file to regenerate `CorInfoBase.cs` and `jitinterface.h`. Update the managed implementation of the method in `CorInfoImpl.cs` manually.
     3. If the JitInterface GUID was updated (`JITEEVersionIdentifier` in `corinfo.h`), update it in `src\Native\jitinterface\jitwrapper.cpp`
-3. Determine the latest Microsoft.NETCore.Jit package to use
+3. Determine the latest Microsoft.NETCore.Jit package to use (**TODO: This package is no longer built. Has to be retooled**)
     1. Go to https://dnceng.visualstudio.com/internal/_build?definitionId=244 and select the latest successful *scheduled build* of the master branch. Success is defined by the "Publish to Build Asset Registry Job" succeeding (currently various test legs fail).
     2. Select the "Build Windows_NT x64 release Job" and open its "Publish packages to blob feed" log
     3. On the first page of the log, note the package version of the various .nupkg package files being processed

--- a/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
+++ b/Documentation/how-to-build-and-run-ilcompiler-in-console-shell-prompt.md
@@ -57,7 +57,7 @@ You should now be able to use the `dotnet` commands of the CLI tools.
 
 ## Using RyuJIT ##
 
-This approach uses the same code-generator (RyuJIT), as [CoreCLR](https://github.com/dotnet/coreclr), for compiling the application. Linking is done using the platform specific linker.
+This approach uses the same code-generator (RyuJIT), as [CoreCLR](https://github.com/dotnet/runtime), for compiling the application. Linking is done using the platform specific linker.
 
 From the shell/command prompt, issue the following commands, from the folder containing your project, to generate the native executable
 


### PR DESCRIPTION
Update links to new unified [dotnet/runtime](https://github.com/dotnet/runtime) repo