### PR TITLE
Make `Activator.CreateInstance<T>` 50% faster

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -67,6 +67,8 @@ namespace ILCompiler.DependencyAnalysis
                     return ((DelegateCreationInfo)target).GetLookupKind(factory);
                 case ReadyToRunHelperId.DefaultConstructor:
                     return factory.GenericLookup.DefaultCtorLookupResult((TypeDesc)target);
+                case ReadyToRunHelperId.ObjectAllocator:
+                    return factory.GenericLookup.ObjectAllocator((TypeDesc)target);
                 default:
                     throw new NotImplementedException();
             }
@@ -252,6 +254,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.GetNonGCStaticBase:
                 case ReadyToRunHelperId.GetThreadStaticBase:
                 case ReadyToRunHelperId.DefaultConstructor:
+                case ReadyToRunHelperId.ObjectAllocator:
                     return comparer.Compare((TypeDesc)_target, (TypeDesc)((ReadyToRunGenericHelperNode)other)._target);
                 case ReadyToRunHelperId.MethodHandle:
                 case ReadyToRunHelperId.MethodDictionary:

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -39,6 +39,7 @@ namespace ILCompiler.DependencyAnalysis
         VirtualDispatchCell,
         DefaultConstructor,
         TypeHandleForCasting,
+        ObjectAllocator,
     }
 
     public partial class ReadyToRunHelperNode : AssemblyStubNode, INodeWithDebugInfo

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunGenericHelperNode.cs
@@ -197,6 +197,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.MethodEntry:
                 case ReadyToRunHelperId.VirtualDispatchCell:
                 case ReadyToRunHelperId.DefaultConstructor:
+                case ReadyToRunHelperId.ObjectAllocator:
                 case ReadyToRunHelperId.TypeHandleForCasting:
                     {
                         EmitDictionaryLookup(factory, ref encoder, contextRegister, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -210,6 +210,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.MethodEntry:
                 case ReadyToRunHelperId.VirtualDispatchCell:
                 case ReadyToRunHelperId.DefaultConstructor:
+                case ReadyToRunHelperId.ObjectAllocator:
                 case ReadyToRunHelperId.TypeHandleForCasting:
                     {
                         EmitDictionaryLookup(factory, ref encoder, contextRegister, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);

--- a/src/ILCompiler.Compiler/src/Compiler/GenericDictionaryLookup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/GenericDictionaryLookup.cs
@@ -22,6 +22,7 @@ namespace ILCompiler
 
         private readonly short _offset1;
         private readonly short _offset2;
+        private readonly bool _indirectLastOffset;
 
         /// <summary>
         /// Gets the information about the source of the generic context for shared code.
@@ -97,23 +98,33 @@ namespace ILCompiler
             }
         }
 
-        private GenericDictionaryLookup(GenericContextSource contextSource, int offset1, int offset2, object helperObject)
+        public bool IndirectLastOffset
+        {
+            get
+            {
+                Debug.Assert(!UseHelper);
+                return _indirectLastOffset;
+            }
+        }
+
+        private GenericDictionaryLookup(GenericContextSource contextSource, int offset1, int offset2, object helperObject, bool indirectLastOffset)
         {
             ContextSource = contextSource;
             _offset1 = checked((short)offset1);
             _offset2 = checked((short)offset2);
             _helperObject = helperObject;
+            _indirectLastOffset = indirectLastOffset;
         }
 
-        public static GenericDictionaryLookup CreateFixedLookup(GenericContextSource contextSource, int offset1, int offset2 = UseHelperOffset)
+        public static GenericDictionaryLookup CreateFixedLookup(GenericContextSource contextSource, int offset1, int offset2 = UseHelperOffset, bool indirectLastOffset = false)
         {
             Debug.Assert(offset1 != UseHelperOffset);
-            return new GenericDictionaryLookup(contextSource, offset1, offset2, null);
+            return new GenericDictionaryLookup(contextSource, offset1, offset2, null, indirectLastOffset);
         }
 
         public static GenericDictionaryLookup CreateHelperLookup(GenericContextSource contextSource, ReadyToRunHelperId helperId, object helperObject)
         {
-            return new GenericDictionaryLookup(contextSource, UseHelperOffset, checked((short)helperId), helperObject);
+            return new GenericDictionaryLookup(contextSource, UseHelperOffset, checked((short)helperId), helperObject, indirectLastOffset: false);
         }
     }
 

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -109,10 +109,18 @@ namespace Internal.JitInterface
                         lookup.runtimeLookup.helper = CorInfoHelpFunc.CORINFO_HELP_RUNTIMEHANDLE_CLASS;
                     }
 
-                    lookup.runtimeLookup.indirections = (ushort)genericLookup.NumberOfIndirections;
+                    lookup.runtimeLookup.indirections = (ushort)(genericLookup.NumberOfIndirections + (genericLookup.IndirectLastOffset ? 1 : 0));
                     lookup.runtimeLookup.offset0 = (IntPtr)genericLookup[0];
                     if (genericLookup.NumberOfIndirections > 1)
+                    {
                         lookup.runtimeLookup.offset1 = (IntPtr)genericLookup[1];
+                        if (genericLookup.IndirectLastOffset)
+                            lookup.runtimeLookup.offset2 = IntPtr.Zero;
+                    }
+                    else if (genericLookup.IndirectLastOffset)
+                    {
+                        lookup.runtimeLookup.offset1 = IntPtr.Zero;
+                    }
                     lookup.runtimeLookup.testForFixup = false; // TODO: this will be needed in true multifile
                     lookup.runtimeLookup.testForNull = false;
                     lookup.runtimeLookup.indirectFirstOffset = false;
@@ -1525,6 +1533,9 @@ namespace Internal.JitInterface
                     break;
                 case "DefaultConstructorOf":
                     ComputeLookup(ref pResolvedToken, method.Instantiation[0], ReadyToRunHelperId.DefaultConstructor, ref pResult.lookup);
+                    break;
+                case "AllocatorOf":
+                    ComputeLookup(ref pResolvedToken, method.Instantiation[0], ReadyToRunHelperId.ObjectAllocator, ref pResult.lookup);
                     break;
             }
         }

--- a/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
+++ b/src/JitInterface/src/CorInfoImpl.Intrinsics.cs
@@ -159,6 +159,7 @@ namespace Internal.JitInterface
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_ReadOnlySpan_GetItem, "get_Item", "System", "ReadOnlySpan`1");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "EETypePtrOf", "System", "EETypePtr");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "DefaultConstructorOf", "System", "Activator");
+            table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "AllocatorOf", "System", "Activator");
 
             // If this assert fails, make sure to add the new intrinsics to the table above and update the expected count below.
             Debug.Assert((int)CorInfoIntrinsics.CORINFO_INTRINSIC_Count == 54);

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -201,7 +201,7 @@ namespace Internal.Runtime.Augments
 
         public static IntPtr GetFallbackDefaultConstructor()
         {
-            return System.Runtime.InteropServices.AddrofIntrinsics.AddrOf<Action>(System.Activator.ClassWithMissingConstructor.MissingDefaultConstructorStaticEntryPoint);
+            return Activator.GetFallbackDefaultConstructor();
         }
 
         //

--- a/src/System.Private.CoreLib/src/System/Activator.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.CoreRT.cs
@@ -97,8 +97,12 @@ namespace System
         // the constructor is missing.
         private class ClassWithMissingConstructor
         {
+            public Guid G;
+
             private ClassWithMissingConstructor()
             {
+                // Ensure we have a unique method body for this that never gets folded with another ctor.
+                G = new Guid(0x68be9718, 0xf787, 0x45ab, 0x84, 0x3b, 0x1f, 0x31, 0xb6, 0x12, 0x65, 0xeb);
             }
         }
 

--- a/src/System.Private.CoreLib/src/System/Activator.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.CoreRT.cs
@@ -50,8 +50,10 @@ namespace System
                     throw new MissingMethodException(SR.Format(SR.MissingConstructor_Name, typeof(T)));
 
                 // Grab a pointer to the optimized allocator for the type and call it.
-                IntPtr allocator = AllocatorOf<T>();
-                T t = RawCalliHelper.Call<T>(allocator, EETypePtr.EETypePtrOf<T>().RawValue);
+                // TODO: we need RyuJIT to respect that RawCalliHelper doesn't do fat pointer transform
+                // IntPtr allocator = AllocatorOf<T>();
+                // T t = RawCalliHelper.Call<T>(allocator, EETypePtr.EETypePtrOf<T>().RawValue);
+                T t = (T)RuntimeImports.RhNewObject(EETypePtr.EETypePtrOf<T>());
 
                 try
                 {

--- a/src/System.Private.CoreLib/src/System/Activator.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Activator.CoreRT.cs
@@ -15,100 +15,90 @@ using System.Runtime.Remoting;
 using System.Runtime;
 
 using Internal.Reflection.Augments;
+using Internal.Runtime.CompilerServices;
 
 namespace System
 {
     public static partial class Activator
     {
-        // The following 2 methods and helper class implement the functionality of Activator.CreateInstance<T>()
-
+        // The following methods and helper class implement the functionality of Activator.CreateInstance<T>()
+        // The implementation relies on several compiler intrinsics that expand to quick dictionary lookups in shared
+        // code, and direct constant references in unshared code.
+        //
         // This method is the public surface area. It wraps the CreateInstance intrinsic with the appropriate try/catch
         // block so that the correct exceptions are generated. Also, it handles the cases where the T type doesn't have 
-        // a default constructor. (Those result in running the ClassWithMissingConstructor's .ctor, which flips the magic
-        // thread static to cause the CreateInstance<T> method to throw the right exception.)
-        //
+        // a default constructor.
         [DebuggerGuidedStepThrough]
         public static T CreateInstance<T>()
         {
-            T t = default(T);
-
-            bool missingDefaultConstructor = false;
-
-            EETypePtr eetype = EETypePtr.EETypePtrOf<T>();
-
             if (!RuntimeHelpers.IsReference<T>())
             {
-                // Early out for valuetypes since we don't support default constructors anyway.
+                // Early out for valuetypes since we don't support default constructors anyway for now.
                 // This lets codegens that expand IsReference<T> optimize away the rest of this code.
-            }
-            else if (eetype.ComponentSize != 0)
-            {
-                // ComponentSize > 0 indicates an array-like type (e.g. string, array, etc).
-                // Allocating this using the normal allocator would result in silent heap corruption.
-                missingDefaultConstructor = true;
-            }
-            else if (eetype.IsInterface)
-            {
-                // Do not attempt to allocate interface types either
-                missingDefaultConstructor = true;
+                return default;
             }
             else
             {
-                bool oldValueOfMissingDefaultCtorMarkerBool = s_createInstanceMissingDefaultConstructor;
+                // Grab the pointer to the default constructor of the type. If T doesn't have a default
+                // constructor, the intrinsic returns a marker pointer that we check for.
+                IntPtr defaultConstructor = DefaultConstructorOf<T>();
+
+                // Check if we got the marker back.
+                //
+                // TODO: might want to disambiguate the different cases for abstract class, interface, etc.
+                if (defaultConstructor == DefaultConstructorOf<ClassWithMissingConstructor>())
+                    throw new MissingMethodException(SR.Format(SR.MissingConstructor_Name, typeof(T)));
+
+                // Grab a pointer to the optimized allocator for the type and call it.
+                IntPtr allocator = AllocatorOf<T>();
+                T t = RawCalliHelper.Call<T>(allocator, EETypePtr.EETypePtrOf<T>().RawValue);
 
                 try
                 {
-                    t = (T)(RuntimeImports.RhNewObject(eetype));
-
-                    // Run the default constructor. If the default constructor was missing, codegen
-                    // will expand DefaultConstructorOf to ClassWithMissingConstructor::.ctor
-                    // and we detect that later.
-                    IntPtr defaultConstructor = DefaultConstructorOf<T>();
+                    // Call the default constructor on the allocated instance.
                     RawCalliHelper.Call(defaultConstructor, t);
+
+                    // Debugger goo so that stepping in works. Only affects debug info generation.
+                    // The call gets optimized away.
                     DebugAnnotations.PreviousCallContainsDebuggerStepInCode();
+
+                    return t;
                 }
                 catch (Exception e)
                 {
                     throw new TargetInvocationException(e);
                 }
-
-                if (s_createInstanceMissingDefaultConstructor != oldValueOfMissingDefaultCtorMarkerBool)
-                {
-                    missingDefaultConstructor = true;
-
-                    // We didn't call the real .ctor (because there wasn't one), but we still allocated
-                    // an uninitialized object. If it has a finalizer, it would run - prevent that.
-                    GC.SuppressFinalize(t);
-                }
             }
-
-            if (missingDefaultConstructor)
-            {
-                throw new MissingMethodException(SR.Format(SR.MissingConstructor_Name, typeof(T)));
-            }
-
-            return t;
         }
 
         [Intrinsic]
         private static IntPtr DefaultConstructorOf<T>()
         {
-            // Codegens must expand this intrinsic.
+            // Codegens must expand this intrinsic to the pointer to the default constructor of T
+            // or to a marker that lets us detect there's no default constructor.
             // We could implement a fallback with the type loader if we wanted to, but it will be slow and unreliable.
             throw new NotSupportedException();
         }
 
-        [ThreadStatic]
-        internal static bool s_createInstanceMissingDefaultConstructor;
-        internal class ClassWithMissingConstructor
+        [Intrinsic]
+        private static IntPtr AllocatorOf<T>()
+        {
+            // Codegens must expand this intrinsic to the pointer to the allocator suitable to allocate an instance of T.
+            // We could implement a fallback with the type loader if we wanted to, but it will be slow and unreliable.
+            throw new NotSupportedException();
+        }
+
+        internal static IntPtr GetFallbackDefaultConstructor()
+        {
+            return DefaultConstructorOf<ClassWithMissingConstructor>();
+        }
+
+        // Marker class. DefaultConstructorOf<T> expands to this type's constructor if
+        // the constructor is missing.
+        private class ClassWithMissingConstructor
         {
             private ClassWithMissingConstructor()
             {
-                s_createInstanceMissingDefaultConstructor = !s_createInstanceMissingDefaultConstructor;
-            }
-            internal static void MissingDefaultConstructorStaticEntryPoint()
-            {
-                s_createInstanceMissingDefaultConstructor = !s_createInstanceMissingDefaultConstructor;
             }
         }
 


### PR DESCRIPTION
|                              | Ratio |
|------------------------------|------:|
| new                          |   1.0 |
| Activator.CreateInstance old |  2.36 |
| Activator.CreateInstance new |  1.26 |

The existing implementation was a bit awkward because of how the intrinsic was implemented in .NET Native (the intrinsic in .NET Native did allocate+call default constructor - in CoreRT we have a separate intrinsic for "get default constructor").

.NET Native required an awkward dance around "uh-oh, this type doesn't have a default constructor, what should I call now". None of that is needed in CoreRT, but we had it there so that we don't diverge too much. It was 3x faster than CoreCLR anyway. We no longer have to worry about diverging and it seems like CoreCLR might be getting a perf boost here for .NET 5, so let's not stay behind.

In this commit:
* Removing the `s_createInstanceMissingDefaultConstructor` flag - we can do this check quickly by comparing the retrieved default constructor with `DefaultConstructorOf<ClassWithMissingConstructor>`.
* Removing upfront checks for arrays/strings/interfaces. We no longer have to worry about accidentally allocating them. We detect them as not having a default ctor.
* For an additional perf boost, exposing `AllocatorOf<T>`. This is a new intrinsic that expands to the existing `AllocatorOf` dictionary entry that represents the optimized allocator method for T. This entry is normally only used in universal shared code, but it's valid to use it outside of that.
* Extra compiler support for dictionary entries that are double indirections. `AllocatorOf` is doubly-indirect for USG reasons. We should probably keep that for universal shared code anyway.

There's still room left for improvement - RyuJIT currently doesn't have support for the `RawCalli` intrinsic and generates a normal calli for them. Normal calli needs to check for fat function pointers. These pointers are never fat pointers.