### PR TITLE
Update compiler from dotnet/runtime

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RyuJITVersion Condition="'$(RyuJITVersion)' == ''">5.0.0-alpha.1.20074.2</RyuJITVersion>
+    <RyuJITVersion Condition="'$(RyuJITVersion)' == ''">5.0.0-preview.1.20118.7</RyuJITVersion>
     <ObjectWriterVersion Condition="'$(ObjectWriterVersion)' == ''">1.0.0-alpha-28204-03</ObjectWriterVersion>
     <CoreFxVersion Condition="'$(CoreFxVersion)' == ''">5.0.0-alpha.1.19563.6</CoreFxVersion>
     <CoreFxUapVersion Condition="'$(CoreFxUapVersion)' == ''">4.7.0-preview6.19265.2</CoreFxUapVersion>

--- a/src/Common/src/Internal/Runtime/CorConstants.cs
+++ b/src/Common/src/Internal/Runtime/CorConstants.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/Internal/Runtime/ModuleHeaders.cs
+++ b/src/Common/src/Internal/Runtime/ModuleHeaders.cs
@@ -59,10 +59,13 @@ namespace Internal.Runtime
         // 107 is deprecated - it was used by an older format of AvailableTypes
         AvailableTypes = 108,
         InstanceMethodEntryPoints = 109,
-        InliningInfo = 110, // Added in v2.1
+        InliningInfo = 110, // Added in v2.1, deprecated in 4.1
         ProfileDataInfo = 111, // Added in v2.2
         ManifestMetadata = 112, // Added in v2.3
         AttributePresence = 113, // Added in V3.1
+        InliningInfo2 = 114, // Added in 4.1
+        ComponentAssemblies = 115, // Added in 4.1
+        OwnerCompositeExecutable = 116, // Added in 4.1
 
         //
         // CoreRT ReadyToRun sections

--- a/src/Common/src/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/Common/src/Internal/Runtime/ReadyToRunConstants.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,12 +7,14 @@ using System;
 namespace Internal.ReadyToRunConstants
 {
     [Flags]
-    public enum ReadyToRunFlag
+    public enum ReadyToRunFlags
     {
         READYTORUN_FLAG_PlatformNeutralSource = 0x00000001,     // Set if the original IL assembly was platform-neutral
         READYTORUN_FLAG_SkipTypeValidation = 0x00000002,        // Set of methods with native code was determined using profile data
         READYTORUN_FLAG_Partial = 0x00000004,
-        READYTORUN_FLAG_NonSharedPInvokeStubs = 0x00000008      // PInvoke stubs compiled into image are non-shareable (no secret parameter)
+        READYTORUN_FLAG_NonSharedPInvokeStubs = 0x00000008,     // PInvoke stubs compiled into image are non-shareable (no secret parameter)
+        READYTORUN_FLAG_EmbeddedMSIL = 0x00000010,              // MSIL is embedded in the composite R2R executable
+        READYTORUN_FLAG_Component = 0x00000020,                 // This is the header describing a component assembly of composite R2R
     }
 
     /// <summary>

--- a/src/Common/src/System/FormattingHelpers.cs
+++ b/src/Common/src/System/FormattingHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/ArrayType.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/ArrayType.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/ByRefType.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/ByRefType.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/CanonTypes.Diagnostic.cs
+++ b/src/Common/src/TypeSystem/Canon/CanonTypes.Diagnostic.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/CanonTypes.cs
+++ b/src/Common/src/TypeSystem/Canon/CanonTypes.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -71,7 +71,7 @@ namespace Internal.TypeSystem
 
         public override bool IsExplicitLayout => false;
 
-        public override ModuleDesc Module => _context.CanonTypesModule;
+        public override ModuleDesc Module => _context.SystemModule;
 
         public override bool IsModuleType => false;
 

--- a/src/Common/src/TypeSystem/Canon/DefType.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/DefType.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/InstantiatedMethod.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/InstantiatedMethod.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/InstantiatedType.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/InstantiatedType.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/MetadataType.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/MetadataType.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/MethodDesc.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/MethodDesc.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/ParameterizedType.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/ParameterizedType.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/PointerType.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/PointerType.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/SignatureVariable.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/SignatureVariable.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/StandardCanonicalizationAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Canon/StandardCanonicalizationAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/TypeDesc.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/TypeDesc.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Canon/TypeSystemContext.Canon.cs
+++ b/src/Common/src/TypeSystem/Canon/TypeSystemContext.Canon.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -42,11 +42,6 @@ namespace Internal.TypeSystem
                 }
                 return _universalCanonType;
             }
-        }
-
-        protected internal virtual ModuleDesc CanonTypesModule
-        {
-            get { return SystemModule; }
         }
 
         /// <summary>

--- a/src/Common/src/TypeSystem/Common/ExplicitLayoutValidator.cs
+++ b/src/Common/src/TypeSystem/Common/ExplicitLayoutValidator.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Common/IModuleResolver.cs
+++ b/src/Common/src/TypeSystem/Common/IModuleResolver.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+namespace Internal.TypeSystem
+{
+    public interface IModuleResolver
+    {
+        ModuleDesc ResolveAssembly(AssemblyName name, bool throwIfNotFound = true);
+        ModuleDesc ResolveModule(IAssemblyDesc referencingModule, string fileName, bool throwIfNotFound = true);
+    }
+}

--- a/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -425,7 +425,7 @@ namespace Internal.TypeSystem
             return computedLayout;
         }
 
-        protected virtual void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset)
+        protected virtual void AlignBaseOffsetIfNecessary(MetadataType type, ref LayoutInt baseOffset, bool requiresAlign8)
         {
         }
 
@@ -433,8 +433,6 @@ namespace Internal.TypeSystem
         {
             // For types inheriting from another type, field offsets continue on from where they left off
             LayoutInt cumulativeInstanceFieldPos = ComputeBytesUsedInParentType(type);
-
-            AlignBaseOffsetIfNecessary(type, ref cumulativeInstanceFieldPos);
 
             var layoutMetadata = type.GetClassLayout();
 
@@ -459,6 +457,7 @@ namespace Internal.TypeSystem
                     continue;
 
                 TypeDesc fieldType = field.FieldType;
+
                 if (IsByValueClass(fieldType))
                 {
                     instanceValueClassFieldCount++;
@@ -495,6 +494,7 @@ namespace Internal.TypeSystem
             // Reset the counters to be used later as the index to insert into the array
             instanceGCPointerFieldsCount = 0;
             instanceValueClassFieldCount = 0;
+            LayoutInt largestAlignmentRequired = LayoutInt.One;
 
             // Iterate over all fields and do the following
             //   - Add instance fields to the appropriate array (while maintaining the enumerated order)
@@ -506,6 +506,9 @@ namespace Internal.TypeSystem
 
                 TypeDesc fieldType = field.FieldType;
 
+                var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType, packingSize);
+                largestAlignmentRequired = LayoutInt.Max(fieldSizeAndAlignment.Alignment, largestAlignmentRequired);
+
                 if (IsByValueClass(fieldType))
                 {
                     instanceValueClassFieldsArr[instanceValueClassFieldCount++] = field;
@@ -516,11 +519,14 @@ namespace Internal.TypeSystem
                 }
                 else
                 {
-                    var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType, packingSize);
                     int log2size = CalculateLog2(fieldSizeAndAlignment.Size.AsInt);
                     instanceNonGCPointerFieldsArr[log2size][instanceNonGCPointerFieldsCount[log2size]++] = field;
                 }
             }
+
+            largestAlignmentRequired = type.Context.Target.GetObjectAlignment(largestAlignmentRequired);
+            bool requiresAlign8 = !largestAlignmentRequired.IsIndeterminate && largestAlignmentRequired.AsInt > 4;
+            AlignBaseOffsetIfNecessary(type, ref cumulativeInstanceFieldPos, requiresAlign8);
 
             // We've finished placing the fields into their appropriate arrays
             // The next optimization may place non-GC Pointers, so repurpose our

--- a/src/Common/src/TypeSystem/Common/MetadataType.MethodImpls.cs
+++ b/src/Common/src/TypeSystem/Common/MetadataType.MethodImpls.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Common/TargetDetails.cs
+++ b/src/Common/src/TypeSystem/Common/TargetDetails.cs
@@ -323,7 +323,7 @@ namespace Internal.TypeSystem
             get
             {
                 // There is a hard limit of 4 elements on an HFA type, see
-                // http://blogs.msdn.com/b/vcblog/archive/2013/07/12/introducing-vector-calling-convention.aspx
+                // https://devblogs.microsoft.com/cppblog/introducing-vector-calling-convention/
                 Debug.Assert(Architecture == TargetArchitecture.ARM ||
                     Architecture == TargetArchitecture.ARM64 ||
                     Architecture == TargetArchitecture.X64 ||

--- a/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/Common/src/TypeSystem/Common/TypeSystemContext.cs
@@ -11,7 +11,7 @@ using Internal.NativeFormat;
 
 namespace Internal.TypeSystem
 {
-    public abstract partial class TypeSystemContext
+    public abstract partial class TypeSystemContext : IModuleResolver
     {
         public TypeSystemContext() : this(new TargetDetails(TargetArchitecture.Unknown, TargetOS.Unknown, TargetAbi.Unknown))
         {
@@ -71,6 +71,11 @@ namespace Internal.TypeSystem
             if (throwIfNotFound)
                 throw new NotSupportedException();
             return null;
+        }
+
+        ModuleDesc IModuleResolver.ResolveModule(IAssemblyDesc referencingModule, string fileName, bool throwIfNotFound)
+        {
+            return ResolveModule(referencingModule, fileName, throwIfNotFound);
         }
 
         //

--- a/src/Common/src/TypeSystem/Ecma/EcmaAssembly.Symbols.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaAssembly.Symbols.cs
@@ -10,8 +10,8 @@ namespace Internal.TypeSystem.Ecma
     // Pluggable file that adds PDB handling functionality to EcmaAssembly
     partial class EcmaAssembly
     {
-        internal EcmaAssembly(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader, PdbSymbolReader pdbReader)
-            : base(context, peReader, metadataReader, containingAssembly: null, pdbReader)
+        internal EcmaAssembly(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader, PdbSymbolReader pdbReader, IModuleResolver customModuleResolver)
+            : base(context, peReader, metadataReader, containingAssembly: null, pdbReader, customModuleResolver)
         {
             _assemblyDefinition = metadataReader.GetAssemblyDefinition();
         }

--- a/src/Common/src/TypeSystem/Ecma/EcmaAssembly.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaAssembly.cs
@@ -29,8 +29,8 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public EcmaAssembly(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader)
-            : base(context, peReader, metadataReader, containingAssembly: null)
+        public EcmaAssembly(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader, IModuleResolver customModuleResolver)
+            : base(context, peReader, metadataReader, containingAssembly: null, customModuleResolver: customModuleResolver)
         {
             if (!metadataReader.IsAssembly)
             {

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.Symbols.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.Symbols.cs
@@ -15,20 +15,20 @@ namespace Internal.TypeSystem.Ecma
             get;
         }
 
-        internal EcmaModule(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader, IAssemblyDesc containingAssembly, PdbSymbolReader pdbReader)
-            : this(context, peReader, metadataReader, containingAssembly)
+        internal EcmaModule(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader, IAssemblyDesc containingAssembly, PdbSymbolReader pdbReader, IModuleResolver customModuleResolver)
+            : this(context, peReader, metadataReader, containingAssembly, customModuleResolver)
         {
             PdbReader = pdbReader;
         }
 
-        public static EcmaModule Create(TypeSystemContext context, PEReader peReader, IAssemblyDesc containingAssembly, PdbSymbolReader pdbReader)
+        public static EcmaModule Create(TypeSystemContext context, PEReader peReader, IAssemblyDesc containingAssembly, PdbSymbolReader pdbReader, IModuleResolver customModuleResolver = null)
         {
             MetadataReader metadataReader = CreateMetadataReader(context, peReader);
 
             if (containingAssembly == null)
-                return new EcmaAssembly(context, peReader, metadataReader, pdbReader);
+                return new EcmaAssembly(context, peReader, metadataReader, pdbReader, customModuleResolver);
             else
-                return new EcmaModule(context, peReader, metadataReader, containingAssembly, pdbReader);
+                return new EcmaModule(context, peReader, metadataReader, containingAssembly, pdbReader, customModuleResolver);
         }
     }
 }

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -171,27 +171,30 @@ namespace Internal.TypeSystem.Ecma
         {
             ModuleReference moduleReference = _metadataReader.GetModuleReference(handle);
             string fileName = _metadataReader.GetString(moduleReference.Name);
-            return Context.ResolveModule(this.Assembly, fileName);
+
+            return _moduleResolver.ResolveModule(this.Assembly, fileName);
         }
 
         private LockFreeReaderHashtable<EntityHandle, IEntityHandleObject> _resolvedTokens;
+        IModuleResolver _moduleResolver;
 
-        internal EcmaModule(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader, IAssemblyDesc containingAssembly)
+        internal EcmaModule(TypeSystemContext context, PEReader peReader, MetadataReader metadataReader, IAssemblyDesc containingAssembly, IModuleResolver customModuleResolver)
             : base(context, containingAssembly)
         {
             _peReader = peReader;
             _metadataReader = metadataReader;
             _resolvedTokens = new EcmaObjectLookupHashtable(this);
+            _moduleResolver = customModuleResolver != null ? customModuleResolver : context;
         }
 
-        public static EcmaModule Create(TypeSystemContext context, PEReader peReader, IAssemblyDesc containingAssembly)
+        public static EcmaModule Create(TypeSystemContext context, PEReader peReader, IAssemblyDesc containingAssembly, IModuleResolver customModuleResolver = null)
         {
             MetadataReader metadataReader = CreateMetadataReader(context, peReader);
 
             if (containingAssembly == null)
-                return new EcmaAssembly(context, peReader, metadataReader);
+                return new EcmaAssembly(context, peReader, metadataReader, customModuleResolver);
             else
-                return new EcmaModule(context, peReader, metadataReader, containingAssembly);
+                return new EcmaModule(context, peReader, metadataReader, containingAssembly, customModuleResolver);
         }
 
         private static MetadataReader CreateMetadataReader(TypeSystemContext context, PEReader peReader)
@@ -260,6 +263,18 @@ namespace Internal.TypeSystem.Ecma
 
                 // Bad metadata
                 throw new BadImageFormatException();
+            }
+        }
+
+        public bool IsPlatformNeutral
+        {
+            get
+            {
+                PEHeaders peHeaders = PEReader.PEHeaders;
+                return peHeaders.PEHeader.Magic == PEMagic.PE32
+                    && (peHeaders.CorHeader.Flags & (CorFlags.Prefers32Bit | CorFlags.Requires32Bit)) != CorFlags.Requires32Bit
+                    && (peHeaders.CorHeader.Flags & CorFlags.ILOnly) != 0
+                    && peHeaders.CoffHeader.Machine == Machine.I386;
             }
         }
 
@@ -485,7 +500,7 @@ namespace Internal.TypeSystem.Ecma
             an.CultureName = _metadataReader.GetString(assemblyReference.Culture);
             an.ContentType = GetContentTypeFromAssemblyFlags(assemblyReference.Flags);
 
-            return Context.ResolveAssembly(an);
+            return _moduleResolver.ResolveAssembly(an);
         }
 
         private Object ResolveExportedType(ExportedTypeHandle handle)

--- a/src/Common/src/TypeSystem/Ecma/SymbolReader/UnmanagedPdbSymbolReader.cs
+++ b/src/Common/src/TypeSystem/Ecma/SymbolReader/UnmanagedPdbSymbolReader.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -340,10 +340,13 @@ namespace Internal.TypeSystem.Interop
                 // * Vector64<T>: Represents the __m64 ABI primitive which requires currently unimplemented handling
                 // * Vector128<T>: Represents the __m128 ABI primitive which requires currently unimplemented handling
                 // * Vector256<T>: Represents the __m256 ABI primitive which requires currently unimplemented handling
-                // * Vector<T>: Has a variable size (either __m128 or __m256) and isn't readily usable for inteorp scenarios
+                // * Vector<T>: Has a variable size (either __m128 or __m256) and isn't readily usable for interop scenarios
+                // We can't block these types for field scenarios for back-compat reasons.
 
-                if (type.HasInstantiation && (!isBlittable
+                if (type.HasInstantiation && !isField && (!isBlittable
                     || InteropTypes.IsSystemByReference(context, type)
+                    || InteropTypes.IsSystemSpan(context, type)
+                    || InteropTypes.IsSystemReadOnlySpan(context, type)
                     || InteropTypes.IsSystemNullable(context, type)
                     || InteropTypes.IsSystemRuntimeIntrinsicsVector64T(context, type)
                     || InteropTypes.IsSystemRuntimeIntrinsicsVector128T(context, type)

--- a/src/Common/src/TypeSystem/Interop/InteropTypes.cs
+++ b/src/Common/src/TypeSystem/Interop/InteropTypes.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -111,6 +111,16 @@ namespace Internal.TypeSystem.Interop
         public static bool IsSystemByReference(TypeSystemContext context, TypeDesc type)
         {
             return IsCoreNamedType(context, type, "System", "ByReference`1");
+        }
+
+        public static bool IsSystemSpan(TypeSystemContext context, TypeDesc type)
+        {
+            return IsCoreNamedType(context, type, "System", "Span`1");
+        }
+
+        public static bool IsSystemReadOnlySpan(TypeSystemContext context, TypeDesc type)
+        {
+            return IsCoreNamedType(context, type, "System", "ReadOnlySpan`1");
         }
 
         public static bool IsSystemNullable(TypeSystemContext context, TypeDesc type)

--- a/src/Common/src/TypeSystem/RuntimeDetermined/DefType.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/DefType.RuntimeDetermined.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/RuntimeDetermined/ParameterizedType.RuntimeDetermined.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/ParameterizedType.RuntimeDetermined.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedCanonicalizationAlgorithm.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedCanonicalizationAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/CodeGenerationFailedException.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CodeGenerationFailedException.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -71,8 +71,6 @@ namespace ILCompiler
         public abstract CompilationBuilder UseILProvider(ILProvider ilProvider);
 
         protected abstract ILProvider GetILProvider();
-
-        public abstract CompilationBuilder UseJitPath(string jitPath);
 
         protected DependencyAnalyzerBase<NodeFactory> CreateDependencyGraph(NodeFactory factory, IComparer<DependencyNodeCore<NodeFactory>> comparer = null)
         {

--- a/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilationModuleGroup.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.Validation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.Validation.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.cs
@@ -106,31 +106,22 @@ namespace ILCompiler
             return GetModuleForSimpleName(name.Name, throwIfNotFound);
         }
 
-        public ModuleDesc GetModuleForSimpleName(string simpleName, bool throwIfNotFound = true)
+        public EcmaModule GetModuleForSimpleName(string simpleName, bool throwIfNotFound = true)
         {
-            ModuleData existing;
-            if (_simpleNameHashtable.TryGetValue(simpleName, out existing))
+            if (_simpleNameHashtable.TryGetValue(simpleName, out ModuleData existing))
                 return existing.Module;
 
-            string filePath;
-            if (!InputFilePaths.TryGetValue(simpleName, out filePath))
-            {
-                if (!ReferenceFilePaths.TryGetValue(simpleName, out filePath))
-                {
-                    // We allow the CanonTypesModule to not be an EcmaModule.
-                    if (((IAssemblyDesc)CanonTypesModule).GetName().Name == simpleName)
-                        return CanonTypesModule;
+            if (InputFilePaths.TryGetValue(simpleName, out string filePath)
+                || ReferenceFilePaths.TryGetValue(simpleName, out filePath))
+                return AddModule(filePath, simpleName, true);
 
-                    // TODO: the exception is wrong for two reasons: for one, this should be assembly full name, not simple name.
-                    // The other reason is that on CoreCLR, the exception also captures the reason. We should be passing two
-                    // string IDs. This makes this rather annoying.
-                    if (throwIfNotFound)
-                        ThrowHelper.ThrowFileNotFoundException(ExceptionStringID.FileLoadErrorGeneric, simpleName);
-                    return null;
-                }
-            }
+            // TODO: the exception is wrong for two reasons: for one, this should be assembly full name, not simple name.
+            // The other reason is that on CoreCLR, the exception also captures the reason. We should be passing two
+            // string IDs. This makes this rather annoying.
+            if (throwIfNotFound)
+                ThrowHelper.ThrowFileNotFoundException(ExceptionStringID.FileLoadErrorGeneric, simpleName);
 
-            return AddModule(filePath, simpleName, true);
+            return null;
         }
 
         public EcmaModule GetModuleFromPath(string filePath)

--- a/src/ILCompiler.Compiler/src/Compiler/CoreRTNameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CoreRTNameMangler.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CompilerComparer.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/CompilerComparer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedDataContainerNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EmbeddedDataContainerNode.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodBodyNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodBodyNode.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/IMethodNode.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/INodeWithRuntimeDeterminedDependencies.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/INodeWithRuntimeDeterminedDependencies.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ISortableNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ISortableNode.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -290,6 +290,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.IMAGE_REL_BASED_ABSOLUTE:
                 case RelocType.IMAGE_REL_BASED_HIGHLOW:
                 case RelocType.IMAGE_REL_SECREL:
+                case RelocType.IMAGE_REL_FILE_ABSOLUTE:
                 case RelocType.IMAGE_REL_BASED_ADDR32NB:
                 case RelocType.IMAGE_REL_SYMBOL_SIZE:
                     EmitInt(delta);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/Relocation.cs
@@ -29,7 +29,8 @@ namespace ILCompiler.DependencyAnalysis
         //
         // Relocations for R2R image production
         //
-        IMAGE_REL_SYMBOL_SIZE = 0x1000,             // The size of data in the image represented by the target symbol node
+        IMAGE_REL_SYMBOL_SIZE           = 0x1000,   // The size of data in the image represented by the target symbol node
+        IMAGE_REL_FILE_ABSOLUTE         = 0x1001,   // 32 bit offset from begining of image
     }
 
     public struct Relocation
@@ -272,6 +273,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.IMAGE_REL_BASED_REL32:
                 case RelocType.IMAGE_REL_BASED_ADDR32NB:
                 case RelocType.IMAGE_REL_SYMBOL_SIZE:
+                case RelocType.IMAGE_REL_FILE_ABSOLUTE:
                     *(int*)location = (int)value;
                     break;
                 case RelocType.IMAGE_REL_BASED_DIR64:
@@ -305,6 +307,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.IMAGE_REL_BASED_REL32:
                 case RelocType.IMAGE_REL_BASED_RELPTR32:
                 case RelocType.IMAGE_REL_SECREL:
+                case RelocType.IMAGE_REL_FILE_ABSOLUTE:
                 case RelocType.IMAGE_REL_SYMBOL_SIZE:
                     return *(int*)location;
                 case RelocType.IMAGE_REL_BASED_DIR64:

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ShadowConcreteMethodNode.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/SortableDependencyNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/SortableDependencyNode.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -59,6 +59,7 @@ namespace ILCompiler.DependencyAnalysis
             //
             CorHeaderNode,
             ReadyToRunHeaderNode,
+            ReadyToRunAssemblyHeaderNode,
             ImportSectionsTableNode,
             ImportSectionNode,
             MethodEntrypointTableNode,

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyTrackingLevel.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyTrackingLevel.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/DevirtualizationManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DevirtualizationManager.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/HardwareIntrinsicHelpers.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/HardwareIntrinsicHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/ICompilationRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/ICompilationRootProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/InternalCompilerErrorException.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/InternalCompilerErrorException.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/SingleMethodRootProvider.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/SingleMethodRootProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.CppCodeGen/src/Compiler/CppCodegenCompilationBuilder.cs
@@ -49,11 +49,6 @@ namespace ILCompiler
 
             return new CppCodegenCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _config);
         }
-
-        public override CompilationBuilder UseJitPath(string jitPath)
-        {
-            throw new NotImplementedException();
-        }
     }
 
     internal class CppCodegenConfigProvider

--- a/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilation.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilation.cs
@@ -20,7 +20,6 @@ namespace ILCompiler
     public sealed class RyuJitCompilation : Compilation
     {
         private readonly ConditionalWeakTable<Thread, CorInfoImpl> _corinfos = new ConditionalWeakTable<Thread, CorInfoImpl>();
-        private readonly JitConfigProvider _jitConfigProvider;
         internal readonly RyuJitCompilationOptions _compilationOptions;
         private readonly ExternSymbolMappedField _hardwareIntrinsicFlags;
         private CountdownEvent _compilationCountdown;
@@ -33,11 +32,9 @@ namespace ILCompiler
             DebugInformationProvider debugInformationProvider,
             Logger logger,
             DevirtualizationManager devirtualizationManager,
-            JitConfigProvider configProvider,
             RyuJitCompilationOptions options)
             : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, devirtualizationManager, logger)
         {
-            _jitConfigProvider = configProvider;
             _compilationOptions = options;
             _hardwareIntrinsicFlags = new ExternSymbolMappedField(nodeFactory.TypeSystemContext.GetWellKnownType(WellKnownType.Int32), "g_cpuFeatures");
         }
@@ -97,7 +94,7 @@ namespace ILCompiler
 
             WaitCallback compileSingleMethodDelegate = m =>
             {
-                CorInfoImpl corInfo = _corinfos.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this, _jitConfigProvider));
+                CorInfoImpl corInfo = _corinfos.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this));
                 CompileSingleMethod(corInfo, (MethodCodeNode)m);
             };
 
@@ -117,7 +114,7 @@ namespace ILCompiler
 
         private void CompileSingleThreaded(List<MethodCodeNode> methodsToCompile)
         {
-            CorInfoImpl corInfo = _corinfos.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this, _jitConfigProvider));
+            CorInfoImpl corInfo = _corinfos.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this));
 
             foreach (MethodCodeNode methodCodeNodeNeedingCode in methodsToCompile)
             {

--- a/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/RyuJitCompilationBuilder.cs
@@ -108,14 +108,9 @@ namespace ILCompiler
 
             var factory = new RyuJitNodeFactory(_context, _compilationGroup, _metadataManager, _interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider);
 
-            var jitConfig = new JitConfigProvider(jitFlagBuilder.ToArray(), _ryujitOptions);
+            JitConfigProvider.Initialize(jitFlagBuilder.ToArray(), _ryujitOptions);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
-            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _devirtualizationManager, jitConfig, options);
-        }
-
-        public override CompilationBuilder UseJitPath(string jitPath)
-        {
-            throw new NotImplementedException();
+            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _devirtualizationManager, options);
         }
     }
 }

--- a/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/ILCompiler.RyuJit/src/JitInterface/CorInfoImpl.RyuJit.cs
@@ -42,8 +42,8 @@ namespace Internal.JitInterface
         private Dictionary<uint, string> _parameterIndexToNameMap;
         private TypeDesc[] _variableToTypeDesc;
 
-        public CorInfoImpl(RyuJitCompilation compilation, JitConfigProvider jitConfig)
-            : this(jitConfig)
+        public CorInfoImpl(RyuJitCompilation compilation)
+            : this()
         {
             _compilation = compilation;
         }
@@ -1695,6 +1695,152 @@ namespace Internal.JitInterface
         private void setEHinfo(uint EHnumber, ref CORINFO_EH_CLAUSE clause)
         {
             _ehClauses[EHnumber] = clause;
+        }
+
+        private void reportInliningDecision(CORINFO_METHOD_STRUCT_* inlinerHnd, CORINFO_METHOD_STRUCT_* inlineeHnd, CorInfoInline inlineResult, byte* reason)
+        {
+        }
+
+        private void getFieldInfo(ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_ACCESS_FLAGS flags, CORINFO_FIELD_INFO* pResult)
+        {
+#if DEBUG
+            // In debug, write some bogus data to the struct to ensure we have filled everything
+            // properly.
+            MemoryHelper.FillMemory((byte*)pResult, 0xcc, Marshal.SizeOf<CORINFO_FIELD_INFO>());
+#endif
+
+            Debug.Assert(((int)flags & ((int)CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_GET |
+                                        (int)CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_SET |
+                                        (int)CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_ADDRESS |
+                                        (int)CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_INIT_ARRAY)) != 0);
+
+            var field = HandleToObject(pResolvedToken.hField);
+
+            CORINFO_FIELD_ACCESSOR fieldAccessor;
+            CORINFO_FIELD_FLAGS fieldFlags = (CORINFO_FIELD_FLAGS)0;
+            uint fieldOffset = (field.IsStatic && field.HasRva ? 0xBAADF00D : (uint)field.Offset.AsInt);
+
+            if (field.IsStatic)
+            {
+                fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_STATIC;
+
+                if (field.HasRva)
+                {
+                    fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_UNMANAGED;
+
+                    // TODO: Handle the case when the RVA is in the TLS range
+                    fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_RVA_ADDRESS;
+
+                    // We are not going through a helper. The constructor has to be triggered explicitly.
+                    if (_compilation.HasLazyStaticConstructor(field.OwningType))
+                    {
+                        fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_INITCLASS;
+                    }
+                }
+                else if (field.OwningType.IsCanonicalSubtype(CanonicalFormKind.Any))
+                {
+                    // The JIT wants to know how to access a static field on a generic type. We need a runtime lookup.
+                    fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_READYTORUN_HELPER;
+                    pResult->helper = CorInfoHelpFunc.CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE;
+
+                    // Don't try to compute the runtime lookup if we're inlining. The JIT is going to abort the inlining
+                    // attempt anyway.
+                    MethodDesc contextMethod = methodFromContext(pResolvedToken.tokenContext);
+                    if (contextMethod == MethodBeingCompiled)
+                    {
+                        FieldDesc runtimeDeterminedField = (FieldDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
+
+                        ReadyToRunHelperId helperId;
+
+                        // Find out what kind of base do we need to look up.
+                        if (field.IsThreadStatic)
+                        {
+                            helperId = ReadyToRunHelperId.GetThreadStaticBase;
+                        }
+                        else if (field.HasGCStaticBase)
+                        {
+                            helperId = ReadyToRunHelperId.GetGCStaticBase;
+                        }
+                        else
+                        {
+                            helperId = ReadyToRunHelperId.GetNonGCStaticBase;
+                        }
+
+                        // What generic context do we look up the base from.
+                        ISymbolNode helper;
+                        if (contextMethod.AcquiresInstMethodTableFromThis() || contextMethod.RequiresInstMethodTableArg())
+                        {
+                            helper = _compilation.NodeFactory.ReadyToRunHelperFromTypeLookup(
+                                helperId, runtimeDeterminedField.OwningType, contextMethod.OwningType);
+                        }
+                        else
+                        {
+                            Debug.Assert(contextMethod.RequiresInstMethodDescArg());
+                            helper = _compilation.NodeFactory.ReadyToRunHelperFromDictionaryLookup(
+                                helperId, runtimeDeterminedField.OwningType, contextMethod);
+                        }
+
+                        pResult->fieldLookup = CreateConstLookupToSymbol(helper);
+                    }
+                }
+                else
+                {
+                    fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_SHARED_STATIC_HELPER;
+                    pResult->helper = CorInfoHelpFunc.CORINFO_HELP_READYTORUN_STATIC_BASE;
+
+                    ReadyToRunHelperId helperId = ReadyToRunHelperId.Invalid;
+                    CORINFO_FIELD_ACCESSOR intrinsicAccessor;
+                    if (field.IsIntrinsic &&
+                        (flags & CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_GET) != 0 &&
+                        (intrinsicAccessor = getFieldIntrinsic(field)) != (CORINFO_FIELD_ACCESSOR)(-1))
+                    {
+                        fieldAccessor = intrinsicAccessor;
+                    }
+                    else if (field.IsThreadStatic)
+                    {
+                        helperId = ReadyToRunHelperId.GetThreadStaticBase;
+                    }
+                    else
+                    {
+                        helperId = field.HasGCStaticBase ?
+                            ReadyToRunHelperId.GetGCStaticBase :
+                            ReadyToRunHelperId.GetNonGCStaticBase;
+
+                        //
+                        // Currently, we only do this optimization for regular statics, but it
+                        // looks like it may be permissible to do this optimization for
+                        // thread statics as well.
+                        //
+                        if ((flags & CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_ADDRESS) != 0 &&
+                            (fieldAccessor != CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_TLS))
+                        {
+                            fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_SAFESTATIC_BYREF_RETURN;
+                        }
+                    }
+
+                    if (helperId != ReadyToRunHelperId.Invalid)
+                    {
+                        pResult->fieldLookup = CreateConstLookupToSymbol(
+                            _compilation.NodeFactory.ReadyToRunHelper(helperId, field.OwningType));
+                    }
+                }
+            }
+            else
+            {
+                fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INSTANCE;
+            }
+
+            if (field.IsInitOnly)
+                fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_FINAL;
+
+            pResult->fieldAccessor = fieldAccessor;
+            pResult->fieldFlags = fieldFlags;
+            pResult->fieldType = getFieldType(pResolvedToken.hField, &pResult->structType, pResolvedToken.hClass);
+            pResult->accessAllowed = CorInfoIsAccessAllowedResult.CORINFO_ACCESS_ALLOWED;
+            pResult->offset = fieldOffset;
+
+            // TODO: We need to implement access checks for fields and methods.  See JitInterface.cpp in mrtjit
+            //       and STS::AccessCheck::CanAccess.
         }
     }
 }

--- a/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
+++ b/src/ILCompiler.TypeSystem/src/ILCompiler.TypeSystem.csproj
@@ -187,6 +187,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\ExplicitLayoutValidator.cs">
       <Link>TypeSystem\Common\ExplicitLayoutValidator.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\IModuleResolver.cs">
+      <Link>TypeSystem\Common\IModuleResolver.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedMethod.cs">
       <Link>TypeSystem\Common\InstantiatedMethod.cs</Link>
     </Compile>

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilationBuilder.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilationBuilder.cs
@@ -48,11 +48,6 @@ namespace ILCompiler
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
             return new WebAssemblyCodegenCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _config);
         }
-
-        public override CompilationBuilder UseJitPath(string jitPath)
-        {
-            throw new NotImplementedException();
-        }
     }
 
     internal class WebAssemblyCodegenConfigProvider

--- a/src/ILCompiler/RyuJIT/RyuJIT.depproj
+++ b/src/ILCompiler/RyuJIT/RyuJIT.depproj
@@ -12,9 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Jit">
+    <PackageReference Include="Microsoft.NETCore.App.Runtime.$(NuPkgRid)">
       <Version>$(RyuJITVersion)</Version>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <FileToInclude Include="clrjit" />
   </ItemGroup>
 
   <Target Name="RenameToJitIlc">

--- a/src/ILCompiler/RyuJIT/RyuJIT.depproj
+++ b/src/ILCompiler/RyuJIT/RyuJIT.depproj
@@ -18,7 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FileToInclude Include="clrjit" />
+    <FileToInclude Include="clrjit" Condition="'$(TargetsUnix)' != 'true'" />
+    <FileToInclude Include="libclrjit" Condition="'$(TargetsUnix)' == 'true'" />
   </ItemGroup>
 
   <Target Name="RenameToJitIlc">

--- a/src/ILVerification/src/ILVerification.csproj
+++ b/src/ILVerification/src/ILVerification.csproj
@@ -103,6 +103,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\FieldLayoutAlgorithm.cs">
       <Link>TypeSystem\Common\FieldLayoutAlgorithm.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\IModuleResolver.cs">
+      <Link>TypeSystem\Common\IModuleResolver.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedMethod.cs">
       <Link>TypeSystem\Common\InstantiatedMethod.cs</Link>
     </Compile>

--- a/src/JitInterface/src/CorInfoBase.cs
+++ b/src/JitInterface/src/CorInfoBase.cs
@@ -84,6 +84,8 @@ namespace Internal.JitInterface
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
         [return: MarshalAs(UnmanagedType.Bool)]delegate bool __isValidStringRef(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, uint metaTOK);
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
+        delegate char* __getStringLiteral(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, uint metaTOK, ref int length);
+        [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
         [return: MarshalAs(UnmanagedType.Bool)]delegate bool __shouldEnforceCallvirtRestriction(IntPtr _this, IntPtr* ppException, CORINFO_MODULE_STRUCT_* scope);
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
         delegate CorInfoType __asCorInfoType(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
@@ -94,7 +96,7 @@ namespace Internal.JitInterface
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
         delegate CORINFO_CLASS_STRUCT_* __getTypeInstantiationArgument(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls, uint index);
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
-        delegate int __appendClassName(IntPtr _this, IntPtr* ppException, short** ppBuf, ref int pnBufLen, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fNamespace, [MarshalAs(UnmanagedType.Bool)]bool fFullInst, [MarshalAs(UnmanagedType.Bool)]bool fAssembly);
+        delegate int __appendClassName(IntPtr _this, IntPtr* ppException, char** ppBuf, ref int pnBufLen, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fNamespace, [MarshalAs(UnmanagedType.Bool)]bool fFullInst, [MarshalAs(UnmanagedType.Bool)]bool fAssembly);
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
         [return: MarshalAs(UnmanagedType.Bool)]delegate bool __isValueClass(IntPtr _this, IntPtr* ppException, CORINFO_CLASS_STRUCT_* cls);
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
@@ -228,7 +230,7 @@ namespace Internal.JitInterface
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
         delegate HRESULT __GetErrorHRESULT(IntPtr _this, IntPtr* ppException, _EXCEPTION_POINTERS* pExceptionPointers);
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
-        delegate uint __GetErrorMessage(IntPtr _this, IntPtr* ppException, short* buffer, uint bufferLength);
+        delegate uint __GetErrorMessage(IntPtr _this, IntPtr* ppException, char* buffer, uint bufferLength);
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
         delegate int __FilterException(IntPtr _this, IntPtr* ppException, _EXCEPTION_POINTERS* pExceptionPointers);
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
@@ -242,7 +244,7 @@ namespace Internal.JitInterface
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
         delegate void __getEEInfo(IntPtr _this, IntPtr* ppException, ref CORINFO_EE_INFO pEEInfoOut);
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
-        [return: MarshalAs(UnmanagedType.LPWStr)]delegate string __getJitTimeLogFilename(IntPtr _this, IntPtr* ppException);
+        delegate char* __getJitTimeLogFilename(IntPtr _this, IntPtr* ppException);
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
         delegate mdToken __getMethodDefFromMethod(IntPtr _this, IntPtr* ppException, CORINFO_METHOD_STRUCT_* hMethod);
         [UnmanagedFunctionPointerAttribute(default(CallingConvention))]
@@ -860,6 +862,20 @@ namespace Internal.JitInterface
             }
         }
 
+        static char* _getStringLiteral(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* module, uint metaTOK, ref int length)
+        {
+            var _this = GetThis(thisHandle);
+            try
+            {
+                return _this.getStringLiteral(module, metaTOK, ref length);
+            }
+            catch (Exception ex)
+            {
+                *ppException = _this.AllocException(ex);
+                return default(char*);
+            }
+        }
+
         [return: MarshalAs(UnmanagedType.Bool)]static bool _shouldEnforceCallvirtRestriction(IntPtr thisHandle, IntPtr* ppException, CORINFO_MODULE_STRUCT_* scope)
         {
             var _this = GetThis(thisHandle);
@@ -930,7 +946,7 @@ namespace Internal.JitInterface
             }
         }
 
-        static int _appendClassName(IntPtr thisHandle, IntPtr* ppException, short** ppBuf, ref int pnBufLen, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fNamespace, [MarshalAs(UnmanagedType.Bool)]bool fFullInst, [MarshalAs(UnmanagedType.Bool)]bool fAssembly)
+        static int _appendClassName(IntPtr thisHandle, IntPtr* ppException, char** ppBuf, ref int pnBufLen, CORINFO_CLASS_STRUCT_* cls, [MarshalAs(UnmanagedType.Bool)]bool fNamespace, [MarshalAs(UnmanagedType.Bool)]bool fFullInst, [MarshalAs(UnmanagedType.Bool)]bool fAssembly)
         {
             var _this = GetThis(thisHandle);
             try
@@ -1859,7 +1875,7 @@ namespace Internal.JitInterface
             }
         }
 
-        static uint _GetErrorMessage(IntPtr thisHandle, IntPtr* ppException, short* buffer, uint bufferLength)
+        static uint _GetErrorMessage(IntPtr thisHandle, IntPtr* ppException, char* buffer, uint bufferLength)
         {
             var _this = GetThis(thisHandle);
             try
@@ -1953,7 +1969,7 @@ namespace Internal.JitInterface
             }
         }
 
-        [return: MarshalAs(UnmanagedType.LPWStr)]static string _getJitTimeLogFilename(IntPtr thisHandle, IntPtr* ppException)
+        static char* _getJitTimeLogFilename(IntPtr thisHandle, IntPtr* ppException)
         {
             var _this = GetThis(thisHandle);
             try
@@ -1963,7 +1979,7 @@ namespace Internal.JitInterface
             catch (Exception ex)
             {
                 *ppException = _this.AllocException(ex);
-                return default(string);
+                return default(char*);
             }
         }
 
@@ -2833,8 +2849,8 @@ namespace Internal.JitInterface
 
         static IntPtr GetUnmanagedCallbacks(out Object keepAlive)
         {
-            IntPtr * callbacks = (IntPtr *)Marshal.AllocCoTaskMem(sizeof(IntPtr) * 179);
-            Object[] delegates = new Object[179];
+            IntPtr * callbacks = (IntPtr *)Marshal.AllocCoTaskMem(sizeof(IntPtr) * 180);
+            Object[] delegates = new Object[180];
 
             var d0 = new __getMethodAttribs(_getMethodAttribs);
             callbacks[0] = Marshal.GetFunctionPointerForDelegate(d0);
@@ -2944,435 +2960,438 @@ namespace Internal.JitInterface
             var d35 = new __isValidStringRef(_isValidStringRef);
             callbacks[35] = Marshal.GetFunctionPointerForDelegate(d35);
             delegates[35] = d35;
-            var d36 = new __shouldEnforceCallvirtRestriction(_shouldEnforceCallvirtRestriction);
+            var d36 = new __getStringLiteral(_getStringLiteral);
             callbacks[36] = Marshal.GetFunctionPointerForDelegate(d36);
             delegates[36] = d36;
-            var d37 = new __asCorInfoType(_asCorInfoType);
+            var d37 = new __shouldEnforceCallvirtRestriction(_shouldEnforceCallvirtRestriction);
             callbacks[37] = Marshal.GetFunctionPointerForDelegate(d37);
             delegates[37] = d37;
-            var d38 = new __getClassName(_getClassName);
+            var d38 = new __asCorInfoType(_asCorInfoType);
             callbacks[38] = Marshal.GetFunctionPointerForDelegate(d38);
             delegates[38] = d38;
-            var d39 = new __getClassNameFromMetadata(_getClassNameFromMetadata);
+            var d39 = new __getClassName(_getClassName);
             callbacks[39] = Marshal.GetFunctionPointerForDelegate(d39);
             delegates[39] = d39;
-            var d40 = new __getTypeInstantiationArgument(_getTypeInstantiationArgument);
+            var d40 = new __getClassNameFromMetadata(_getClassNameFromMetadata);
             callbacks[40] = Marshal.GetFunctionPointerForDelegate(d40);
             delegates[40] = d40;
-            var d41 = new __appendClassName(_appendClassName);
+            var d41 = new __getTypeInstantiationArgument(_getTypeInstantiationArgument);
             callbacks[41] = Marshal.GetFunctionPointerForDelegate(d41);
             delegates[41] = d41;
-            var d42 = new __isValueClass(_isValueClass);
+            var d42 = new __appendClassName(_appendClassName);
             callbacks[42] = Marshal.GetFunctionPointerForDelegate(d42);
             delegates[42] = d42;
-            var d43 = new __canInlineTypeCheck(_canInlineTypeCheck);
+            var d43 = new __isValueClass(_isValueClass);
             callbacks[43] = Marshal.GetFunctionPointerForDelegate(d43);
             delegates[43] = d43;
-            var d44 = new __canInlineTypeCheckWithObjectVTable(_canInlineTypeCheckWithObjectVTable);
+            var d44 = new __canInlineTypeCheck(_canInlineTypeCheck);
             callbacks[44] = Marshal.GetFunctionPointerForDelegate(d44);
             delegates[44] = d44;
-            var d45 = new __getClassAttribs(_getClassAttribs);
+            var d45 = new __canInlineTypeCheckWithObjectVTable(_canInlineTypeCheckWithObjectVTable);
             callbacks[45] = Marshal.GetFunctionPointerForDelegate(d45);
             delegates[45] = d45;
-            var d46 = new __isStructRequiringStackAllocRetBuf(_isStructRequiringStackAllocRetBuf);
+            var d46 = new __getClassAttribs(_getClassAttribs);
             callbacks[46] = Marshal.GetFunctionPointerForDelegate(d46);
             delegates[46] = d46;
-            var d47 = new __getClassModule(_getClassModule);
+            var d47 = new __isStructRequiringStackAllocRetBuf(_isStructRequiringStackAllocRetBuf);
             callbacks[47] = Marshal.GetFunctionPointerForDelegate(d47);
             delegates[47] = d47;
-            var d48 = new __getModuleAssembly(_getModuleAssembly);
+            var d48 = new __getClassModule(_getClassModule);
             callbacks[48] = Marshal.GetFunctionPointerForDelegate(d48);
             delegates[48] = d48;
-            var d49 = new __getAssemblyName(_getAssemblyName);
+            var d49 = new __getModuleAssembly(_getModuleAssembly);
             callbacks[49] = Marshal.GetFunctionPointerForDelegate(d49);
             delegates[49] = d49;
-            var d50 = new __LongLifetimeMalloc(_LongLifetimeMalloc);
+            var d50 = new __getAssemblyName(_getAssemblyName);
             callbacks[50] = Marshal.GetFunctionPointerForDelegate(d50);
             delegates[50] = d50;
-            var d51 = new __LongLifetimeFree(_LongLifetimeFree);
+            var d51 = new __LongLifetimeMalloc(_LongLifetimeMalloc);
             callbacks[51] = Marshal.GetFunctionPointerForDelegate(d51);
             delegates[51] = d51;
-            var d52 = new __getClassModuleIdForStatics(_getClassModuleIdForStatics);
+            var d52 = new __LongLifetimeFree(_LongLifetimeFree);
             callbacks[52] = Marshal.GetFunctionPointerForDelegate(d52);
             delegates[52] = d52;
-            var d53 = new __getClassSize(_getClassSize);
+            var d53 = new __getClassModuleIdForStatics(_getClassModuleIdForStatics);
             callbacks[53] = Marshal.GetFunctionPointerForDelegate(d53);
             delegates[53] = d53;
-            var d54 = new __getHeapClassSize(_getHeapClassSize);
+            var d54 = new __getClassSize(_getClassSize);
             callbacks[54] = Marshal.GetFunctionPointerForDelegate(d54);
             delegates[54] = d54;
-            var d55 = new __canAllocateOnStack(_canAllocateOnStack);
+            var d55 = new __getHeapClassSize(_getHeapClassSize);
             callbacks[55] = Marshal.GetFunctionPointerForDelegate(d55);
             delegates[55] = d55;
-            var d56 = new __getClassAlignmentRequirement(_getClassAlignmentRequirement);
+            var d56 = new __canAllocateOnStack(_canAllocateOnStack);
             callbacks[56] = Marshal.GetFunctionPointerForDelegate(d56);
             delegates[56] = d56;
-            var d57 = new __getClassGClayout(_getClassGClayout);
+            var d57 = new __getClassAlignmentRequirement(_getClassAlignmentRequirement);
             callbacks[57] = Marshal.GetFunctionPointerForDelegate(d57);
             delegates[57] = d57;
-            var d58 = new __getClassNumInstanceFields(_getClassNumInstanceFields);
+            var d58 = new __getClassGClayout(_getClassGClayout);
             callbacks[58] = Marshal.GetFunctionPointerForDelegate(d58);
             delegates[58] = d58;
-            var d59 = new __getFieldInClass(_getFieldInClass);
+            var d59 = new __getClassNumInstanceFields(_getClassNumInstanceFields);
             callbacks[59] = Marshal.GetFunctionPointerForDelegate(d59);
             delegates[59] = d59;
-            var d60 = new __checkMethodModifier(_checkMethodModifier);
+            var d60 = new __getFieldInClass(_getFieldInClass);
             callbacks[60] = Marshal.GetFunctionPointerForDelegate(d60);
             delegates[60] = d60;
-            var d61 = new __getNewHelper(_getNewHelper);
+            var d61 = new __checkMethodModifier(_checkMethodModifier);
             callbacks[61] = Marshal.GetFunctionPointerForDelegate(d61);
             delegates[61] = d61;
-            var d62 = new __getNewArrHelper(_getNewArrHelper);
+            var d62 = new __getNewHelper(_getNewHelper);
             callbacks[62] = Marshal.GetFunctionPointerForDelegate(d62);
             delegates[62] = d62;
-            var d63 = new __getCastingHelper(_getCastingHelper);
+            var d63 = new __getNewArrHelper(_getNewArrHelper);
             callbacks[63] = Marshal.GetFunctionPointerForDelegate(d63);
             delegates[63] = d63;
-            var d64 = new __getSharedCCtorHelper(_getSharedCCtorHelper);
+            var d64 = new __getCastingHelper(_getCastingHelper);
             callbacks[64] = Marshal.GetFunctionPointerForDelegate(d64);
             delegates[64] = d64;
-            var d65 = new __getSecurityPrologHelper(_getSecurityPrologHelper);
+            var d65 = new __getSharedCCtorHelper(_getSharedCCtorHelper);
             callbacks[65] = Marshal.GetFunctionPointerForDelegate(d65);
             delegates[65] = d65;
-            var d66 = new __getTypeForBox(_getTypeForBox);
+            var d66 = new __getSecurityPrologHelper(_getSecurityPrologHelper);
             callbacks[66] = Marshal.GetFunctionPointerForDelegate(d66);
             delegates[66] = d66;
-            var d67 = new __getBoxHelper(_getBoxHelper);
+            var d67 = new __getTypeForBox(_getTypeForBox);
             callbacks[67] = Marshal.GetFunctionPointerForDelegate(d67);
             delegates[67] = d67;
-            var d68 = new __getUnBoxHelper(_getUnBoxHelper);
+            var d68 = new __getBoxHelper(_getBoxHelper);
             callbacks[68] = Marshal.GetFunctionPointerForDelegate(d68);
             delegates[68] = d68;
-            var d69 = new __getReadyToRunHelper(_getReadyToRunHelper);
+            var d69 = new __getUnBoxHelper(_getUnBoxHelper);
             callbacks[69] = Marshal.GetFunctionPointerForDelegate(d69);
             delegates[69] = d69;
-            var d70 = new __getReadyToRunDelegateCtorHelper(_getReadyToRunDelegateCtorHelper);
+            var d70 = new __getReadyToRunHelper(_getReadyToRunHelper);
             callbacks[70] = Marshal.GetFunctionPointerForDelegate(d70);
             delegates[70] = d70;
-            var d71 = new __getHelperName(_getHelperName);
+            var d71 = new __getReadyToRunDelegateCtorHelper(_getReadyToRunDelegateCtorHelper);
             callbacks[71] = Marshal.GetFunctionPointerForDelegate(d71);
             delegates[71] = d71;
-            var d72 = new __initClass(_initClass);
+            var d72 = new __getHelperName(_getHelperName);
             callbacks[72] = Marshal.GetFunctionPointerForDelegate(d72);
             delegates[72] = d72;
-            var d73 = new __classMustBeLoadedBeforeCodeIsRun(_classMustBeLoadedBeforeCodeIsRun);
+            var d73 = new __initClass(_initClass);
             callbacks[73] = Marshal.GetFunctionPointerForDelegate(d73);
             delegates[73] = d73;
-            var d74 = new __getBuiltinClass(_getBuiltinClass);
+            var d74 = new __classMustBeLoadedBeforeCodeIsRun(_classMustBeLoadedBeforeCodeIsRun);
             callbacks[74] = Marshal.GetFunctionPointerForDelegate(d74);
             delegates[74] = d74;
-            var d75 = new __getTypeForPrimitiveValueClass(_getTypeForPrimitiveValueClass);
+            var d75 = new __getBuiltinClass(_getBuiltinClass);
             callbacks[75] = Marshal.GetFunctionPointerForDelegate(d75);
             delegates[75] = d75;
-            var d76 = new __getTypeForPrimitiveNumericClass(_getTypeForPrimitiveNumericClass);
+            var d76 = new __getTypeForPrimitiveValueClass(_getTypeForPrimitiveValueClass);
             callbacks[76] = Marshal.GetFunctionPointerForDelegate(d76);
             delegates[76] = d76;
-            var d77 = new __canCast(_canCast);
+            var d77 = new __getTypeForPrimitiveNumericClass(_getTypeForPrimitiveNumericClass);
             callbacks[77] = Marshal.GetFunctionPointerForDelegate(d77);
             delegates[77] = d77;
-            var d78 = new __areTypesEquivalent(_areTypesEquivalent);
+            var d78 = new __canCast(_canCast);
             callbacks[78] = Marshal.GetFunctionPointerForDelegate(d78);
             delegates[78] = d78;
-            var d79 = new __compareTypesForCast(_compareTypesForCast);
+            var d79 = new __areTypesEquivalent(_areTypesEquivalent);
             callbacks[79] = Marshal.GetFunctionPointerForDelegate(d79);
             delegates[79] = d79;
-            var d80 = new __compareTypesForEquality(_compareTypesForEquality);
+            var d80 = new __compareTypesForCast(_compareTypesForCast);
             callbacks[80] = Marshal.GetFunctionPointerForDelegate(d80);
             delegates[80] = d80;
-            var d81 = new __mergeClasses(_mergeClasses);
+            var d81 = new __compareTypesForEquality(_compareTypesForEquality);
             callbacks[81] = Marshal.GetFunctionPointerForDelegate(d81);
             delegates[81] = d81;
-            var d82 = new __isMoreSpecificType(_isMoreSpecificType);
+            var d82 = new __mergeClasses(_mergeClasses);
             callbacks[82] = Marshal.GetFunctionPointerForDelegate(d82);
             delegates[82] = d82;
-            var d83 = new __getParentType(_getParentType);
+            var d83 = new __isMoreSpecificType(_isMoreSpecificType);
             callbacks[83] = Marshal.GetFunctionPointerForDelegate(d83);
             delegates[83] = d83;
-            var d84 = new __getChildType(_getChildType);
+            var d84 = new __getParentType(_getParentType);
             callbacks[84] = Marshal.GetFunctionPointerForDelegate(d84);
             delegates[84] = d84;
-            var d85 = new __satisfiesClassConstraints(_satisfiesClassConstraints);
+            var d85 = new __getChildType(_getChildType);
             callbacks[85] = Marshal.GetFunctionPointerForDelegate(d85);
             delegates[85] = d85;
-            var d86 = new __isSDArray(_isSDArray);
+            var d86 = new __satisfiesClassConstraints(_satisfiesClassConstraints);
             callbacks[86] = Marshal.GetFunctionPointerForDelegate(d86);
             delegates[86] = d86;
-            var d87 = new __getArrayRank(_getArrayRank);
+            var d87 = new __isSDArray(_isSDArray);
             callbacks[87] = Marshal.GetFunctionPointerForDelegate(d87);
             delegates[87] = d87;
-            var d88 = new __getArrayInitializationData(_getArrayInitializationData);
+            var d88 = new __getArrayRank(_getArrayRank);
             callbacks[88] = Marshal.GetFunctionPointerForDelegate(d88);
             delegates[88] = d88;
-            var d89 = new __canAccessClass(_canAccessClass);
+            var d89 = new __getArrayInitializationData(_getArrayInitializationData);
             callbacks[89] = Marshal.GetFunctionPointerForDelegate(d89);
             delegates[89] = d89;
-            var d90 = new __getFieldName(_getFieldName);
+            var d90 = new __canAccessClass(_canAccessClass);
             callbacks[90] = Marshal.GetFunctionPointerForDelegate(d90);
             delegates[90] = d90;
-            var d91 = new __getFieldClass(_getFieldClass);
+            var d91 = new __getFieldName(_getFieldName);
             callbacks[91] = Marshal.GetFunctionPointerForDelegate(d91);
             delegates[91] = d91;
-            var d92 = new __getFieldType(_getFieldType);
+            var d92 = new __getFieldClass(_getFieldClass);
             callbacks[92] = Marshal.GetFunctionPointerForDelegate(d92);
             delegates[92] = d92;
-            var d93 = new __getFieldOffset(_getFieldOffset);
+            var d93 = new __getFieldType(_getFieldType);
             callbacks[93] = Marshal.GetFunctionPointerForDelegate(d93);
             delegates[93] = d93;
-            var d94 = new __isWriteBarrierHelperRequired(_isWriteBarrierHelperRequired);
+            var d94 = new __getFieldOffset(_getFieldOffset);
             callbacks[94] = Marshal.GetFunctionPointerForDelegate(d94);
             delegates[94] = d94;
-            var d95 = new __getFieldInfo(_getFieldInfo);
+            var d95 = new __isWriteBarrierHelperRequired(_isWriteBarrierHelperRequired);
             callbacks[95] = Marshal.GetFunctionPointerForDelegate(d95);
             delegates[95] = d95;
-            var d96 = new __isFieldStatic(_isFieldStatic);
+            var d96 = new __getFieldInfo(_getFieldInfo);
             callbacks[96] = Marshal.GetFunctionPointerForDelegate(d96);
             delegates[96] = d96;
-            var d97 = new __getBoundaries(_getBoundaries);
+            var d97 = new __isFieldStatic(_isFieldStatic);
             callbacks[97] = Marshal.GetFunctionPointerForDelegate(d97);
             delegates[97] = d97;
-            var d98 = new __setBoundaries(_setBoundaries);
+            var d98 = new __getBoundaries(_getBoundaries);
             callbacks[98] = Marshal.GetFunctionPointerForDelegate(d98);
             delegates[98] = d98;
-            var d99 = new __getVars(_getVars);
+            var d99 = new __setBoundaries(_setBoundaries);
             callbacks[99] = Marshal.GetFunctionPointerForDelegate(d99);
             delegates[99] = d99;
-            var d100 = new __setVars(_setVars);
+            var d100 = new __getVars(_getVars);
             callbacks[100] = Marshal.GetFunctionPointerForDelegate(d100);
             delegates[100] = d100;
-            var d101 = new __allocateArray(_allocateArray);
+            var d101 = new __setVars(_setVars);
             callbacks[101] = Marshal.GetFunctionPointerForDelegate(d101);
             delegates[101] = d101;
-            var d102 = new __freeArray(_freeArray);
+            var d102 = new __allocateArray(_allocateArray);
             callbacks[102] = Marshal.GetFunctionPointerForDelegate(d102);
             delegates[102] = d102;
-            var d103 = new __getArgNext(_getArgNext);
+            var d103 = new __freeArray(_freeArray);
             callbacks[103] = Marshal.GetFunctionPointerForDelegate(d103);
             delegates[103] = d103;
-            var d104 = new __getArgType(_getArgType);
+            var d104 = new __getArgNext(_getArgNext);
             callbacks[104] = Marshal.GetFunctionPointerForDelegate(d104);
             delegates[104] = d104;
-            var d105 = new __getArgClass(_getArgClass);
+            var d105 = new __getArgType(_getArgType);
             callbacks[105] = Marshal.GetFunctionPointerForDelegate(d105);
             delegates[105] = d105;
-            var d106 = new __getHFAType(_getHFAType);
+            var d106 = new __getArgClass(_getArgClass);
             callbacks[106] = Marshal.GetFunctionPointerForDelegate(d106);
             delegates[106] = d106;
-            var d107 = new __GetErrorHRESULT(_GetErrorHRESULT);
+            var d107 = new __getHFAType(_getHFAType);
             callbacks[107] = Marshal.GetFunctionPointerForDelegate(d107);
             delegates[107] = d107;
-            var d108 = new __GetErrorMessage(_GetErrorMessage);
+            var d108 = new __GetErrorHRESULT(_GetErrorHRESULT);
             callbacks[108] = Marshal.GetFunctionPointerForDelegate(d108);
             delegates[108] = d108;
-            var d109 = new __FilterException(_FilterException);
+            var d109 = new __GetErrorMessage(_GetErrorMessage);
             callbacks[109] = Marshal.GetFunctionPointerForDelegate(d109);
             delegates[109] = d109;
-            var d110 = new __HandleException(_HandleException);
+            var d110 = new __FilterException(_FilterException);
             callbacks[110] = Marshal.GetFunctionPointerForDelegate(d110);
             delegates[110] = d110;
-            var d111 = new __ThrowExceptionForJitResult(_ThrowExceptionForJitResult);
+            var d111 = new __HandleException(_HandleException);
             callbacks[111] = Marshal.GetFunctionPointerForDelegate(d111);
             delegates[111] = d111;
-            var d112 = new __ThrowExceptionForHelper(_ThrowExceptionForHelper);
+            var d112 = new __ThrowExceptionForJitResult(_ThrowExceptionForJitResult);
             callbacks[112] = Marshal.GetFunctionPointerForDelegate(d112);
             delegates[112] = d112;
-            var d113 = new __runWithErrorTrap(_runWithErrorTrap);
+            var d113 = new __ThrowExceptionForHelper(_ThrowExceptionForHelper);
             callbacks[113] = Marshal.GetFunctionPointerForDelegate(d113);
             delegates[113] = d113;
-            var d114 = new __getEEInfo(_getEEInfo);
+            var d114 = new __runWithErrorTrap(_runWithErrorTrap);
             callbacks[114] = Marshal.GetFunctionPointerForDelegate(d114);
             delegates[114] = d114;
-            var d115 = new __getJitTimeLogFilename(_getJitTimeLogFilename);
+            var d115 = new __getEEInfo(_getEEInfo);
             callbacks[115] = Marshal.GetFunctionPointerForDelegate(d115);
             delegates[115] = d115;
-            var d116 = new __getMethodDefFromMethod(_getMethodDefFromMethod);
+            var d116 = new __getJitTimeLogFilename(_getJitTimeLogFilename);
             callbacks[116] = Marshal.GetFunctionPointerForDelegate(d116);
             delegates[116] = d116;
-            var d117 = new __getMethodName(_getMethodName);
+            var d117 = new __getMethodDefFromMethod(_getMethodDefFromMethod);
             callbacks[117] = Marshal.GetFunctionPointerForDelegate(d117);
             delegates[117] = d117;
-            var d118 = new __getMethodNameFromMetadata(_getMethodNameFromMetadata);
+            var d118 = new __getMethodName(_getMethodName);
             callbacks[118] = Marshal.GetFunctionPointerForDelegate(d118);
             delegates[118] = d118;
-            var d119 = new __getMethodHash(_getMethodHash);
+            var d119 = new __getMethodNameFromMetadata(_getMethodNameFromMetadata);
             callbacks[119] = Marshal.GetFunctionPointerForDelegate(d119);
             delegates[119] = d119;
-            var d120 = new __findNameOfToken(_findNameOfToken);
+            var d120 = new __getMethodHash(_getMethodHash);
             callbacks[120] = Marshal.GetFunctionPointerForDelegate(d120);
             delegates[120] = d120;
-            var d121 = new __getSystemVAmd64PassStructInRegisterDescriptor(_getSystemVAmd64PassStructInRegisterDescriptor);
+            var d121 = new __findNameOfToken(_findNameOfToken);
             callbacks[121] = Marshal.GetFunctionPointerForDelegate(d121);
             delegates[121] = d121;
-            var d122 = new __getThreadTLSIndex(_getThreadTLSIndex);
+            var d122 = new __getSystemVAmd64PassStructInRegisterDescriptor(_getSystemVAmd64PassStructInRegisterDescriptor);
             callbacks[122] = Marshal.GetFunctionPointerForDelegate(d122);
             delegates[122] = d122;
-            var d123 = new __getInlinedCallFrameVptr(_getInlinedCallFrameVptr);
+            var d123 = new __getThreadTLSIndex(_getThreadTLSIndex);
             callbacks[123] = Marshal.GetFunctionPointerForDelegate(d123);
             delegates[123] = d123;
-            var d124 = new __getAddrOfCaptureThreadGlobal(_getAddrOfCaptureThreadGlobal);
+            var d124 = new __getInlinedCallFrameVptr(_getInlinedCallFrameVptr);
             callbacks[124] = Marshal.GetFunctionPointerForDelegate(d124);
             delegates[124] = d124;
-            var d125 = new __getHelperFtn(_getHelperFtn);
+            var d125 = new __getAddrOfCaptureThreadGlobal(_getAddrOfCaptureThreadGlobal);
             callbacks[125] = Marshal.GetFunctionPointerForDelegate(d125);
             delegates[125] = d125;
-            var d126 = new __getFunctionEntryPoint(_getFunctionEntryPoint);
+            var d126 = new __getHelperFtn(_getHelperFtn);
             callbacks[126] = Marshal.GetFunctionPointerForDelegate(d126);
             delegates[126] = d126;
-            var d127 = new __getFunctionFixedEntryPoint(_getFunctionFixedEntryPoint);
+            var d127 = new __getFunctionEntryPoint(_getFunctionEntryPoint);
             callbacks[127] = Marshal.GetFunctionPointerForDelegate(d127);
             delegates[127] = d127;
-            var d128 = new __getMethodSync(_getMethodSync);
+            var d128 = new __getFunctionFixedEntryPoint(_getFunctionFixedEntryPoint);
             callbacks[128] = Marshal.GetFunctionPointerForDelegate(d128);
             delegates[128] = d128;
-            var d129 = new __getLazyStringLiteralHelper(_getLazyStringLiteralHelper);
+            var d129 = new __getMethodSync(_getMethodSync);
             callbacks[129] = Marshal.GetFunctionPointerForDelegate(d129);
             delegates[129] = d129;
-            var d130 = new __embedModuleHandle(_embedModuleHandle);
+            var d130 = new __getLazyStringLiteralHelper(_getLazyStringLiteralHelper);
             callbacks[130] = Marshal.GetFunctionPointerForDelegate(d130);
             delegates[130] = d130;
-            var d131 = new __embedClassHandle(_embedClassHandle);
+            var d131 = new __embedModuleHandle(_embedModuleHandle);
             callbacks[131] = Marshal.GetFunctionPointerForDelegate(d131);
             delegates[131] = d131;
-            var d132 = new __embedMethodHandle(_embedMethodHandle);
+            var d132 = new __embedClassHandle(_embedClassHandle);
             callbacks[132] = Marshal.GetFunctionPointerForDelegate(d132);
             delegates[132] = d132;
-            var d133 = new __embedFieldHandle(_embedFieldHandle);
+            var d133 = new __embedMethodHandle(_embedMethodHandle);
             callbacks[133] = Marshal.GetFunctionPointerForDelegate(d133);
             delegates[133] = d133;
-            var d134 = new __embedGenericHandle(_embedGenericHandle);
+            var d134 = new __embedFieldHandle(_embedFieldHandle);
             callbacks[134] = Marshal.GetFunctionPointerForDelegate(d134);
             delegates[134] = d134;
-            var d135 = new __getLocationOfThisType(_getLocationOfThisType);
+            var d135 = new __embedGenericHandle(_embedGenericHandle);
             callbacks[135] = Marshal.GetFunctionPointerForDelegate(d135);
             delegates[135] = d135;
-            var d136 = new __getPInvokeUnmanagedTarget(_getPInvokeUnmanagedTarget);
+            var d136 = new __getLocationOfThisType(_getLocationOfThisType);
             callbacks[136] = Marshal.GetFunctionPointerForDelegate(d136);
             delegates[136] = d136;
-            var d137 = new __getAddressOfPInvokeFixup(_getAddressOfPInvokeFixup);
+            var d137 = new __getPInvokeUnmanagedTarget(_getPInvokeUnmanagedTarget);
             callbacks[137] = Marshal.GetFunctionPointerForDelegate(d137);
             delegates[137] = d137;
-            var d138 = new __getAddressOfPInvokeTarget(_getAddressOfPInvokeTarget);
+            var d138 = new __getAddressOfPInvokeFixup(_getAddressOfPInvokeFixup);
             callbacks[138] = Marshal.GetFunctionPointerForDelegate(d138);
             delegates[138] = d138;
-            var d139 = new __GetCookieForPInvokeCalliSig(_GetCookieForPInvokeCalliSig);
+            var d139 = new __getAddressOfPInvokeTarget(_getAddressOfPInvokeTarget);
             callbacks[139] = Marshal.GetFunctionPointerForDelegate(d139);
             delegates[139] = d139;
-            var d140 = new __canGetCookieForPInvokeCalliSig(_canGetCookieForPInvokeCalliSig);
+            var d140 = new __GetCookieForPInvokeCalliSig(_GetCookieForPInvokeCalliSig);
             callbacks[140] = Marshal.GetFunctionPointerForDelegate(d140);
             delegates[140] = d140;
-            var d141 = new __getJustMyCodeHandle(_getJustMyCodeHandle);
+            var d141 = new __canGetCookieForPInvokeCalliSig(_canGetCookieForPInvokeCalliSig);
             callbacks[141] = Marshal.GetFunctionPointerForDelegate(d141);
             delegates[141] = d141;
-            var d142 = new __GetProfilingHandle(_GetProfilingHandle);
+            var d142 = new __getJustMyCodeHandle(_getJustMyCodeHandle);
             callbacks[142] = Marshal.GetFunctionPointerForDelegate(d142);
             delegates[142] = d142;
-            var d143 = new __getCallInfo(_getCallInfo);
+            var d143 = new __GetProfilingHandle(_GetProfilingHandle);
             callbacks[143] = Marshal.GetFunctionPointerForDelegate(d143);
             delegates[143] = d143;
-            var d144 = new __canAccessFamily(_canAccessFamily);
+            var d144 = new __getCallInfo(_getCallInfo);
             callbacks[144] = Marshal.GetFunctionPointerForDelegate(d144);
             delegates[144] = d144;
-            var d145 = new __isRIDClassDomainID(_isRIDClassDomainID);
+            var d145 = new __canAccessFamily(_canAccessFamily);
             callbacks[145] = Marshal.GetFunctionPointerForDelegate(d145);
             delegates[145] = d145;
-            var d146 = new __getClassDomainID(_getClassDomainID);
+            var d146 = new __isRIDClassDomainID(_isRIDClassDomainID);
             callbacks[146] = Marshal.GetFunctionPointerForDelegate(d146);
             delegates[146] = d146;
-            var d147 = new __getFieldAddress(_getFieldAddress);
+            var d147 = new __getClassDomainID(_getClassDomainID);
             callbacks[147] = Marshal.GetFunctionPointerForDelegate(d147);
             delegates[147] = d147;
-            var d148 = new __getStaticFieldCurrentClass(_getStaticFieldCurrentClass);
+            var d148 = new __getFieldAddress(_getFieldAddress);
             callbacks[148] = Marshal.GetFunctionPointerForDelegate(d148);
             delegates[148] = d148;
-            var d149 = new __getVarArgsHandle(_getVarArgsHandle);
+            var d149 = new __getStaticFieldCurrentClass(_getStaticFieldCurrentClass);
             callbacks[149] = Marshal.GetFunctionPointerForDelegate(d149);
             delegates[149] = d149;
-            var d150 = new __canGetVarArgsHandle(_canGetVarArgsHandle);
+            var d150 = new __getVarArgsHandle(_getVarArgsHandle);
             callbacks[150] = Marshal.GetFunctionPointerForDelegate(d150);
             delegates[150] = d150;
-            var d151 = new __constructStringLiteral(_constructStringLiteral);
+            var d151 = new __canGetVarArgsHandle(_canGetVarArgsHandle);
             callbacks[151] = Marshal.GetFunctionPointerForDelegate(d151);
             delegates[151] = d151;
-            var d152 = new __emptyStringLiteral(_emptyStringLiteral);
+            var d152 = new __constructStringLiteral(_constructStringLiteral);
             callbacks[152] = Marshal.GetFunctionPointerForDelegate(d152);
             delegates[152] = d152;
-            var d153 = new __getFieldThreadLocalStoreID(_getFieldThreadLocalStoreID);
+            var d153 = new __emptyStringLiteral(_emptyStringLiteral);
             callbacks[153] = Marshal.GetFunctionPointerForDelegate(d153);
             delegates[153] = d153;
-            var d154 = new __setOverride(_setOverride);
+            var d154 = new __getFieldThreadLocalStoreID(_getFieldThreadLocalStoreID);
             callbacks[154] = Marshal.GetFunctionPointerForDelegate(d154);
             delegates[154] = d154;
-            var d155 = new __addActiveDependency(_addActiveDependency);
+            var d155 = new __setOverride(_setOverride);
             callbacks[155] = Marshal.GetFunctionPointerForDelegate(d155);
             delegates[155] = d155;
-            var d156 = new __GetDelegateCtor(_GetDelegateCtor);
+            var d156 = new __addActiveDependency(_addActiveDependency);
             callbacks[156] = Marshal.GetFunctionPointerForDelegate(d156);
             delegates[156] = d156;
-            var d157 = new __MethodCompileComplete(_MethodCompileComplete);
+            var d157 = new __GetDelegateCtor(_GetDelegateCtor);
             callbacks[157] = Marshal.GetFunctionPointerForDelegate(d157);
             delegates[157] = d157;
-            var d158 = new __getTailCallCopyArgsThunk(_getTailCallCopyArgsThunk);
+            var d158 = new __MethodCompileComplete(_MethodCompileComplete);
             callbacks[158] = Marshal.GetFunctionPointerForDelegate(d158);
             delegates[158] = d158;
-            var d159 = new __convertPInvokeCalliToCall(_convertPInvokeCalliToCall);
+            var d159 = new __getTailCallCopyArgsThunk(_getTailCallCopyArgsThunk);
             callbacks[159] = Marshal.GetFunctionPointerForDelegate(d159);
             delegates[159] = d159;
-            var d160 = new __getMemoryManager(_getMemoryManager);
+            var d160 = new __convertPInvokeCalliToCall(_convertPInvokeCalliToCall);
             callbacks[160] = Marshal.GetFunctionPointerForDelegate(d160);
             delegates[160] = d160;
-            var d161 = new __allocMem(_allocMem);
+            var d161 = new __getMemoryManager(_getMemoryManager);
             callbacks[161] = Marshal.GetFunctionPointerForDelegate(d161);
             delegates[161] = d161;
-            var d162 = new __reserveUnwindInfo(_reserveUnwindInfo);
+            var d162 = new __allocMem(_allocMem);
             callbacks[162] = Marshal.GetFunctionPointerForDelegate(d162);
             delegates[162] = d162;
-            var d163 = new __allocUnwindInfo(_allocUnwindInfo);
+            var d163 = new __reserveUnwindInfo(_reserveUnwindInfo);
             callbacks[163] = Marshal.GetFunctionPointerForDelegate(d163);
             delegates[163] = d163;
-            var d164 = new __allocGCInfo(_allocGCInfo);
+            var d164 = new __allocUnwindInfo(_allocUnwindInfo);
             callbacks[164] = Marshal.GetFunctionPointerForDelegate(d164);
             delegates[164] = d164;
-            var d165 = new __yieldExecution(_yieldExecution);
+            var d165 = new __allocGCInfo(_allocGCInfo);
             callbacks[165] = Marshal.GetFunctionPointerForDelegate(d165);
             delegates[165] = d165;
-            var d166 = new __setEHcount(_setEHcount);
+            var d166 = new __yieldExecution(_yieldExecution);
             callbacks[166] = Marshal.GetFunctionPointerForDelegate(d166);
             delegates[166] = d166;
-            var d167 = new __setEHinfo(_setEHinfo);
+            var d167 = new __setEHcount(_setEHcount);
             callbacks[167] = Marshal.GetFunctionPointerForDelegate(d167);
             delegates[167] = d167;
-            var d168 = new __logMsg(_logMsg);
+            var d168 = new __setEHinfo(_setEHinfo);
             callbacks[168] = Marshal.GetFunctionPointerForDelegate(d168);
             delegates[168] = d168;
-            var d169 = new __doAssert(_doAssert);
+            var d169 = new __logMsg(_logMsg);
             callbacks[169] = Marshal.GetFunctionPointerForDelegate(d169);
             delegates[169] = d169;
-            var d170 = new __reportFatalError(_reportFatalError);
+            var d170 = new __doAssert(_doAssert);
             callbacks[170] = Marshal.GetFunctionPointerForDelegate(d170);
             delegates[170] = d170;
-            var d171 = new __allocMethodBlockCounts(_allocMethodBlockCounts);
+            var d171 = new __reportFatalError(_reportFatalError);
             callbacks[171] = Marshal.GetFunctionPointerForDelegate(d171);
             delegates[171] = d171;
-            var d172 = new __getMethodBlockCounts(_getMethodBlockCounts);
+            var d172 = new __allocMethodBlockCounts(_allocMethodBlockCounts);
             callbacks[172] = Marshal.GetFunctionPointerForDelegate(d172);
             delegates[172] = d172;
-            var d173 = new __recordCallSite(_recordCallSite);
+            var d173 = new __getMethodBlockCounts(_getMethodBlockCounts);
             callbacks[173] = Marshal.GetFunctionPointerForDelegate(d173);
             delegates[173] = d173;
-            var d174 = new __recordRelocation(_recordRelocation);
+            var d174 = new __recordCallSite(_recordCallSite);
             callbacks[174] = Marshal.GetFunctionPointerForDelegate(d174);
             delegates[174] = d174;
-            var d175 = new __getRelocTypeHint(_getRelocTypeHint);
+            var d175 = new __recordRelocation(_recordRelocation);
             callbacks[175] = Marshal.GetFunctionPointerForDelegate(d175);
             delegates[175] = d175;
-            var d176 = new __getModuleNativeEntryPointRange(_getModuleNativeEntryPointRange);
+            var d176 = new __getRelocTypeHint(_getRelocTypeHint);
             callbacks[176] = Marshal.GetFunctionPointerForDelegate(d176);
             delegates[176] = d176;
-            var d177 = new __getExpectedTargetArchitecture(_getExpectedTargetArchitecture);
+            var d177 = new __getModuleNativeEntryPointRange(_getModuleNativeEntryPointRange);
             callbacks[177] = Marshal.GetFunctionPointerForDelegate(d177);
             delegates[177] = d177;
-            var d178 = new __getJitFlags(_getJitFlags);
+            var d178 = new __getExpectedTargetArchitecture(_getExpectedTargetArchitecture);
             callbacks[178] = Marshal.GetFunctionPointerForDelegate(d178);
             delegates[178] = d178;
+            var d179 = new __getJitFlags(_getJitFlags);
+            callbacks[179] = Marshal.GetFunctionPointerForDelegate(d179);
+            delegates[179] = d179;
 
             keepAlive = delegates;
             return (IntPtr)callbacks;

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -44,7 +44,7 @@ namespace Internal.JitInterface
             ARM64 = 0xaa64,
         }
 
-        public const string JitLibrary = "clrjitilc";
+        internal const string JitLibrary = "clrjitilc";
 
 #if SUPPORT_JIT
         private const string JitSupportLibrary = "*";
@@ -109,16 +109,15 @@ namespace Internal.JitInterface
         [DllImport(JitSupportLibrary)]
         private extern static char* GetExceptionMessage(IntPtr obj);
 
-        private JitConfigProvider _jitConfig;
-
         private readonly UnboxingMethodDescFactory _unboxingThunkFactory;
 
-        public CorInfoImpl(JitConfigProvider jitConfig)
+        public static void Startup()
         {
-            _jitConfig = jitConfig;
+            jitStartup(GetJitHost(JitConfigProvider.Instance.UnmanagedInstance));
+        }
 
-            jitStartup(GetJitHost(jitConfig.UnmanagedInstance));
-
+        public CorInfoImpl()
+        {
             _jit = getJit();
             if (_jit == IntPtr.Zero)
             {
@@ -226,7 +225,7 @@ namespace Internal.JitInterface
             var relocs = _relocs.ToArray();
             Array.Sort(relocs, (x, y) => (x.Offset - y.Offset));
 
-            int alignment = _jitConfig.HasFlag(CorJitFlag.CORJIT_FLAG_SIZE_OPT) ?
+            int alignment = JitConfigProvider.Instance.HasFlag(CorJitFlag.CORJIT_FLAG_SIZE_OPT) ?
                 _compilation.NodeFactory.Target.MinimumFunctionAlignment :
                 _compilation.NodeFactory.Target.OptimumFunctionAlignment;
 
@@ -260,6 +259,9 @@ namespace Internal.JitInterface
 
             _methodCodeNode.InitializeDebugLocInfos(_debugLocInfos);
             _methodCodeNode.InitializeDebugVarInfos(_debugVarInfos);
+#if READYTORUN
+            _methodCodeNode.InitializeInliningInfo(_inlinedMethods.ToArray());
+#endif
             PublishProfileData();
         }
 
@@ -339,6 +341,7 @@ namespace Internal.JitInterface
 
 #if READYTORUN
             _profileDataNode = null;
+            _inlinedMethods = new ArrayBuilder<MethodDesc>();
 #endif
         }
 
@@ -754,10 +757,6 @@ namespace Internal.JitInterface
             }
         }
 
-        private void reportInliningDecision(CORINFO_METHOD_STRUCT_* inlinerHnd, CORINFO_METHOD_STRUCT_* inlineeHnd, CorInfoInline inlineResult, byte* reason)
-        {
-        }
-
         private void reportTailCallDecision(CORINFO_METHOD_STRUCT_* callerHnd, CORINFO_METHOD_STRUCT_* calleeHnd, bool fIsTailPrefix, CorInfoTailCall tailCallResult, byte* reason)
         {
         }
@@ -948,7 +947,8 @@ namespace Internal.JitInterface
                 else
                 {
                     var methodContext = (MethodDesc)typeOrMethodContext;
-                    Debug.Assert(methodContext.GetTypicalMethodDefinition() == owningMethod.GetTypicalMethodDefinition());
+                    Debug.Assert(methodContext.GetTypicalMethodDefinition() == owningMethod.GetTypicalMethodDefinition() ||
+                        (owningMethod.Name == "CreateDefaultInstance" && methodContext.Name == "CreateInstance"));
                     typeInst = methodContext.OwningType.Instantiation;
                     methodInst = methodContext.Instantiation;
                 }
@@ -1153,6 +1153,14 @@ namespace Internal.JitInterface
         private bool shouldEnforceCallvirtRestriction(CORINFO_MODULE_STRUCT_* scope)
         { throw new NotImplementedException("shouldEnforceCallvirtRestriction"); }
 
+        private char* getStringLiteral(CORINFO_MODULE_STRUCT_* module, uint metaTOK, ref int length)
+        {
+            MethodIL methodIL = (MethodIL)HandleToObject((IntPtr)module);
+            string s = (string)methodIL.GetObject((int)metaTOK);
+            length = (int)s.Length;
+            return (char*)GetPin(s);
+        }
+
         private CorInfoType asCorInfoType(CORINFO_CLASS_STRUCT_* cls)
         {
             var type = HandleToObject(cls);
@@ -1189,7 +1197,7 @@ namespace Internal.JitInterface
         }
 
 
-        private int appendClassName(short** ppBuf, ref int pnBufLen, CORINFO_CLASS_STRUCT_* cls, bool fNamespace, bool fFullInst, bool fAssembly)
+        private int appendClassName(char** ppBuf, ref int pnBufLen, CORINFO_CLASS_STRUCT_* cls, bool fNamespace, bool fFullInst, bool fAssembly)
         {
             // We support enough of this to make SIMD work, but not much else.
 
@@ -1201,13 +1209,13 @@ namespace Internal.JitInterface
             int length = name.Length;
             if (pnBufLen > 0)
             {
-                short* buffer = *ppBuf;
+                char* buffer = *ppBuf;
                 for (int i = 0; i < Math.Min(name.Length, pnBufLen); i++)
-                    buffer[i] = (short)name[i];
+                    buffer[i] = name[i];
                 if (name.Length < pnBufLen)
-                    buffer[name.Length] = 0;
+                    buffer[name.Length] = (char)0;
                 else
-                    buffer[pnBufLen - 1] = 0;
+                    buffer[pnBufLen - 1] = (char)0;
                 pnBufLen -= length;
                 *ppBuf = buffer + length;
             }
@@ -1401,7 +1409,7 @@ namespace Internal.JitInterface
         {
             int result = 0;
 
-            if (type.IsByReferenceOfT || type.IsWellKnownType(WellKnownType.TypedReference))
+            if (type.IsByReferenceOfT)
             {
                 return MarkGcField(gcPtrs, CorInfoGCType.TYPE_GC_BYREF);
             }
@@ -1758,16 +1766,29 @@ namespace Internal.JitInterface
                     {
                         result = TypeCompareState.Must;
                     }
-                    // For negative results, the unknown type parameter in
-                    // fromClass might match some instantiated interface,
-                    // either directly or via variance.
+                    // We have __Canon parameter(s) in fromClass, somewhere.
                     //
-                    // However, CanCastTo will report failure in such cases since
-                    // __Canon won't match the instantiated type on the
-                    // interface (which can't be __Canon since we screened out
-                    // canonical subtypes for toClass above). So only report
-                    // failure if the interface is not instantiated.
-                    else if (!toType.HasInstantiation)
+                    // In CanCastTo, these __Canon(s) won't match the interface or
+                    // instantiated types on the interface, so CanCastTo may
+                    // return false negatives.
+                    //
+                    // Only report MustNot if the fromClass is not __Canon
+                    // and the interface is not instantiated; then there is
+                    // no way for the fromClass __Canon(s) to confuse things.
+                    //
+                    //    __Canon       -> IBar             May
+                    //    IFoo<__Canon> -> IFoo<string>     May
+                    //    IFoo<__Canon> -> IBar             MustNot
+                    //
+                    else if (fromType.IsCanonicalDefinitionType(CanonicalFormKind.Any))
+                    {
+                        result = TypeCompareState.May;
+                    }
+                    else if (toType.HasInstantiation)
+                    {
+                        result = TypeCompareState.May;
+                    }
+                    else
                     {
                         result = TypeCompareState.MustNot;
                     }
@@ -2048,221 +2069,6 @@ namespace Internal.JitInterface
             return (CORINFO_FIELD_ACCESSOR)(-1);
         }
 
-        private void getFieldInfo(ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, CORINFO_ACCESS_FLAGS flags, CORINFO_FIELD_INFO* pResult)
-        {
-#if DEBUG
-            // In debug, write some bogus data to the struct to ensure we have filled everything
-            // properly.
-            MemoryHelper.FillMemory((byte*)pResult, 0xcc, Marshal.SizeOf<CORINFO_FIELD_INFO>());
-#endif
-
-            Debug.Assert(((int)flags & ((int)CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_GET |
-                                        (int)CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_SET |
-                                        (int)CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_ADDRESS |
-                                        (int)CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_INIT_ARRAY)) != 0);
-
-            var field = HandleToObject(pResolvedToken.hField);
-#if READYTORUN
-            MethodDesc callerMethod = HandleToObject(callerHandle);
-
-            if (field.Offset.IsIndeterminate)
-                throw new RequiresRuntimeJitException(field);
-#endif
-
-            CORINFO_FIELD_ACCESSOR fieldAccessor;
-            CORINFO_FIELD_FLAGS fieldFlags = (CORINFO_FIELD_FLAGS)0;
-            uint fieldOffset = (field.IsStatic && field.HasRva ? 0xBAADF00D : (uint)field.Offset.AsInt);
-
-            if (field.IsStatic)
-            {
-                fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_STATIC;
-
-#if READYTORUN
-                if (field.FieldType.IsValueType && field.HasGCStaticBase && !field.HasRva)
-                {
-                    // statics of struct types are stored as implicitly boxed in CoreCLR i.e.
-                    // we need to modify field access flags appropriately
-                    fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_STATIC_IN_HEAP;
-                }
-#endif
-
-                if (field.HasRva)
-                {
-                    fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_UNMANAGED;
-
-                    // TODO: Handle the case when the RVA is in the TLS range
-                    fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_RVA_ADDRESS;
-
-                    // We are not going through a helper. The constructor has to be triggered explicitly.
-#if READYTORUN
-                    if (!IsClassPreInited(field.OwningType))
-#else
-                    if (_compilation.HasLazyStaticConstructor(field.OwningType))
-#endif
-                    {
-                        fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_INITCLASS;
-                    }
-                }
-                else if (field.OwningType.IsCanonicalSubtype(CanonicalFormKind.Any))
-                {
-                    // The JIT wants to know how to access a static field on a generic type. We need a runtime lookup.
-#if READYTORUN
-                    fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_GENERICS_STATIC_HELPER;
-                    if (field.IsThreadStatic)
-                    {
-                        pResult->helper = (field.HasGCStaticBase ?
-                            CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_GCTHREADSTATIC_BASE:
-                            CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_NONGCTHREADSTATIC_BASE);
-                    }
-                    else
-                    {
-                        pResult->helper = (field.HasGCStaticBase ?
-                            CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_GCSTATIC_BASE:
-                            CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_NONGCSTATIC_BASE);
-                    }
-#else
-                    fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_READYTORUN_HELPER;
-                    pResult->helper = CorInfoHelpFunc.CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE;
-
-                    // Don't try to compute the runtime lookup if we're inlining. The JIT is going to abort the inlining
-                    // attempt anyway.
-                    MethodDesc contextMethod = methodFromContext(pResolvedToken.tokenContext);
-                    if (contextMethod == MethodBeingCompiled)
-                    {
-                        FieldDesc runtimeDeterminedField = (FieldDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
-
-                        ReadyToRunHelperId helperId;
-
-                        // Find out what kind of base do we need to look up.
-                        if (field.IsThreadStatic)
-                        {
-                            helperId = ReadyToRunHelperId.GetThreadStaticBase;
-                        }
-                        else if (field.HasGCStaticBase)
-                        {
-                            helperId = ReadyToRunHelperId.GetGCStaticBase;
-                        }
-                        else
-                        {
-                            helperId = ReadyToRunHelperId.GetNonGCStaticBase;
-                        }
-
-                        // What generic context do we look up the base from.
-                        ISymbolNode helper;
-                        if (contextMethod.AcquiresInstMethodTableFromThis() || contextMethod.RequiresInstMethodTableArg())
-                        {
-                            helper = _compilation.NodeFactory.ReadyToRunHelperFromTypeLookup(
-                                helperId, runtimeDeterminedField.OwningType, contextMethod.OwningType);
-                        }
-                        else
-                        {
-                            Debug.Assert(contextMethod.RequiresInstMethodDescArg());
-                            helper = _compilation.NodeFactory.ReadyToRunHelperFromDictionaryLookup(
-                                helperId, runtimeDeterminedField.OwningType, contextMethod);
-                        }
-
-                        pResult->fieldLookup = CreateConstLookupToSymbol(helper);
-                    }
-#endif // READYTORUN
-                }
-                else
-                {
-                    fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_SHARED_STATIC_HELPER;
-                    pResult->helper = CorInfoHelpFunc.CORINFO_HELP_READYTORUN_STATIC_BASE;
-
-                    ReadyToRunHelperId helperId = ReadyToRunHelperId.Invalid;
-                    CORINFO_FIELD_ACCESSOR intrinsicAccessor;
-                    if (field.IsIntrinsic &&
-                        (flags & CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_GET) != 0 &&
-                        (intrinsicAccessor = getFieldIntrinsic(field)) != (CORINFO_FIELD_ACCESSOR)(-1))
-                    {
-                        fieldAccessor = intrinsicAccessor;
-                    }
-                    else if (field.IsThreadStatic)
-                    {
-#if READYTORUN
-                        if (field.HasGCStaticBase)
-                        {
-                            helperId = ReadyToRunHelperId.GetThreadStaticBase;
-                        }
-                        else
-                        {
-                            helperId = ReadyToRunHelperId.GetThreadNonGcStaticBase;
-                        }
-#else
-                        helperId = ReadyToRunHelperId.GetThreadStaticBase;
-#endif
-                    }
-                    else
-                    {
-                        helperId = field.HasGCStaticBase ?
-                            ReadyToRunHelperId.GetGCStaticBase :
-                            ReadyToRunHelperId.GetNonGCStaticBase;
-
-                        //
-                        // Currently, we only do this optimization for regular statics, but it
-                        // looks like it may be permissible to do this optimization for
-                        // thread statics as well.
-                        //
-                        if ((flags & CORINFO_ACCESS_FLAGS.CORINFO_ACCESS_ADDRESS) != 0 &&
-                            (fieldAccessor != CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_TLS))
-                        {
-                            fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_SAFESTATIC_BYREF_RETURN;
-                        }
-                    }
-
-#if READYTORUN
-                    if (!_compilation.NodeFactory.CompilationModuleGroup.VersionsWithType(field.OwningType) &&
-                        fieldAccessor == CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_STATIC_SHARED_STATIC_HELPER)
-                    {
-                        PreventRecursiveFieldInlinesOutsideVersionBubble(field, callerMethod);
-                        
-                        // Static fields outside of the version bubble need to be accessed using the ENCODE_FIELD_ADDRESS
-                        // helper in accordance with ZapInfo::getFieldInfo in CoreCLR.
-                        pResult->fieldLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.FieldAddress(field, GetSignatureContext()));
-
-                        pResult->helper = CorInfoHelpFunc.CORINFO_HELP_READYTORUN_STATIC_BASE;
-
-                        fieldFlags &= ~CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_STATIC_IN_HEAP; // The dynamic helper takes care of the unboxing
-                        fieldOffset = 0;
-                    }
-                    else
-#endif
-
-                    if (helperId != ReadyToRunHelperId.Invalid)
-                    {
-                        pResult->fieldLookup = CreateConstLookupToSymbol(
-#if READYTORUN
-                            _compilation.SymbolNodeFactory.CreateReadyToRunHelper(helperId, field.OwningType, GetSignatureContext())
-#else
-                            _compilation.NodeFactory.ReadyToRunHelper(helperId, field.OwningType)
-#endif
-                            );
-                    }
-                }
-            }
-            else
-            {
-                fieldAccessor = CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INSTANCE;
-            }
-
-            if (field.IsInitOnly)
-                fieldFlags |= CORINFO_FIELD_FLAGS.CORINFO_FLG_FIELD_FINAL;
-
-            pResult->fieldAccessor = fieldAccessor;
-            pResult->fieldFlags = fieldFlags;
-            pResult->fieldType = getFieldType(pResolvedToken.hField, &pResult->structType, pResolvedToken.hClass);
-            pResult->accessAllowed = CorInfoIsAccessAllowedResult.CORINFO_ACCESS_ALLOWED;
-            pResult->offset = fieldOffset;
-
-#if READYTORUN
-            EncodeFieldBaseOffset(field, pResult, callerMethod);
-#endif
-
-            // TODO: We need to implement access checks for fields and methods.  See JitInterface.cpp in mrtjit
-            //       and STS::AccessCheck::CanAccess.
-        }
-
         private bool isFieldStatic(CORINFO_FIELD_STRUCT_* fldHnd)
         {
             return HandleToObject(fldHnd).IsStatic;
@@ -2354,7 +2160,7 @@ namespace Internal.JitInterface
 
         private HRESULT GetErrorHRESULT(_EXCEPTION_POINTERS* pExceptionPointers)
         { throw new NotImplementedException("GetErrorHRESULT"); }
-        private uint GetErrorMessage(short* buffer, uint bufferLength)
+        private uint GetErrorMessage(char* buffer, uint bufferLength)
         { throw new NotImplementedException("GetErrorMessage"); }
 
         private int FilterException(_EXCEPTION_POINTERS* pExceptionPointers)
@@ -2417,7 +2223,7 @@ namespace Internal.JitInterface
             pEEInfoOut.osType = _compilation.NodeFactory.Target.IsWindows ? CORINFO_OS.CORINFO_WINNT : CORINFO_OS.CORINFO_UNIX;
         }
 
-        private string getJitTimeLogFilename()
+        private char* getJitTimeLogFilename()
         {
             return null;
         }
@@ -3021,7 +2827,7 @@ namespace Internal.JitInterface
         private uint getJitFlags(ref CORJIT_FLAGS flags, uint sizeInBytes)
         {
             // Read the user-defined configuration options.
-            foreach (var flag in _jitConfig.Flags)
+            foreach (var flag in JitConfigProvider.Instance.Flags)
                 flags.Set(flag);
 
             // Set the rest of the flags that don't make sense to expose publically.

--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -764,6 +764,8 @@ namespace Internal.JitInterface
         CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN = 0x00000000, // The code will be use the normal alignment
         CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN = 0x00000001, // The code will be 16-byte aligned
         CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN = 0x00000002, // The read-only data will be 16-byte aligned
+        CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN   = 0x00000004, // The code will be 32-byte aligned
+        CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN = 0x00000008, // The read-only data will be 32-byte aligned
     }
 
     public enum CorJitFuncKind
@@ -1150,20 +1152,6 @@ namespace Internal.JitInterface
         // SystemVClassificationTypeX87             = Unused, // Not supported by the CLR.
         // SystemVClassificationTypeX87Up           = Unused, // Not supported by the CLR.
         // SystemVClassificationTypeComplexX87      = Unused, // Not supported by the CLR.
-
-        // Internal flags - never returned outside of the classification implementation.
-
-        // This value represents a very special type with two eightbytes.
-        // First ByRef, second Integer (platform int).
-        // The VM has a special Elem type for this type - ELEMENT_TYPE_TYPEDBYREF.
-        // This is the classification counterpart for that element type. It is used to detect
-        // the special TypedReference type and specialize its classification.
-        // This type is represented as a struct with two fields. The classification needs to do
-        // special handling of it since the source/methadata type of the fieds is IntPtr.
-        // The VM changes the first to ByRef. The second is left as IntPtr (TYP_I_IMPL really). The classification needs to match this and
-        // special handling is warranted (similar thing is done in the getGCLayout function for this type).
-        SystemVClassificationTypeTypedReference     = 8,
-        SystemVClassificationTypeMAX                = 9
     };
 
     public struct SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR
@@ -1358,7 +1346,7 @@ namespace Internal.JitInterface
         CORJIT_FLAG_RELATIVE_CODE_RELOCS = 41, // JIT should generate PC-relative address computations instead of EE relocation records
         CORJIT_FLAG_NO_INLINING = 42, // JIT should not inline any called method into this method
 
-#region ARM64
+#region TARGET_ARM64
         CORJIT_FLAG_HAS_ARM64_AES           = 43, // ID_AA64ISAR0_EL1.AES is 1 or better
         CORJIT_FLAG_HAS_ARM64_ATOMICS       = 44, // ID_AA64ISAR0_EL1.Atomic is 2 or better
         CORJIT_FLAG_HAS_ARM64_CRC32         = 45, // ID_AA64ISAR0_EL1.CRC32 is 1 or better

--- a/src/JitInterface/src/JitConfigProvider.cs
+++ b/src/JitInterface/src/JitConfigProvider.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 using NumberStyles = System.Globalization.NumberStyles;
 
@@ -12,9 +14,49 @@ namespace Internal.JitInterface
 {
     public sealed class JitConfigProvider
     {
+        // Jit configuration is static because RyuJIT doesn't support multiple hosts within the same process.
+        private static JitConfigProvider s_instance;
+        public static JitConfigProvider Instance
+        {
+            get
+            {
+                Debug.Assert(s_instance != null);
+                return s_instance;
+            }
+        }
+
         private CorJitFlag[] _jitFlags;
         private Dictionary<string, string> _config = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private object _keepAlive; // Keeps callback delegates alive
+
+        public static void Initialize(IEnumerable<CorJitFlag> jitFlags, IEnumerable<KeyValuePair<string, string>> parameters, string jitPath = null)
+        {
+            var config = new JitConfigProvider(jitFlags, parameters);
+
+            // Make sure we didn't try to initialize two instances of JIT configuration.
+            // RyuJIT doesn't support multiple hosts in a single process.
+            if (Interlocked.CompareExchange(ref s_instance, config, null) != null)
+                throw new InvalidOperationException();
+
+#if READYTORUN
+            if (jitPath != null)
+            {
+                NativeLibrary.SetDllImportResolver(typeof(CorInfoImpl).Assembly, (libName, assembly, searchPath) =>
+                {
+                    IntPtr libHandle = IntPtr.Zero;
+                    if (libName == CorInfoImpl.JitLibrary)
+                    {
+                        libHandle = NativeLibrary.Load(jitPath, assembly, searchPath);
+                    }
+                    return libHandle;
+                });
+            }
+#else
+            Debug.Assert(jitPath == null);
+#endif
+
+            CorInfoImpl.Startup();
+        }
 
         public IntPtr UnmanagedInstance
         {
@@ -28,7 +70,6 @@ namespace Internal.JitInterface
         /// </summary>
         /// <param name="jitFlags">A collection of JIT compiler flags.</param>
         /// <param name="parameters">A collection of parameter name/value pairs.</param>
-        /// <param name="jitPath">A path to the JIT library to be used (may be null).</param>
         public JitConfigProvider(IEnumerable<CorJitFlag> jitFlags, IEnumerable<KeyValuePair<string, string>> parameters)
         {
             ArrayBuilder<CorJitFlag> jitFlagBuilder = new ArrayBuilder<CorJitFlag>();

--- a/src/JitInterface/src/SystemVStructClassificator.cs
+++ b/src/JitInterface/src/SystemVStructClassificator.cs
@@ -99,8 +99,7 @@ namespace Internal.JitInterface
             int typeSize = typeDesc.GetElementSize().AsInt;
             if (typeDesc.IsValueType && (typeSize <= CLR_SYSTEMV_MAX_STRUCT_BYTES_TO_PASS_IN_REGISTERS))
             {
-                if ((TypeDef2SystemVClassification(typeDesc) != SystemVClassificationTypeStruct) &&
-                    (TypeDef2SystemVClassification(typeDesc) != SystemVClassificationTypeTypedReference))
+                if (TypeDef2SystemVClassification(typeDesc) != SystemVClassificationTypeStruct)
                 {
                     return;
                 }
@@ -126,12 +125,6 @@ namespace Internal.JitInterface
 
         private static SystemVClassificationType TypeDef2SystemVClassification(TypeDesc typeDesc)
         {
-            if (typeDesc.IsWellKnownType(WellKnownType.TypedReference))
-            {
-                // There is no category representing typed reference
-                return SystemVClassificationTypeTypedReference;
-            }
-
             switch (typeDesc.Category)
             {
                 case TypeFlags.Boolean:
@@ -334,47 +327,6 @@ namespace Internal.JitInterface
                     }
 
                     continue;
-                }
-
-                if (fieldClassificationType == SystemVClassificationTypeTypedReference || 
-                    TypeDef2SystemVClassification(typeDesc) == SystemVClassificationTypeTypedReference)
-                {
-                    // The TypedReference is a very special type.
-                    // In source/metadata it has two fields - Type and Value and both are defined of type IntPtr.
-                    // When the VM creates a layout of the type it changes the type of the Value to ByRef type and the
-                    // type of the Type field is left to IntPtr (TYPE_I internally - native int type.)
-                    // This requires a special treatment of this type. The code below handles the both fields (and this entire type).
-
-                    for (int i = 0; i < 2; i++)
-                    {
-                        fieldSize = 8;
-                        fieldOffset = (i == 0 ? 0 : 8);
-                        normalizedFieldOffset = fieldOffset + startOffsetOfStruct;
-                        fieldClassificationType = (i == 0 ? SystemVClassificationTypeIntegerByRef : SystemVClassificationTypeInteger);
-                        if ((normalizedFieldOffset % fieldSize) != 0)
-                        {
-                            // The spec requires that struct values on the stack from register passed fields expects
-                            // those fields to be at their natural alignment.
-                            return false;
-                        }
-
-                        helper.LargestFieldOffset = (int)normalizedFieldOffset;
-
-                        // Set the data for a new field.
-
-                        // The new field classification must not have been initialized yet.
-                        Debug.Assert(helper.FieldClassifications[helper.CurrentUniqueOffsetField] == SystemVClassificationTypeNoClass);
-
-                        helper.FieldClassifications[helper.CurrentUniqueOffsetField] = fieldClassificationType;
-                        helper.FieldSizes[helper.CurrentUniqueOffsetField] = fieldSize;
-                        helper.FieldOffsets[helper.CurrentUniqueOffsetField] = normalizedFieldOffset;
-
-                        helper.CurrentUniqueOffsetField++;
-                    }
-
-                    // Both fields of the special TypedReference struct are handled.
-                    // Done classifying the System.TypedReference struct fields.
-                    break;
                 }
 
                 if ((normalizedFieldOffset % fieldSize) != 0)

--- a/src/JitInterface/src/ThunkGenerator/Program.cs
+++ b/src/JitInterface/src/ThunkGenerator/Program.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/JitInterface/src/ThunkGenerator/ThunkInput.txt
+++ b/src/JitInterface/src/ThunkGenerator/ThunkInput.txt
@@ -72,11 +72,11 @@ ULONG32*,ref uint,unsigned int*
 LONG*,int*,long*
 char*,byte*
 const char**,byte**
-WCHAR**,short**,wchar_t**
+WCHAR**,char**,wchar_t**
 LPCSTR,byte*,const char*
-LPWSTR,short*,wchar_t*
-LPCWSTR,short*,const wchar_t*
-wchar_t*,short*
+LPWSTR,char*,wchar_t*
+LPCWSTR,char*,const wchar_t*
+wchar_t*,char*
 const wchar_t*,String
 
 DWORD**,ref uint*,unsigned int**
@@ -158,7 +158,6 @@ struct _EXCEPTION_POINTERS*,_EXCEPTION_POINTERS*,void*
 RETURNTYPES
 BOOL,[return: MarshalAs(UnmanagedType.Bool)]bool,int
 bool,[return: MarshalAs(UnmanagedType.I1)]bool
-LPCWSTR,[return: MarshalAs(UnmanagedType.LPWStr)]string,const wchar_t*
 ; NOTE in managed SIZE_T is an enum that is 64bits in size, and returning one of those causing mcg to do the wrong thing.
 size_t,byte*,size_t
 
@@ -199,6 +198,7 @@ FUNCTIONS
     CorInfoCanSkipVerificationResult canSkipVerification(CORINFO_MODULE_HANDLE module)
     BOOL isValidToken(CORINFO_MODULE_HANDLE module, unsigned metaTOK)
     BOOL isValidStringRef(CORINFO_MODULE_HANDLE module, unsigned metaTOK)
+    LPCWSTR getStringLiteral(CORINFO_MODULE_HANDLE module, unsigned metaTOK, int* length)
     BOOL shouldEnforceCallvirtRestriction(CORINFO_MODULE_HANDLE scope)
     CorInfoType asCorInfoType(CORINFO_CLASS_HANDLE cls)
     const char* getClassName(CORINFO_CLASS_HANDLE cls)

--- a/src/Native/jitinterface/jitinterface.h
+++ b/src/Native/jitinterface/jitinterface.h
@@ -46,6 +46,7 @@ struct JitInterfaceCallbacks
     int (* canSkipVerification)(void * thisHandle, CorInfoException** ppException, void* module);
     int (* isValidToken)(void * thisHandle, CorInfoException** ppException, void* module, unsigned metaTOK);
     int (* isValidStringRef)(void * thisHandle, CorInfoException** ppException, void* module, unsigned metaTOK);
+    const wchar_t* (* getStringLiteral)(void * thisHandle, CorInfoException** ppException, void* module, unsigned metaTOK, int* length);
     int (* shouldEnforceCallvirtRestriction)(void * thisHandle, CorInfoException** ppException, void* scope);
     int (* asCorInfoType)(void * thisHandle, CorInfoException** ppException, void* cls);
     const char* (* getClassName)(void * thisHandle, CorInfoException** ppException, void* cls);
@@ -508,6 +509,15 @@ public:
     {
         CorInfoException* pException = nullptr;
         int _ret = _callbacks->isValidStringRef(_thisHandle, &pException, module, metaTOK);
+        if (pException != nullptr)
+            throw pException;
+        return _ret;
+    }
+
+    virtual const wchar_t* getStringLiteral(void* module, unsigned metaTOK, int* length)
+    {
+        CorInfoException* pException = nullptr;
+        const wchar_t* _ret = _callbacks->getStringLiteral(_thisHandle, &pException, module, metaTOK, length);
         if (pException != nullptr)
             throw pException;
         return _ret;

--- a/src/Native/jitinterface/jitwrapper.cpp
+++ b/src/Native/jitinterface/jitwrapper.cpp
@@ -27,11 +27,11 @@ private:
     uint64_t corJitFlags;
 };
 
-static const GUID JITEEVersionIdentifier = { /* abcf830c-56d1-4b33-a8ec-5063bb5495f1 */
-    0xabcf830c,
-    0x56d1,
-    0x4b33,
-    {0xa8, 0xec, 0x50, 0x63, 0xbb, 0x54, 0x95, 0xf1}
+static const GUID JITEEVersionIdentifier = { /* 96fc0c0a-9f77-450d-9663-ee33ae0fcae8 */
+    0x96fc0c0a,
+    0x9f77,
+    0x450d,
+    {0x96, 0x63, 0xee, 0x33, 0xae, 0x0f, 0xca, 0xe8}
 };
 
 class Jit

--- a/src/System.Private.Jit/src/Internal/Runtime/JitSupport/RyuJitExecutionStrategy.cs
+++ b/src/System.Private.Jit/src/Internal/Runtime/JitSupport/RyuJitExecutionStrategy.cs
@@ -73,9 +73,9 @@ namespace Internal.Runtime.JitSupport
                     Compilation compilation = new Compilation(_context);
                     _nodeFactory = compilation.NodeFactory;
 
-                    JitConfigProvider configProvider = new JitConfigProvider(new CorJitFlag[] { CorJitFlag.CORJIT_FLAG_DEBUG_CODE }, Array.Empty<KeyValuePair<string, string>>());
+                    JitConfigProvider.Initialize(new CorJitFlag[] { CorJitFlag.CORJIT_FLAG_DEBUG_CODE }, Array.Empty<KeyValuePair<string, string>>());
 
-                    _corInfoImpl = new CorInfoImpl(compilation, configProvider);
+                    _corInfoImpl = new CorInfoImpl(compilation);
                 }
 
                 MethodDesc methodToCompile = methodEntrypoint.MethodIdentifier.ToMethodDesc(_context);

--- a/src/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
+++ b/src/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
@@ -679,7 +679,7 @@ namespace Internal.TypeSystem
 
             protected override Internal.TypeSystem.Ecma.EcmaModule CreateValueFromKey(EcmaModuleInfo key)
             {
-                Internal.TypeSystem.Ecma.EcmaModule result = new Internal.TypeSystem.Ecma.EcmaModule(_context, key.PE, key.MetadataReader, null);
+                Internal.TypeSystem.Ecma.EcmaModule result = new Internal.TypeSystem.Ecma.EcmaModule(_context, key.PE, key.MetadataReader, null, null);
                 result.SetRuntimeModuleInfoUNSAFE(key);
                 return result;
             }

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -315,6 +315,9 @@
     <Compile Include="..\..\Common\src\TypeSystem\Common\IAssemblyDesc.cs">
       <Link>Internal\TypeSystem\IAssemblyDesc.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\src\TypeSystem\Common\IModuleResolver.cs">
+      <Link>Internal\TypeSystem\IModuleResolver.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\src\TypeSystem\Common\InstantiatedMethod.cs">
       <Link>Internal\TypeSystem\InstantiatedMethod.cs</Link>
     </Compile>


### PR DESCRIPTION
This also changes the mechanism by which we pick up RyuJIT - we now get it from Microsoft.NETCore.App.Runtime because Microsoft.NETCore.Jit was discontinued.