### PR TITLE
Use TypeFlags enum instead of CorElementType in EEType

### DIFF
--- a/src/Common/src/Internal/Runtime/EEType.Constants.cs
+++ b/src/Common/src/Internal/Runtime/EEType.Constants.cs
@@ -69,10 +69,10 @@ namespace Internal.Runtime
         IsGenericFlag = 0x0400,
 
         /// <summary>
-        /// We are storing a CorElementType in the upper bits for unboxing enums.
+        /// We are storing a EETypeElementType in the upper bits for unboxing enums.
         /// </summary>
-        CorElementTypeMask = 0xf800,
-        CorElementTypeShift = 11,
+        ElementTypeMask = 0xf800,
+        ElementTypeShift = 11,
 
         /// <summary>
         /// Single mark to check TypeKind and two flags. When non-zero, casting is more complicated.
@@ -209,37 +209,43 @@ namespace Internal.Runtime
         ETF_DynamicThreadStaticOffset,
     }
 
-    internal enum CorElementType
+    // Subset of the managed TypeFlags enum understood by Redhawk.
+    // This should match the values in the TypeFlags enum except for the special
+    // entry that marks System.Array specifically.
+    internal enum EETypeElementType
     {
-        ELEMENT_TYPE_END = 0x00,
+        // Primitive
+        Unknown = 0x00,
+        Void = 0x01,
+        Boolean = 0x02,
+        Char = 0x03,
+        SByte = 0x04,
+        Byte = 0x05,
+        Int16 = 0x06,
+        UInt16 = 0x07,
+        Int32 = 0x08,
+        UInt32 = 0x09,
+        Int64 = 0x0A,
+        UInt64 = 0x0B,
+        IntPtr = 0x0C,
+        UIntPtr = 0x0D,
+        Single = 0x0E,
+        Double = 0x0F,
 
-        ELEMENT_TYPE_VOID = 0x1,
-        ELEMENT_TYPE_BOOLEAN = 0x2,
-        ELEMENT_TYPE_CHAR = 0x3,
-        ELEMENT_TYPE_I1 = 0x4,
-        ELEMENT_TYPE_U1 = 0x5,
-        ELEMENT_TYPE_I2 = 0x6,
-        ELEMENT_TYPE_U2 = 0x7,
-        ELEMENT_TYPE_I4 = 0x8,
-        ELEMENT_TYPE_U4 = 0x9,
-        ELEMENT_TYPE_I8 = 0xa,
-        ELEMENT_TYPE_U8 = 0xb,
-        ELEMENT_TYPE_R4 = 0xc,
-        ELEMENT_TYPE_R8 = 0xd,
-        ELEMENT_TYPE_STRING = 0xe,
-        ELEMENT_TYPE_PTR = 0xf,
-        ELEMENT_TYPE_BYREF = 0x10,
-        ELEMENT_TYPE_VALUETYPE = 0x11,
-        ELEMENT_TYPE_CLASS = 0x12,
+        ValueType = 0x10,
+        // Enum = 0x11, // EETypes store enums as their underlying type
+        Nullable = 0x12,
+        // Unused 0x13,
 
-        ELEMENT_TYPE_ARRAY = 0x14,
+        Class = 0x14,
+        Interface = 0x15,
 
-        ELEMENT_TYPE_TYPEDBYREF = 0x16,
-        ELEMENT_TYPE_I = 0x18,
-        ELEMENT_TYPE_U = 0x19,
-        ELEMENT_TYPE_FNPTR = 0x1b,
-        ELEMENT_TYPE_OBJECT = 0x1c,
-        ELEMENT_TYPE_SZARRAY = 0x1d,
+        SystemArray = 0x16, // System.Array type
+
+        Array = 0x17,
+        SzArray = 0x18,
+        ByRef = 0x19,
+        Pointer = 0x1A,
     }
 
     internal enum EETypeOptionalFieldTag : byte

--- a/src/Common/src/Internal/Runtime/EEType.cs
+++ b/src/Common/src/Internal/Runtime/EEType.cs
@@ -1249,11 +1249,11 @@ namespace Internal.Runtime
             }
         }
 
-        internal CorElementType CorElementType
+        internal EETypeElementType ElementType
         {
             get
             {
-                return (CorElementType)((_usFlags & (ushort)EETypeFlags.CorElementTypeMask) >> (ushort)EETypeFlags.CorElementTypeShift);
+                return (EETypeElementType)((_usFlags & (ushort)EETypeFlags.ElementTypeMask) >> (ushort)EETypeFlags.ElementTypeShift);
             }
         }
 

--- a/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -11,49 +11,36 @@ namespace Internal.Runtime
 {
     internal static class EETypeBuilderHelpers
     {
-        private static CorElementType ComputeRhCorElementType(TypeDesc type)
+        private static EETypeElementType ComputeEETypeElementType(TypeDesc type)
         {
-            Debug.Assert(type.IsPrimitive);
-            Debug.Assert(type.Category != TypeFlags.Unknown);
+            // Enums are represented as their underlying type
+            type = type.UnderlyingType;
 
-            switch (type.Category)
+            if (type.IsWellKnownType(WellKnownType.Array))
             {
-                case TypeFlags.Void:
-                    return CorElementType.ELEMENT_TYPE_VOID;
-                case TypeFlags.Boolean:
-                    return CorElementType.ELEMENT_TYPE_BOOLEAN;
-                case TypeFlags.Char:
-                    return CorElementType.ELEMENT_TYPE_CHAR;
-                case TypeFlags.SByte:
-                    return CorElementType.ELEMENT_TYPE_I1;
-                case TypeFlags.Byte:
-                    return CorElementType.ELEMENT_TYPE_U1;
-                case TypeFlags.Int16:
-                    return CorElementType.ELEMENT_TYPE_I2;
-                case TypeFlags.UInt16:
-                    return CorElementType.ELEMENT_TYPE_U2;
-                case TypeFlags.Int32:
-                    return CorElementType.ELEMENT_TYPE_I4;
-                case TypeFlags.UInt32:
-                    return CorElementType.ELEMENT_TYPE_U4;
-                case TypeFlags.Int64:
-                    return CorElementType.ELEMENT_TYPE_I8;
-                case TypeFlags.UInt64:
-                    return CorElementType.ELEMENT_TYPE_U8;
-                case TypeFlags.IntPtr:
-                    return CorElementType.ELEMENT_TYPE_I;
-                case TypeFlags.UIntPtr:
-                    return CorElementType.ELEMENT_TYPE_U;
-                case TypeFlags.Single:
-                    return CorElementType.ELEMENT_TYPE_R4;
-                case TypeFlags.Double:
-                    return CorElementType.ELEMENT_TYPE_R8;
-                default:
-                    break;
+                // SystemArray is a special EETypeElementType that doesn't exist in TypeFlags
+                return EETypeElementType.SystemArray;
             }
+            else
+            {
+                // The rest of TypeFlags should be directly castable to EETypeElementType.
+                // Spot check the enums match.
+                Debug.Assert((int)TypeFlags.Void == (int)EETypeElementType.Void);
+                Debug.Assert((int)TypeFlags.IntPtr == (int)EETypeElementType.IntPtr);
+                Debug.Assert((int)TypeFlags.Single == (int)EETypeElementType.Single);
+                Debug.Assert((int)TypeFlags.UInt32 == (int)EETypeElementType.UInt32);
+                Debug.Assert((int)TypeFlags.Pointer == (int)EETypeElementType.Pointer);
+                Debug.Assert((int)TypeFlags.Array == (int)EETypeElementType.Array);
 
-            Debug.Fail("Primitive type value expected.");
-            return 0;
+                EETypeElementType elementType = (EETypeElementType)type.Category;
+
+                // Would be surprising to get these here though.
+                Debug.Assert(elementType != EETypeElementType.SystemArray);
+                Debug.Assert(elementType <= EETypeElementType.Pointer);
+
+                return elementType;
+
+            }            
         }
 
         public static UInt16 ComputeFlags(TypeDesc type)
@@ -96,8 +83,8 @@ namespace Internal.Runtime
                 }
                 else if (type.IsArray)
                 {
-                    var elementType = ((ArrayType)type).ElementType;
-                    if ((elementType.IsValueType && ((DefType)elementType).ContainsGCPointers) || elementType.IsGCPointer)
+                    var arrayElementType = ((ArrayType)type).ElementType;
+                    if ((arrayElementType.IsValueType && ((DefType)arrayElementType).ContainsGCPointers) || arrayElementType.IsGCPointer)
                     {
                         flags |= (UInt16)EETypeFlags.HasPointersFlag;
                     }
@@ -123,29 +110,9 @@ namespace Internal.Runtime
         {
             UInt16 flags = 0;
 
-            CorElementType corElementType = CorElementType.ELEMENT_TYPE_END;
-
             // The top 5 bits of flags are used to convey enum underlying type, primitive type, or mark the type as being System.Array
-            if (type.IsEnum)
-            {
-                TypeDesc underlyingType = type.UnderlyingType;
-                Debug.Assert(TypeFlags.SByte <= underlyingType.Category && underlyingType.Category <= TypeFlags.UInt64);
-                corElementType = ComputeRhCorElementType(underlyingType);
-            }
-            else if (type.IsPrimitive)
-            {
-                corElementType = ComputeRhCorElementType(type);
-            }
-            else if (type.IsWellKnownType(WellKnownType.Array))
-            {
-                // Mark System.Array with CorElementType so casting code can distinguish it
-                corElementType = CorElementType.ELEMENT_TYPE_ARRAY;
-            }
-
-            if (corElementType != CorElementType.ELEMENT_TYPE_END)
-            {
-                flags |= (UInt16)((UInt16)corElementType << (UInt16)EETypeFlags.CorElementTypeShift);
-            }
+            EETypeElementType elementType = ComputeEETypeElementType(type);
+            flags |= (UInt16)((UInt16)elementType << (UInt16)EETypeFlags.ElementTypeShift);
 
             return flags;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -27,7 +27,7 @@ namespace ILCompiler.DependencyAnalysis
     ///                 | and 0 for all other types.
     ///                 |
     /// UInt16          | EETypeKind (Normal, Array, Pointer type). Flags for: IsValueType, IsCrossModule, HasPointers,
-    ///                 | HasOptionalFields, IsInterface, IsGeneric. Top 5 bits are used for enum CorElementType to
+    ///                 | HasOptionalFields, IsInterface, IsGeneric. Top 5 bits are used for enum EETypeElementType to
     ///                 | record whether it's back by an Int32, Int16 etc
     ///                 |
     /// Uint32          | Base size.

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -60,8 +60,7 @@ namespace ILCompiler.DependencyAnalysis
             if (HasOptionalFields)
                 flags |= (short)EETypeFlags.OptionalFieldsFlag;
 
-            if (_type.IsEnum)
-                flags |= (short)EETypeBuilderHelpers.ComputeElementTypeFlags(_type);
+            flags |= (short)EETypeBuilderHelpers.ComputeElementTypeFlags(_type);
 
             dataBuilder.EmitShort((short)_type.Instantiation.Length);
             dataBuilder.EmitShort(flags);

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -787,21 +787,21 @@ bool EETypesEquivalentEnoughForUnboxing(EEType *pObjectEEType, EEType *pUnboxToE
     if (pObjectEEType->IsEquivalentTo(pUnboxToEEType))
         return true;
 
-    if (pObjectEEType->GetCorElementType() == pUnboxToEEType->GetCorElementType())
+    if (pObjectEEType->GetElementType() == pUnboxToEEType->GetElementType())
     {
-        // Enums and primitive types can unbox if their CorElementTypes exactly match
-        switch (pObjectEEType->GetCorElementType())
+        // Enums and primitive types can unbox if their EETypeElementTypes exactly match
+        switch (pObjectEEType->GetElementType())
         {
-        case ELEMENT_TYPE_I1:
-        case ELEMENT_TYPE_U1:
-        case ELEMENT_TYPE_I2:
-        case ELEMENT_TYPE_U2:
-        case ELEMENT_TYPE_I4:
-        case ELEMENT_TYPE_U4:
-        case ELEMENT_TYPE_I8:
-        case ELEMENT_TYPE_U8:
-        case ELEMENT_TYPE_I:
-        case ELEMENT_TYPE_U:
+        case ElementType_SByte:
+        case ElementType_Byte:
+        case ElementType_Int16:
+        case ElementType_UInt16:
+        case ElementType_Int32:
+        case ElementType_UInt32:
+        case ElementType_Int64:
+        case ElementType_UInt64:
+        case ElementType_IntPtr:
+        case ElementType_UIntPtr:
             return true;
         default:
             break;

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -125,33 +125,44 @@ public:
         { return &m_dispatchMap[m_entryCount]; }
 };
 
-#if !defined(BINDER)
 //-------------------------------------------------------------------------------------------------
-// The subset of CLR-style CorElementTypes that Redhawk knows about at runtime (just the primitives and a
-// special case for ELEMENT_TYPE_ARRAY used to mark the System.Array EEType).
-enum CorElementType : UInt8
+// The subset of TypeFlags that Redhawk knows about at runtime
+// This should match the TypeFlags enum in the managed type system.
+enum EETypeElementType : UInt8
 {
-    ELEMENT_TYPE_END        = 0x0,
+    // Primitive
+    ElementType_Unknown = 0x00,
+    ElementType_Void = 0x01,
+    ElementType_Boolean = 0x02,
+    ElementType_Char = 0x03,
+    ElementType_SByte = 0x04,
+    ElementType_Byte = 0x05,
+    ElementType_Int16 = 0x06,
+    ElementType_UInt16 = 0x07,
+    ElementType_Int32 = 0x08,
+    ElementType_UInt32 = 0x09,
+    ElementType_Int64 = 0x0A,
+    ElementType_UInt64 = 0x0B,
+    ElementType_IntPtr = 0x0C,
+    ElementType_UIntPtr = 0x0D,
+    ElementType_Single = 0x0E,
+    ElementType_Double = 0x0F,
 
-    ELEMENT_TYPE_BOOLEAN    = 0x2,
-    ELEMENT_TYPE_CHAR       = 0x3,
-    ELEMENT_TYPE_I1         = 0x4,
-    ELEMENT_TYPE_U1         = 0x5,
-    ELEMENT_TYPE_I2         = 0x6,
-    ELEMENT_TYPE_U2         = 0x7,
-    ELEMENT_TYPE_I4         = 0x8,
-    ELEMENT_TYPE_U4         = 0x9,
-    ELEMENT_TYPE_I8         = 0xa,
-    ELEMENT_TYPE_U8         = 0xb,
-    ELEMENT_TYPE_R4         = 0xc,
-    ELEMENT_TYPE_R8         = 0xd,
+    ElementType_ValueType = 0x10,
+    // Enum = 0x11, // EETypes store enums as their underlying type
+    ElementType_Nullable = 0x12,
+    // Unused 0x13,
 
-    ELEMENT_TYPE_ARRAY      = 0x14,
+    ElementType_Class = 0x14,
+    ElementType_Interface = 0x15,
 
-    ELEMENT_TYPE_I          = 0x18,
-    ELEMENT_TYPE_U          = 0x19,
+    ElementType_SystemArray = 0x16, // System.Array type
+
+    ElementType_Array = 0x17,
+    ElementType_SzArray = 0x18,
+    ElementType_ByRef = 0x19,
+    ElementType_Pointer = 0x1A,
 };
-#endif // !BINDER
 
 //-------------------------------------------------------------------------------------------------
 // Support for encapsulating the location of fields in the EEType that have variable offsets or may be
@@ -274,9 +285,9 @@ private:
         // This type is generic.
         IsGenericFlag           = 0x0400,
 
-        // We are storing a CorElementType in the upper bits for unboxing enums
-        CorElementTypeMask      = 0xf800,
-        CorElementTypeShift     = 11,
+        // We are storing a EETypeElementType in the upper bits for unboxing enums
+        ElementTypeMask      = 0xf800,
+        ElementTypeShift     = 11,
     };
 
 public:
@@ -515,12 +526,8 @@ public:
     bool IsSystemObject()
         { return !IsParameterizedType() && !IsInterface() && get_BaseType() == NULL; }
 
-    CorElementType GetCorElementType()
-        { return (CorElementType)((m_usFlags & CorElementTypeMask) >> CorElementTypeShift); }
-
-    // Is this type specifically System.Array?
-    bool IsSystemArray()
-        { return GetCorElementType() == ELEMENT_TYPE_ARRAY; }
+    EETypeElementType GetElementType()
+        { return (EETypeElementType)((m_usFlags & ElementTypeMask) >> ElementTypeShift); }
 
 #ifndef BINDER
     // Determine whether a type requires 8-byte alignment for its fields (required only on certain platforms,

--- a/src/Native/Runtime/rheventtrace.cpp
+++ b/src/Native/Runtime/rheventtrace.cpp
@@ -137,6 +137,63 @@ public:
     }
 };
 
+enum class CorElementType : UInt8
+{
+    ELEMENT_TYPE_END = 0x0,
+
+    ELEMENT_TYPE_BOOLEAN = 0x2,
+    ELEMENT_TYPE_CHAR = 0x3,
+    ELEMENT_TYPE_I1 = 0x4,
+    ELEMENT_TYPE_U1 = 0x5,
+    ELEMENT_TYPE_I2 = 0x6,
+    ELEMENT_TYPE_U2 = 0x7,
+    ELEMENT_TYPE_I4 = 0x8,
+    ELEMENT_TYPE_U4 = 0x9,
+    ELEMENT_TYPE_I8 = 0xa,
+    ELEMENT_TYPE_U8 = 0xb,
+    ELEMENT_TYPE_R4 = 0xc,
+    ELEMENT_TYPE_R8 = 0xd,
+
+    ELEMENT_TYPE_I = 0x18,
+    ELEMENT_TYPE_U = 0x19,
+};
+
+static CorElementType ElementTypeToCorElementType(EETypeElementType elementType)
+{
+    switch (elementType)
+    {
+    case EETypeElementType::ElementType_Boolean:
+        return CorElementType::ELEMENT_TYPE_BOOLEAN;
+    case EETypeElementType::ElementType_Char:
+        return CorElementType::ELEMENT_TYPE_CHAR;
+    case EETypeElementType::ElementType_SByte:
+        return CorElementType::ELEMENT_TYPE_I1;
+    case EETypeElementType::ElementType_Byte:
+        return CorElementType::ELEMENT_TYPE_U1;
+    case EETypeElementType::ElementType_Int16:
+        return CorElementType::ELEMENT_TYPE_I2;
+    case EETypeElementType::ElementType_UInt16:
+        return CorElementType::ELEMENT_TYPE_U2;
+    case EETypeElementType::ElementType_Int32:
+        return CorElementType::ELEMENT_TYPE_I4;
+    case EETypeElementType::ElementType_UInt32:
+        return CorElementType::ELEMENT_TYPE_U4;
+    case EETypeElementType::ElementType_Int64:
+        return CorElementType::ELEMENT_TYPE_I8;
+    case EETypeElementType::ElementType_UInt64:
+        return CorElementType::ELEMENT_TYPE_U8;
+    case EETypeElementType::ElementType_Single:
+        return CorElementType::ELEMENT_TYPE_R4;
+    case EETypeElementType::ElementType_Double:
+        return CorElementType::ELEMENT_TYPE_R8;
+    case EETypeElementType::ElementType_IntPtr:
+        return CorElementType::ELEMENT_TYPE_I;
+    case EETypeElementType::ElementType_UIntPtr:
+        return CorElementType::ELEMENT_TYPE_U;
+    }
+    return CorElementType::ELEMENT_TYPE_END;
+}
+
 // Avoid reporting the same type twice by keeping a hash of logged types.
 SHash<LoggedTypesTraits>* s_loggedTypesHash = NULL;
 
@@ -188,7 +245,7 @@ int BulkTypeEventLogger::LogSingleType(EEType * pEEType)
 
     pVal->fixedSizedData.TypeID = (ULONGLONG) pEEType;
     pVal->fixedSizedData.Flags = kEtwTypeFlagsModuleBaseAddress;
-    pVal->fixedSizedData.CorElementType = pEEType->GetCorElementType();
+    pVal->fixedSizedData.CorElementType = (BYTE)ElementTypeToCorElementType(pEEType->GetElementType());
 
     ULONGLONG * rgTypeParamsForEvent = NULL;
     ULONGLONG typeParamForNonGenericType = 0;

--- a/src/Runtime.Base/src/System/Runtime/EEType.Runtime.cs
+++ b/src/Runtime.Base/src/System/Runtime/EEType.Runtime.cs
@@ -157,7 +157,7 @@ namespace Internal.Runtime
         // The binder sets a special CorElementType for this well known type
         internal static unsafe bool IsSystemArray(EEType* pEEType)
         {
-            return (pEEType->CorElementType == CorElementType.ELEMENT_TYPE_ARRAY);
+            return (pEEType->ElementType == EETypeElementType.SystemArray);
         }
     }
 }

--- a/src/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -130,22 +130,22 @@ namespace System.Runtime
             if (TypeCast.AreTypesEquivalentInternal(pEEType, ptrUnboxToEEType))
                 return true;
 
-            if (pEEType->CorElementType == ptrUnboxToEEType->CorElementType)
+            if (pEEType->ElementType == ptrUnboxToEEType->ElementType)
             {
                 // Enum's and primitive types should pass the UnboxAny exception cases
                 // if they have an exactly matching cor element type.
-                switch (ptrUnboxToEEType->CorElementType)
+                switch (ptrUnboxToEEType->ElementType)
                 {
-                    case CorElementType.ELEMENT_TYPE_I1:
-                    case CorElementType.ELEMENT_TYPE_U1:
-                    case CorElementType.ELEMENT_TYPE_I2:
-                    case CorElementType.ELEMENT_TYPE_U2:
-                    case CorElementType.ELEMENT_TYPE_I4:
-                    case CorElementType.ELEMENT_TYPE_U4:
-                    case CorElementType.ELEMENT_TYPE_I8:
-                    case CorElementType.ELEMENT_TYPE_U8:
-                    case CorElementType.ELEMENT_TYPE_I:
-                    case CorElementType.ELEMENT_TYPE_U:
+                    case EETypeElementType.Byte:
+                    case EETypeElementType.SByte:
+                    case EETypeElementType.Int16:
+                    case EETypeElementType.UInt16:
+                    case EETypeElementType.Int32:
+                    case EETypeElementType.UInt32:
+                    case EETypeElementType.Int64:
+                    case EETypeElementType.UInt64:
+                    case EETypeElementType.IntPtr:
+                    case EETypeElementType.UIntPtr:
                         return true;
                 }
             }

--- a/src/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -173,23 +173,6 @@ namespace System.Runtime
             return result;
         }
 
-        [RuntimeExport("RhTypeCast_CheckUnbox")]
-        public static unsafe void CheckUnbox(object obj, byte expectedCorElementType)
-        {
-            if (obj == null)
-            {
-                return;
-            }
-
-            if (obj.EEType->CorElementType == (CorElementType)expectedCorElementType)
-                return;
-
-            // Throw the invalid cast exception defined by the classlib, using the input object's EEType* 
-            // to find the correct classlib.
-
-            throw obj.EEType->GetClasslibException(ExceptionIDs.InvalidCast);
-        }
-
         [RuntimeExport("RhTypeCast_IsInstanceOfArray")]
         public static unsafe object IsInstanceOfArray(void* pvTargetType, object obj)
         {
@@ -1004,37 +987,37 @@ namespace System.Runtime
         // Returns true of the two types are equivalent primitive types. Used by array casts.
         private static unsafe bool ArePrimitveTypesEquivalentSize(EEType* pType1, EEType* pType2)
         {
-            CorElementType sourceCorType = pType1->CorElementType;
+            EETypeElementType sourceCorType = pType1->ElementType;
             int sourcePrimitiveTypeEquivalenceSize = GetIntegralTypeMatchSize(sourceCorType);
 
             // Quick check to see if the first type is even primitive.
             if (sourcePrimitiveTypeEquivalenceSize == 0)
                 return false;
 
-            CorElementType targetCorType = pType2->CorElementType;
+            EETypeElementType targetCorType = pType2->ElementType;
             int targetPrimitiveTypeEquivalenceSize = GetIntegralTypeMatchSize(targetCorType);
 
             return sourcePrimitiveTypeEquivalenceSize == targetPrimitiveTypeEquivalenceSize;
         }
 
-        private static unsafe int GetIntegralTypeMatchSize(CorElementType corType)
+        private static unsafe int GetIntegralTypeMatchSize(EETypeElementType elementType)
         {
-            switch (corType)
+            switch (elementType)
             {
-                case CorElementType.ELEMENT_TYPE_I1:
-                case CorElementType.ELEMENT_TYPE_U1:
+                case EETypeElementType.Byte:
+                case EETypeElementType.SByte:
                     return 1;
-                case CorElementType.ELEMENT_TYPE_I2:
-                case CorElementType.ELEMENT_TYPE_U2:
+                case EETypeElementType.Int16:
+                case EETypeElementType.UInt16:
                     return 2;
-                case CorElementType.ELEMENT_TYPE_I4:
-                case CorElementType.ELEMENT_TYPE_U4:
+                case EETypeElementType.Int32:
+                case EETypeElementType.UInt32:
                     return 4;
-                case CorElementType.ELEMENT_TYPE_I8:
-                case CorElementType.ELEMENT_TYPE_U8:
+                case EETypeElementType.Int64:
+                case EETypeElementType.UInt64:
                     return 8;
-                case CorElementType.ELEMENT_TYPE_I:
-                case CorElementType.ELEMENT_TYPE_U:
+                case EETypeElementType.IntPtr:
+                case EETypeElementType.UIntPtr:
                     return sizeof(IntPtr);
                 default:
                     return 0;

--- a/src/System.Private.CoreLib/shared/System/Enum.cs
+++ b/src/System.Private.CoreLib/shared/System/Enum.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using Internal.Runtime.CompilerServices;
 
 #if CORERT
-using CorElementType = System.Runtime.RuntimeImports.RhCorElementType;
 using RuntimeType = System.Type;
 using EnumInfo = Internal.Runtime.Augments.EnumInfo;
 #endif

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -22,7 +22,7 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
 
-using RhCorElementType = System.Runtime.RuntimeImports.RhCorElementType;
+using EETypeElementType = Internal.Runtime.EETypeElementType;
 
 using EnumInfo = Internal.Runtime.Augments.EnumInfo;
 
@@ -62,21 +62,21 @@ namespace Internal.Reflection.Augments
 
             // Note: Type.GetTypeCode() is expected to return the underlying type's TypeCode for enums. EETypePtr.CorElementType does the same,
             // so this one switch handles both cases.
-            RhCorElementType rhType = eeType.CorElementType;
+            EETypeElementType rhType = eeType.ElementType;
             switch (rhType)
             {
-                case RhCorElementType.ELEMENT_TYPE_BOOLEAN: return TypeCode.Boolean;
-                case RhCorElementType.ELEMENT_TYPE_CHAR: return TypeCode.Char;
-                case RhCorElementType.ELEMENT_TYPE_I1: return TypeCode.SByte;
-                case RhCorElementType.ELEMENT_TYPE_U1: return TypeCode.Byte;
-                case RhCorElementType.ELEMENT_TYPE_I2: return TypeCode.Int16;
-                case RhCorElementType.ELEMENT_TYPE_U2: return TypeCode.UInt16;
-                case RhCorElementType.ELEMENT_TYPE_I4: return TypeCode.Int32;
-                case RhCorElementType.ELEMENT_TYPE_U4: return TypeCode.UInt32;
-                case RhCorElementType.ELEMENT_TYPE_I8: return TypeCode.Int64;
-                case RhCorElementType.ELEMENT_TYPE_U8: return TypeCode.UInt64;
-                case RhCorElementType.ELEMENT_TYPE_R4: return TypeCode.Single;
-                case RhCorElementType.ELEMENT_TYPE_R8: return TypeCode.Double;
+                case EETypeElementType.Boolean: return TypeCode.Boolean;
+                case EETypeElementType.Char: return TypeCode.Char;
+                case EETypeElementType.SByte: return TypeCode.SByte;
+                case EETypeElementType.Byte: return TypeCode.Byte;
+                case EETypeElementType.Int16: return TypeCode.Int16;
+                case EETypeElementType.UInt16: return TypeCode.UInt16;
+                case EETypeElementType.Int32: return TypeCode.Int32;
+                case EETypeElementType.UInt32: return TypeCode.UInt32;
+                case EETypeElementType.Int64: return TypeCode.Int64;
+                case EETypeElementType.UInt64: return TypeCode.UInt64;
+                case EETypeElementType.Single: return TypeCode.Single;
+                case EETypeElementType.Double: return TypeCode.Double;
                 default:
                     break;
             }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -441,28 +441,28 @@ namespace Internal.Runtime.Augments
         {
             Debug.Assert(enumTypeHandle.ToEETypePtr().IsEnum);
 
-            RuntimeImports.RhCorElementType corElementType = enumTypeHandle.ToEETypePtr().CorElementType;
-            switch (corElementType)
+            EETypeElementType elementType = enumTypeHandle.ToEETypePtr().ElementType;
+            switch (elementType)
             {
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_BOOLEAN:
+                case EETypeElementType.Boolean:
                     return CommonRuntimeTypes.Boolean;
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_CHAR:
+                case EETypeElementType.Char:
                     return CommonRuntimeTypes.Char;
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I1:
+                case EETypeElementType.SByte:
                     return CommonRuntimeTypes.SByte;
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U1:
+                case EETypeElementType.Byte:
                     return CommonRuntimeTypes.Byte;
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I2:
+                case EETypeElementType.Int16:
                     return CommonRuntimeTypes.Int16;
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U2:
+                case EETypeElementType.UInt16:
                     return CommonRuntimeTypes.UInt16;
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I4:
+                case EETypeElementType.Int32:
                     return CommonRuntimeTypes.Int32;
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U4:
+                case EETypeElementType.UInt32:
                     return CommonRuntimeTypes.UInt32;
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I8:
+                case EETypeElementType.Int64:
                     return CommonRuntimeTypes.Int64;
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U8:
+                case EETypeElementType.UInt64:
                     return CommonRuntimeTypes.UInt64;
                 default:
                     throw new NotSupportedException();
@@ -938,11 +938,6 @@ namespace Internal.Runtime.Augments
         public static unsafe RuntimeTypeHandle GetRuntimeTypeHandleFromObjectReference(object obj)
         {
             return new RuntimeTypeHandle(obj.EETypePtr);
-        }
-
-        public static int GetCorElementType(RuntimeTypeHandle type)
-        {
-            return (int)type.ToEETypePtr().CorElementType;
         }
 
         // Move memory which may be on the heap which may have object references in it.

--- a/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -17,6 +17,7 @@ using Internal.Runtime.CompilerServices;
 using Internal.Reflection.Core.NonPortable;
 using Internal.IntrinsicSupport;
 using EEType = Internal.Runtime.EEType;
+using EETypeElementType = Internal.Runtime.EETypeElementType;
 
 #if TARGET_64BIT
 using nuint = System.UInt64;
@@ -574,8 +575,8 @@ namespace System
 
             Debug.Assert(sourceElementEEType.IsPrimitive && destinationElementEEType.IsPrimitive); // Caller has already validated this.
 
-            RuntimeImports.RhCorElementType sourceElementType = sourceElementEEType.CorElementType;
-            RuntimeImports.RhCorElementType destElementType = destinationElementEEType.CorElementType;
+            EETypeElementType sourceElementType = sourceElementEEType.ElementType;
+            EETypeElementType destElementType = destinationElementEEType.ElementType;
 
             nuint srcElementSize = sourceArray.ElementSize;
             nuint destElementSize = destinationArray.ElementSize;
@@ -618,31 +619,31 @@ namespace System
                     // converting w/ sign extension and floating point conversions.
                     switch (sourceElementType)
                     {
-                        case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U1:
+                        case EETypeElementType.Byte:
                             {
                                 switch (destElementType)
                                 {
-                                    case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R4:
+                                    case EETypeElementType.Single:
                                         *(float*)data = *(byte*)srcData;
                                         break;
 
-                                    case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8:
+                                    case EETypeElementType.Double:
                                         *(double*)data = *(byte*)srcData;
                                         break;
 
-                                    case RuntimeImports.RhCorElementType.ELEMENT_TYPE_CHAR:
-                                    case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I2:
-                                    case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U2:
+                                    case EETypeElementType.Char:
+                                    case EETypeElementType.Int16:
+                                    case EETypeElementType.UInt16:
                                         *(short*)data = *(byte*)srcData;
                                         break;
 
-                                    case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I4:
-                                    case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U4:
+                                    case EETypeElementType.Int32:
+                                    case EETypeElementType.UInt32:
                                         *(int*)data = *(byte*)srcData;
                                         break;
 
-                                    case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I8:
-                                    case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U8:
+                                    case EETypeElementType.Int64:
+                                    case EETypeElementType.UInt64:
                                         *(long*)data = *(byte*)srcData;
                                         break;
 
@@ -652,26 +653,26 @@ namespace System
                                 break;
                             }
 
-                        case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I1:
+                        case EETypeElementType.SByte:
                             switch (destElementType)
                             {
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I2:
+                                case EETypeElementType.Int16:
                                     *(short*)data = *(sbyte*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I4:
+                                case EETypeElementType.Int32:
                                     *(int*)data = *(sbyte*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I8:
+                                case EETypeElementType.Int64:
                                     *(long*)data = *(sbyte*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R4:
+                                case EETypeElementType.Single:
                                     *(float*)data = *(sbyte*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8:
+                                case EETypeElementType.Double:
                                     *(double*)data = *(sbyte*)srcData;
                                     break;
 
@@ -680,30 +681,30 @@ namespace System
                             }
                             break;
 
-                        case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U2:
-                        case RuntimeImports.RhCorElementType.ELEMENT_TYPE_CHAR:
+                        case EETypeElementType.UInt16:
+                        case EETypeElementType.Char:
                             switch (destElementType)
                             {
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R4:
+                                case EETypeElementType.Single:
                                     *(float*)data = *(ushort*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8:
+                                case EETypeElementType.Double:
                                     *(double*)data = *(ushort*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U2:
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_CHAR:
+                                case EETypeElementType.UInt16:
+                                case EETypeElementType.Char:
                                     *(ushort*)data = *(ushort*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I4:
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U4:
+                                case EETypeElementType.Int32:
+                                case EETypeElementType.UInt32:
                                     *(uint*)data = *(ushort*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I8:
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U8:
+                                case EETypeElementType.Int64:
+                                case EETypeElementType.UInt64:
                                     *(ulong*)data = *(ushort*)srcData;
                                     break;
 
@@ -712,22 +713,22 @@ namespace System
                             }
                             break;
 
-                        case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I2:
+                        case EETypeElementType.Int16:
                             switch (destElementType)
                             {
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I4:
+                                case EETypeElementType.Int32:
                                     *(int*)data = *(short*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I8:
+                                case EETypeElementType.Int64:
                                     *(long*)data = *(short*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R4:
+                                case EETypeElementType.Single:
                                     *(float*)data = *(short*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8:
+                                case EETypeElementType.Double:
                                     *(double*)data = *(short*)srcData;
                                     break;
 
@@ -736,18 +737,18 @@ namespace System
                             }
                             break;
 
-                        case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I4:
+                        case EETypeElementType.Int32:
                             switch (destElementType)
                             {
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I8:
+                                case EETypeElementType.Int64:
                                     *(long*)data = *(int*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R4:
+                                case EETypeElementType.Single:
                                     *(float*)data = (float)*(int*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8:
+                                case EETypeElementType.Double:
                                     *(double*)data = *(int*)srcData;
                                     break;
 
@@ -756,19 +757,19 @@ namespace System
                             }
                             break;
 
-                        case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U4:
+                        case EETypeElementType.UInt32:
                             switch (destElementType)
                             {
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I8:
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U8:
+                                case EETypeElementType.Int64:
+                                case EETypeElementType.UInt64:
                                     *(long*)data = *(uint*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R4:
+                                case EETypeElementType.Single:
                                     *(float*)data = (float)*(uint*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8:
+                                case EETypeElementType.Double:
                                     *(double*)data = *(uint*)srcData;
                                     break;
 
@@ -778,14 +779,14 @@ namespace System
                             break;
 
 
-                        case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I8:
+                        case EETypeElementType.Int64:
                             switch (destElementType)
                             {
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R4:
+                                case EETypeElementType.Single:
                                     *(float*)data = (float)*(long*)srcData;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8:
+                                case EETypeElementType.Double:
                                     *(double*)data = (double)*(long*)srcData;
                                     break;
 
@@ -794,10 +795,10 @@ namespace System
                             }
                             break;
 
-                        case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U8:
+                        case EETypeElementType.UInt64:
                             switch (destElementType)
                             {
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R4:
+                                case EETypeElementType.Single:
 
                                     //*(float*) data = (float) *(Ulong*)srcData;
                                     long srcValToFloat = *(long*)srcData;
@@ -808,7 +809,7 @@ namespace System
                                     *(float*)data = f;
                                     break;
 
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8:
+                                case EETypeElementType.Double:
                                     //*(double*) data = (double) *(Ulong*)srcData;
                                     long srcValToDouble = *(long*)srcData;
                                     double d = (double)srcValToDouble;
@@ -823,10 +824,10 @@ namespace System
                             }
                             break;
 
-                        case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R4:
+                        case EETypeElementType.Single:
                             switch (destElementType)
                             {
-                                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8:
+                                case EETypeElementType.Double:
                                     *(double*)data = *(float*)srcData;
                                     break;
 
@@ -1213,7 +1214,7 @@ namespace System
 
         internal CorElementType GetCorElementTypeOfElementType()
         {
-            return (CorElementType)ElementEEType.CorElementType;
+            return ElementEEType.CorElementType;
         }
 
         internal bool IsValueOfElementType(object o)

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -17,7 +17,9 @@ using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
 using EEType = Internal.Runtime.EEType;
+using EETypeElementType = Internal.Runtime.EETypeElementType;
 using EETypeRef = Internal.Runtime.EETypeRef;
+using CorElementType = System.Reflection.CorElementType;
 
 namespace System
 {
@@ -175,10 +177,7 @@ namespace System
         {
             get
             {
-                RuntimeImports.RhCorElementType et = CorElementType;
-                return ((et >= RuntimeImports.RhCorElementType.ELEMENT_TYPE_BOOLEAN) && (et <= RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8)) ||
-                    (et == RuntimeImports.RhCorElementType.ELEMENT_TYPE_I) ||
-                    (et == RuntimeImports.RhCorElementType.ELEMENT_TYPE_U);
+                return ElementType < EETypeElementType.ValueType;
             }
         }
 
@@ -385,13 +384,46 @@ namespace System
             }
         }
 
-        internal RuntimeImports.RhCorElementType CorElementType
+        internal CorElementType CorElementType
         {
             get
             {
-                Debug.Assert((int)Internal.Runtime.CorElementType.ELEMENT_TYPE_I1 == (int)RuntimeImports.RhCorElementType.ELEMENT_TYPE_I1);
-                Debug.Assert((int)Internal.Runtime.CorElementType.ELEMENT_TYPE_R8 == (int)RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8);
-                return (RuntimeImports.RhCorElementType)_value->CorElementType;
+                Debug.Assert((int)CorElementType.ELEMENT_TYPE_BOOLEAN == (int)EETypeElementType.Boolean);
+                Debug.Assert((int)CorElementType.ELEMENT_TYPE_I1 == (int)EETypeElementType.SByte);
+                Debug.Assert((int)CorElementType.ELEMENT_TYPE_I8 == (int)EETypeElementType.Int64);
+                EETypeElementType elementType = ElementType;
+
+                if (elementType <= EETypeElementType.UInt64)
+                    return (CorElementType)elementType;
+                else if (elementType == EETypeElementType.Single)
+                    return CorElementType.ELEMENT_TYPE_R4;
+                else if (elementType == EETypeElementType.Double)
+                    return CorElementType.ELEMENT_TYPE_R8;
+                else if (elementType == EETypeElementType.IntPtr)
+                    return CorElementType.ELEMENT_TYPE_I;
+                else if (elementType == EETypeElementType.UIntPtr)
+                    return CorElementType.ELEMENT_TYPE_U;
+                else if (IsValueType)
+                    return CorElementType.ELEMENT_TYPE_VALUETYPE;
+                else if (IsByRef)
+                    return CorElementType.ELEMENT_TYPE_BYREF;
+                else if (IsPointer)
+                    return CorElementType.ELEMENT_TYPE_PTR;
+                else if (IsSzArray)
+                    return CorElementType.ELEMENT_TYPE_SZARRAY;
+                else if (IsArray)
+                    return CorElementType.ELEMENT_TYPE_ARRAY;
+                else
+                    return CorElementType.ELEMENT_TYPE_CLASS;
+
+            }
+        }
+
+        internal EETypeElementType ElementType
+        {
+            get
+            {
+                return _value->ElementType;
             }
         }
 
@@ -399,7 +431,7 @@ namespace System
         {
             get
             {
-                RuntimeImports.RhCorElementType corElementType = this.CorElementType;
+                EETypeElementType corElementType = this.ElementType;
                 return RuntimeImports.GetRhCorElementTypeInfo(corElementType);
             }
         }

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -431,8 +431,7 @@ namespace System
         {
             get
             {
-                EETypeElementType corElementType = this.ElementType;
-                return RuntimeImports.GetRhCorElementTypeInfo(corElementType);
+                return RuntimeImports.GetRhCorElementTypeInfo(CorElementType);
             }
         }
 

--- a/src/System.Private.CoreLib/src/System/Enum.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Enum.CoreRT.cs
@@ -9,7 +9,8 @@ using Internal.Runtime.CompilerServices;
 using Internal.Runtime.Augments;
 using Internal.Reflection.Augments;
 
-using CorElementType = System.Runtime.RuntimeImports.RhCorElementType;
+using CorElementType = System.Reflection.CorElementType;
+using EETypeElementType = Internal.Runtime.EETypeElementType;
 
 namespace System
 {
@@ -72,7 +73,10 @@ namespace System
             }
         }
 
-        private CorElementType InternalGetCorElementType() => this.EETypePtr.CorElementType;
+        private CorElementType InternalGetCorElementType()
+        {
+            return this.EETypePtr.CorElementType;
+        }
 
         [Intrinsic]
         public bool HasFlag(Enum flag)
@@ -122,49 +126,49 @@ namespace System
                 result = 0;
                 return false;
             }
-            CorElementType corElementType = eeType.CorElementType;
+            EETypeElementType elementType = eeType.ElementType;
 
             ref byte pValue = ref value.GetRawData();
 
-            switch (corElementType)
+            switch (elementType)
             {
-                case CorElementType.ELEMENT_TYPE_BOOLEAN:
+                case EETypeElementType.Boolean:
                     result = Unsafe.As<byte, bool>(ref pValue) ? 1UL : 0UL;
                     return true;
 
-                case CorElementType.ELEMENT_TYPE_CHAR:
+                case EETypeElementType.Char:
                     result = (ulong)(long)Unsafe.As<byte, char>(ref pValue);
                     return true;
 
-                case CorElementType.ELEMENT_TYPE_I1:
+                case EETypeElementType.SByte:
                     result = (ulong)(long)Unsafe.As<byte, sbyte>(ref pValue);
                     return true;
 
-                case CorElementType.ELEMENT_TYPE_U1:
+                case EETypeElementType.Byte:
                     result = (ulong)(long)Unsafe.As<byte, byte>(ref pValue);
                     return true;
 
-                case CorElementType.ELEMENT_TYPE_I2:
+                case EETypeElementType.Int16:
                     result = (ulong)(long)Unsafe.As<byte, short>(ref pValue);
                     return true;
 
-                case CorElementType.ELEMENT_TYPE_U2:
+                case EETypeElementType.UInt16:
                     result = (ulong)(long)Unsafe.As<byte, ushort>(ref pValue);
                     return true;
 
-                case CorElementType.ELEMENT_TYPE_I4:
+                case EETypeElementType.Int32:
                     result = (ulong)(long)Unsafe.As<byte, int>(ref pValue);
                     return true;
 
-                case CorElementType.ELEMENT_TYPE_U4:
+                case EETypeElementType.UInt32:
                     result = (ulong)(long)Unsafe.As<byte, uint>(ref pValue);
                     return true;
 
-                case CorElementType.ELEMENT_TYPE_I8:
+                case EETypeElementType.Int64:
                     result = (ulong)(long)Unsafe.As<byte, long>(ref pValue);
                     return true;
 
-                case CorElementType.ELEMENT_TYPE_U8:
+                case EETypeElementType.UInt64:
                     result = (ulong)(long)Unsafe.As<byte, ulong>(ref pValue);
                     return true;
 
@@ -325,26 +329,26 @@ namespace System
             // On Debug builds, include the big-endian code to help deter bitrot (the "Conditional("BIGENDIAN")" will prevent it from executing on little-endian). 
             // On Release builds, exclude code to deter IL bloat and toolchain work.
 #if BIGENDIAN || DEBUG
-            CorElementType corElementType = enumEEType.CorElementType;
-            switch (corElementType)
+            EETypeElementType elementType = enumEEType.ElementType;
+            switch (elementType)
             {
-                case CorElementType.ELEMENT_TYPE_I1:
-                case CorElementType.ELEMENT_TYPE_U1:
+                case EETypeElementType.SByte:
+                case EETypeElementType.Byte:
                     pValue += sizeof(long) - sizeof(byte);
                     break;
 
-                case CorElementType.ELEMENT_TYPE_I2:
-                case CorElementType.ELEMENT_TYPE_U2:
+                case EETypeElementType.Int16:
+                case EETypeElementType.UInt16:
                     pValue += sizeof(long) - sizeof(short);
                     break;
 
-                case CorElementType.ELEMENT_TYPE_I4:
-                case CorElementType.ELEMENT_TYPE_U4:
+                case EETypeElementType.Int32:
+                case EETypeElementType.UInt32:
                     pValue += sizeof(long) - sizeof(int);
                     break;
 
-                case CorElementType.ELEMENT_TYPE_I8:
-                case CorElementType.ELEMENT_TYPE_U8:
+                case EETypeElementType.Int64:
+                case EETypeElementType.UInt64:
                     break;
 
                 default:

--- a/src/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -149,67 +149,67 @@ namespace System
                 return CreateChangeTypeException(srcEEType, dstEEType, semantics);
             }
 
-            EETypeElementType dstElementType = dstEEType.ElementType;
-            if (!srcEEType.CorElementTypeInfo.CanWidenTo(dstElementType))
+            CorElementType dstCorElementType = dstEEType.CorElementType;
+            if (!srcEEType.CorElementTypeInfo.CanWidenTo(dstCorElementType))
             {
                 dstObject = null;
                 return CreateChangeTypeArgumentException(srcEEType, dstEEType);
             }
 
-            switch (dstElementType)
+            switch (dstCorElementType)
             {
-                case EETypeElementType.Boolean:
+                case CorElementType.ELEMENT_TYPE_BOOLEAN:
                     bool boolValue = Convert.ToBoolean(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, boolValue ? 1 : 0) : boolValue;
                     break;
 
-                case EETypeElementType.Char:
+                case CorElementType.ELEMENT_TYPE_CHAR:
                     char charValue = Convert.ToChar(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, charValue) : charValue;
                     break;
 
-                case EETypeElementType.SByte:
+                case CorElementType.ELEMENT_TYPE_I1:
                     sbyte sbyteValue = Convert.ToSByte(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, sbyteValue) : sbyteValue;
                     break;
 
-                case EETypeElementType.Int16:
+                case CorElementType.ELEMENT_TYPE_I2:
                     short shortValue = Convert.ToInt16(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, shortValue) : shortValue;
                     break;
 
-                case EETypeElementType.Int32:
+                case CorElementType.ELEMENT_TYPE_I4:
                     int intValue = Convert.ToInt32(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, intValue) : intValue;
                     break;
 
-                case EETypeElementType.Int64:
+                case CorElementType.ELEMENT_TYPE_I8:
                     long longValue = Convert.ToInt64(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, longValue) : longValue;
                     break;
 
-                case EETypeElementType.Byte:
+                case CorElementType.ELEMENT_TYPE_U1:
                     byte byteValue = Convert.ToByte(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, byteValue) : byteValue;
                     break;
 
-                case EETypeElementType.UInt16:
+                case CorElementType.ELEMENT_TYPE_U2:
                     ushort ushortValue = Convert.ToUInt16(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, ushortValue) : ushortValue;
                     break;
 
-                case EETypeElementType.UInt32:
+                case CorElementType.ELEMENT_TYPE_U4:
                     uint uintValue = Convert.ToUInt32(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, uintValue) : uintValue;
                     break;
 
-                case EETypeElementType.UInt64:
+                case CorElementType.ELEMENT_TYPE_U8:
                     ulong ulongValue = Convert.ToUInt64(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, (long)ulongValue) : ulongValue;
                     break;
 
-                case EETypeElementType.Single:
-                    if (srcEEType.ElementType == EETypeElementType.Char)
+                case CorElementType.ELEMENT_TYPE_R4:
+                    if (srcEEType.CorElementType == CorElementType.ELEMENT_TYPE_CHAR)
                     {
                         dstObject = (float)(char)srcObject;
                     }
@@ -219,8 +219,8 @@ namespace System
                     }
                     break;
 
-                case EETypeElementType.Double:
-                    if (srcEEType.ElementType == EETypeElementType.Char)
+                case CorElementType.ELEMENT_TYPE_R8:
+                    if (srcEEType.CorElementType == CorElementType.ELEMENT_TYPE_CHAR)
                     {
                         dstObject = (double)(char)srcObject;
                     }
@@ -231,7 +231,7 @@ namespace System
                     break;
 
                 default:
-                    Debug.Fail("Unexpected ElementType: " + dstElementType + ": Not a valid widening target.");
+                    Debug.Fail("Unexpected CorElementType: " + dstCorElementType + ": Not a valid widening target.");
                     dstObject = null;
                     return CreateChangeTypeException(srcEEType, dstEEType, semantics);
             }

--- a/src/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -12,6 +12,7 @@ using Internal.Reflection.Core.NonPortable;
 using Internal.Runtime.Augments;
 using Internal.Runtime.CompilerServices;
 
+using EETypeElementType = Internal.Runtime.EETypeElementType;
 using Interlocked = System.Threading.Interlocked;
 
 namespace System
@@ -148,67 +149,67 @@ namespace System
                 return CreateChangeTypeException(srcEEType, dstEEType, semantics);
             }
 
-            RuntimeImports.RhCorElementType dstCorElementType = dstEEType.CorElementType;
-            if (!srcEEType.CorElementTypeInfo.CanWidenTo(dstCorElementType))
+            EETypeElementType dstElementType = dstEEType.ElementType;
+            if (!srcEEType.CorElementTypeInfo.CanWidenTo(dstElementType))
             {
                 dstObject = null;
                 return CreateChangeTypeArgumentException(srcEEType, dstEEType);
             }
 
-            switch (dstCorElementType)
+            switch (dstElementType)
             {
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_BOOLEAN:
+                case EETypeElementType.Boolean:
                     bool boolValue = Convert.ToBoolean(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, boolValue ? 1 : 0) : boolValue;
                     break;
 
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_CHAR:
+                case EETypeElementType.Char:
                     char charValue = Convert.ToChar(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, charValue) : charValue;
                     break;
 
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I1:
+                case EETypeElementType.SByte:
                     sbyte sbyteValue = Convert.ToSByte(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, sbyteValue) : sbyteValue;
                     break;
 
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I2:
+                case EETypeElementType.Int16:
                     short shortValue = Convert.ToInt16(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, shortValue) : shortValue;
                     break;
 
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I4:
+                case EETypeElementType.Int32:
                     int intValue = Convert.ToInt32(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, intValue) : intValue;
                     break;
 
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_I8:
+                case EETypeElementType.Int64:
                     long longValue = Convert.ToInt64(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, longValue) : longValue;
                     break;
 
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U1:
+                case EETypeElementType.Byte:
                     byte byteValue = Convert.ToByte(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, byteValue) : byteValue;
                     break;
 
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U2:
+                case EETypeElementType.UInt16:
                     ushort ushortValue = Convert.ToUInt16(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, ushortValue) : ushortValue;
                     break;
 
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U4:
+                case EETypeElementType.UInt32:
                     uint uintValue = Convert.ToUInt32(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, uintValue) : uintValue;
                     break;
 
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_U8:
+                case EETypeElementType.UInt64:
                     ulong ulongValue = Convert.ToUInt64(srcObject);
                     dstObject = dstEEType.IsEnum ? Enum.ToObject(dstEEType, (long)ulongValue) : ulongValue;
                     break;
 
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R4:
-                    if (srcEEType.CorElementType == RuntimeImports.RhCorElementType.ELEMENT_TYPE_CHAR)
+                case EETypeElementType.Single:
+                    if (srcEEType.ElementType == EETypeElementType.Char)
                     {
                         dstObject = (float)(char)srcObject;
                     }
@@ -218,8 +219,8 @@ namespace System
                     }
                     break;
 
-                case RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8:
-                    if (srcEEType.CorElementType == RuntimeImports.RhCorElementType.ELEMENT_TYPE_CHAR)
+                case EETypeElementType.Double:
+                    if (srcEEType.ElementType == EETypeElementType.Char)
                     {
                         dstObject = (double)(char)srcObject;
                     }
@@ -230,7 +231,7 @@ namespace System
                     break;
 
                 default:
-                    Debug.Fail("Unexpected CorElementType: " + dstCorElementType + ": Not a valid widening target.");
+                    Debug.Fail("Unexpected ElementType: " + dstElementType + ": Not a valid widening target.");
                     dstObject = null;
                     return CreateChangeTypeException(srcEEType, dstEEType, semantics);
             }
@@ -792,7 +793,7 @@ namespace System
                     }
                     else
                     {
-                        if (widenAndCompareType.ToEETypePtr().CorElementType != incomingParam.EETypePtr.CorElementType)
+                        if (widenAndCompareType.ToEETypePtr().ElementType != incomingParam.EETypePtr.ElementType)
                         {
                             System.Diagnostics.Debug.Assert(paramType == DynamicInvokeParamType.In);
                             incomingParam = InvokeUtils.CheckArgument(incomingParam, widenAndCompareType.ToEETypePtr(), InvokeUtils.CheckArgumentSemantics.DynamicInvoke, s_binderBundle, s_getExactTypeForCustomBinder);

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -10,6 +10,8 @@ using System.Runtime.CompilerServices;
 using Internal.Runtime;
 using Internal.Runtime.CompilerServices;
 
+using CorElementType = System.Reflection.CorElementType;
+
 #if TARGET_64BIT
 using nuint = System.UInt64;
 #else
@@ -1083,28 +1085,7 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhpArrayClear")]
         internal static extern bool TryArrayClear(Array array, int index, int length);
 
-        // Only the values defined below are valid. Any other value returned from RhGetCorElementType
-        // indicates only that the type is not one of the primitives defined below and is otherwise undefined
-        // and subject to change.
-        internal enum RhCorElementType : byte
-        {
-            ELEMENT_TYPE_BOOLEAN = 0x2,
-            ELEMENT_TYPE_CHAR = 0x3,
-            ELEMENT_TYPE_I1 = 0x4,
-            ELEMENT_TYPE_U1 = 0x5,
-            ELEMENT_TYPE_I2 = 0x6,
-            ELEMENT_TYPE_U2 = 0x7,
-            ELEMENT_TYPE_I4 = 0x8,
-            ELEMENT_TYPE_U4 = 0x9,
-            ELEMENT_TYPE_I8 = 0xa,
-            ELEMENT_TYPE_U8 = 0xb,
-            ELEMENT_TYPE_R4 = 0xc,
-            ELEMENT_TYPE_R8 = 0xd,
-            ELEMENT_TYPE_I = 0x18,
-            ELEMENT_TYPE_U = 0x19,
-        }
-
-        internal static RhCorElementTypeInfo GetRhCorElementTypeInfo(RuntimeImports.RhCorElementType elementType)
+        internal static RhCorElementTypeInfo GetRhCorElementTypeInfo(CorElementType elementType)
         {
             return RhCorElementTypeInfo.GetRhCorElementTypeInfo(elementType);
         }
@@ -1149,14 +1130,14 @@ namespace System.Runtime
             // This is a port of InvokeUtil::CanPrimitiveWiden() in the desktop runtime. This is used by various apis such as Array.SetValue()
             // and Delegate.DynamicInvoke() which allow value-preserving widenings from one primitive type to another.
             //
-            public bool CanWidenTo(RuntimeImports.RhCorElementType targetElementType)
+            public bool CanWidenTo(CorElementType targetElementType)
             {
                 // Caller expected to ensure that both sides are primitive before calling us.
                 Debug.Assert(this.IsPrimitive);
                 Debug.Assert(GetRhCorElementTypeInfo(targetElementType).IsPrimitive);
 
                 // Once we've asserted that the target is a primitive, we can also assert that it is >= ET_BOOLEAN.
-                Debug.Assert(targetElementType >= RuntimeImports.RhCorElementType.ELEMENT_TYPE_BOOLEAN);
+                Debug.Assert(targetElementType >= CorElementType.ELEMENT_TYPE_BOOLEAN);
                 byte targetElementTypeAsByte = (byte)targetElementType;
                 ushort mask = (ushort)(1 << targetElementTypeAsByte);  // This is expected to overflow on larger ET_I and ET_U - this is ok and anticipated.
                 if (0 != (_widenMask & mask))
@@ -1164,7 +1145,7 @@ namespace System.Runtime
                 return false;
             }
 
-            internal static RhCorElementTypeInfo GetRhCorElementTypeInfo(RuntimeImports.RhCorElementType elementType)
+            internal static RhCorElementTypeInfo GetRhCorElementTypeInfo(CorElementType elementType)
             {
                 // The _lookupTable array only covers a subset of RhCorElementTypes, so we return a default 
                 // info when someone asks for an elementType which does not have an entry in the table.

--- a/src/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/System.Private.CoreLib/src/System/ValueType.cs
@@ -155,11 +155,11 @@ namespace System
 
                 Debug.Assert(!fieldType.IsPointer);
 
-                if (fieldType.CorElementType == RuntimeImports.RhCorElementType.ELEMENT_TYPE_R4)
+                if (fieldType.ElementType == Internal.Runtime.EETypeElementType.Single)
                 {
                     hashCode = Unsafe.Read<float>(ref fieldData).GetHashCode();
                 }
-                else if (fieldType.CorElementType == RuntimeImports.RhCorElementType.ELEMENT_TYPE_R8)
+                else if (fieldType.ElementType == Internal.Runtime.EETypeElementType.Double)
                 {
                     hashCode = Unsafe.Read<double>(ref fieldData).GetHashCode();
                 }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallingConventions.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/CallingConventions.cs
@@ -163,13 +163,30 @@ namespace Internal.Runtime.CallConverter
 
             // The core redhawk runtime has a slightly different concept of what CorElementType should be for a type. It matches for primitive and enum types
             // but for other types, it doesn't match the needs in this file.
-            CorElementType rhCorElementType = _eeType->CorElementType;
+            EETypeElementType rhCorElementType = _eeType->ElementType;
 
-            if (((rhCorElementType >= CorElementType.ELEMENT_TYPE_BOOLEAN) && (rhCorElementType <= CorElementType.ELEMENT_TYPE_R8)) ||
-                    (rhCorElementType == CorElementType.ELEMENT_TYPE_I) ||
-                    (rhCorElementType == CorElementType.ELEMENT_TYPE_U))
+            if (rhCorElementType >= EETypeElementType.Boolean && rhCorElementType <= EETypeElementType.UInt64)
             {
-                return rhCorElementType; // If Redhawk thinks the corelementtype is a primitive type, then it agree with the concept of corelement type needed in this codebase.
+                Debug.Assert((int)EETypeElementType.Boolean == (int)CorElementType.ELEMENT_TYPE_BOOLEAN);
+                Debug.Assert((int)EETypeElementType.Int32 == (int)CorElementType.ELEMENT_TYPE_I4);
+                Debug.Assert((int)EETypeElementType.UInt64 == (int)CorElementType.ELEMENT_TYPE_U8);
+                return (CorElementType)rhCorElementType;
+            }
+            else if (rhCorElementType == EETypeElementType.Single)
+            {
+                return CorElementType.ELEMENT_TYPE_R4;
+            }
+            else if (rhCorElementType == EETypeElementType.Double)
+            {
+                return CorElementType.ELEMENT_TYPE_R8;
+            }
+            else if (rhCorElementType == EETypeElementType.IntPtr)
+            {
+                return CorElementType.ELEMENT_TYPE_I;
+            }
+            else if (rhCorElementType == EETypeElementType.UIntPtr)
+            {
+                return CorElementType.ELEMENT_TYPE_U;
             }
             else if (_eeType == typeof(void).TypeHandle.ToEETypePtr())
             {
@@ -1802,5 +1819,38 @@ namespace Internal.Runtime.CallConverter
             return false;
 #endif
         }
-    };
+    }
+
+    internal enum CorElementType
+    {
+        ELEMENT_TYPE_END = 0x00,
+
+        ELEMENT_TYPE_VOID = 0x1,
+        ELEMENT_TYPE_BOOLEAN = 0x2,
+        ELEMENT_TYPE_CHAR = 0x3,
+        ELEMENT_TYPE_I1 = 0x4,
+        ELEMENT_TYPE_U1 = 0x5,
+        ELEMENT_TYPE_I2 = 0x6,
+        ELEMENT_TYPE_U2 = 0x7,
+        ELEMENT_TYPE_I4 = 0x8,
+        ELEMENT_TYPE_U4 = 0x9,
+        ELEMENT_TYPE_I8 = 0xa,
+        ELEMENT_TYPE_U8 = 0xb,
+        ELEMENT_TYPE_R4 = 0xc,
+        ELEMENT_TYPE_R8 = 0xd,
+        ELEMENT_TYPE_STRING = 0xe,
+        ELEMENT_TYPE_PTR = 0xf,
+        ELEMENT_TYPE_BYREF = 0x10,
+        ELEMENT_TYPE_VALUETYPE = 0x11,
+        ELEMENT_TYPE_CLASS = 0x12,
+
+        ELEMENT_TYPE_ARRAY = 0x14,
+
+        ELEMENT_TYPE_TYPEDBYREF = 0x16,
+        ELEMENT_TYPE_I = 0x18,
+        ELEMENT_TYPE_U = 0x19,
+        ELEMENT_TYPE_FNPTR = 0x1b,
+        ELEMENT_TYPE_OBJECT = 0x1c,
+        ELEMENT_TYPE_SZARRAY = 0x1d,
+    }
 }

--- a/src/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
+++ b/src/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
@@ -102,60 +102,6 @@ namespace Internal.TypeSystem
         internal static RuntimeTypeHandleToParameterTypeRuntimeTypeHandleHashtable ByRefTypesCache { get; } =
             new RuntimeTypeHandleToParameterTypeRuntimeTypeHandleHashtable();
 
-        internal TypeDesc GetTypeFromCorElementType(CorElementType corElementType)
-        {
-            switch (corElementType)
-            {
-                case CorElementType.ELEMENT_TYPE_I1:
-                    return GetWellKnownType(WellKnownType.SByte);
-
-                case CorElementType.ELEMENT_TYPE_U1:
-                    return GetWellKnownType(WellKnownType.Byte);
-
-                case CorElementType.ELEMENT_TYPE_I2:
-                    return GetWellKnownType(WellKnownType.Int16);
-
-                case CorElementType.ELEMENT_TYPE_U2:
-                    return GetWellKnownType(WellKnownType.UInt16);
-
-                case CorElementType.ELEMENT_TYPE_I4:
-                    return GetWellKnownType(WellKnownType.Int32);
-
-                case CorElementType.ELEMENT_TYPE_U4:
-                    return GetWellKnownType(WellKnownType.UInt32);
-
-                case CorElementType.ELEMENT_TYPE_I8:
-                    return GetWellKnownType(WellKnownType.Int64);
-
-                case CorElementType.ELEMENT_TYPE_U8:
-                    return GetWellKnownType(WellKnownType.UInt64);
-
-                case CorElementType.ELEMENT_TYPE_CHAR:
-                    return GetWellKnownType(WellKnownType.Char);
-
-                case CorElementType.ELEMENT_TYPE_BOOLEAN:
-                    return GetWellKnownType(WellKnownType.Boolean);
-
-                case CorElementType.ELEMENT_TYPE_VOID:
-                    return GetWellKnownType(WellKnownType.Void);
-
-                case CorElementType.ELEMENT_TYPE_STRING:
-                    return GetWellKnownType(WellKnownType.String);
-
-                case CorElementType.ELEMENT_TYPE_I:
-                    return GetWellKnownType(WellKnownType.IntPtr);
-
-                case CorElementType.ELEMENT_TYPE_U:
-                    return GetWellKnownType(WellKnownType.UIntPtr);
-
-                case CorElementType.ELEMENT_TYPE_OBJECT:
-                    return GetWellKnownType(WellKnownType.Object);
-
-                default:
-                    throw new BadImageFormatException();
-            }
-        }
-
         public Instantiation ResolveRuntimeTypeHandles(RuntimeTypeHandle[] runtimeTypeHandles)
         {
             TypeDesc[] TypeDescs = new TypeDesc[runtimeTypeHandles.Length];


### PR DESCRIPTION
Fixes #478.

It doesn't fully reap the benefits yet (we can e.g. delete the IsInterface and IsValueType bits). I'm going to work on those later. This is already too big and too scary.