### PR TITLE
Wasm: Change condition around to switch on OSEnvironment == Windows_NT to fix `build wasm`

### DIFF
--- a/src/ILCompiler/RyuJIT/RyuJIT.depproj
+++ b/src/ILCompiler/RyuJIT/RyuJIT.depproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FileToInclude Include="clrjit" Condition="'$(TargetsUnix)' != 'true'" />
-    <FileToInclude Include="libclrjit" Condition="'$(TargetsUnix)' == 'true'" />
+    <FileToInclude Include="clrjit" Condition="'$(OSEnvironment)' == 'Windows_NT'" />
+    <FileToInclude Include="libclrjit" Condition="'$(OSEnvironment)' != 'Windows_NT'" />
   </ItemGroup>
 
   <Target Name="RenameToJitIlc">


### PR DESCRIPTION
`build wasm` was failing, this change in the windows/unix switch allows wasm to pick up the windows file.