### PR TITLE
Support Assembly.Location / CodeBase for ECMA Assemblies

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -129,6 +129,7 @@ namespace Internal.Reflection.Augments
     {
         public abstract Assembly Load(AssemblyName refName, bool throwOnFileNotFound);
         public abstract Assembly Load(byte[] rawAssembly, byte[] pdbSymbolStore);
+        public abstract Assembly Load(string assemblyPath);
 
         public abstract MethodBase GetMethodFromHandle(RuntimeMethodHandle runtimeMethodHandle);
         public abstract MethodBase GetMethodFromHandle(RuntimeMethodHandle runtimeMethodHandle, RuntimeTypeHandle declaringTypeHandle);

--- a/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreRT.cs
@@ -43,7 +43,9 @@ namespace System.Runtime.Loader
 
         private Assembly InternalLoadFromPath(string? assemblyPath, string? nativeImagePath)
         {
-            throw new PlatformNotSupportedException();
+            // TODO: This is not passing down the AssemblyLoadContext,
+            // so it won't actually work properly when multiple assemblies with the same identity get loaded.
+            return ReflectionAugments.ReflectionCoreCallbacks.Load(assemblyPath);
         }
 
         internal Assembly InternalLoad(byte[] arrAssembly, byte[] arrSymbols)

--- a/src/System.Private.DisabledReflection/src/Internal/Reflection/ReflectionCoreCallbacksImplementation.cs
+++ b/src/System.Private.DisabledReflection/src/Internal/Reflection/ReflectionCoreCallbacksImplementation.cs
@@ -40,6 +40,7 @@ namespace Internal.Reflection
         public override Type GetTypeFromCLSID(Guid clsid, string server, bool throwOnError) => throw new NotSupportedException(SR.Reflection_Disabled);
         public override Assembly Load(AssemblyName refName, bool throwOnFileNotFound) => throw new NotSupportedException(SR.Reflection_Disabled);
         public override Assembly Load(byte[] rawAssembly, byte[] pdbSymbolStore) => throw new NotSupportedException(SR.Reflection_Disabled);
+        public override Assembly Load(string assemblyPath) => throw new NotSupportedException(SR.Reflection_Disabled);
         public override void MakeTypedReference(object target, FieldInfo[] flds, out Type type, out int offset) => throw new NotSupportedException(SR.Reflection_Disabled);
         public override void RunModuleConstructor(Module module) => throw new NotSupportedException(SR.Reflection_Disabled);
     }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.Ecma.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.Ecma.cs
@@ -33,10 +33,10 @@ namespace System.Reflection.Runtime.Assemblies
     //-----------------------------------------------------------------------------------------------------------
     internal partial class RuntimeAssembly
     {
-        static partial void GetEcmaRuntimeAssembly(AssemblyBindResult bindResult, ref RuntimeAssembly runtimeAssembly)
+        static partial void GetEcmaRuntimeAssembly(AssemblyBindResult bindResult, string assemblyPath, ref RuntimeAssembly runtimeAssembly)
         {
             if (bindResult.EcmaMetadataReader != null)
-                runtimeAssembly = EcmaFormatRuntimeAssembly.GetRuntimeAssembly(bindResult.EcmaMetadataReader);
+                runtimeAssembly = EcmaFormatRuntimeAssembly.GetRuntimeAssembly(bindResult.EcmaMetadataReader, assemblyPath);
         }
     }
 }
@@ -45,9 +45,9 @@ namespace System.Reflection.Runtime.Assemblies.EcmaFormat
 {
     internal sealed partial class EcmaFormatRuntimeAssembly
     {
-        internal static RuntimeAssembly GetRuntimeAssembly(MetadataReader ecmaMetadataReader)
+        internal static RuntimeAssembly GetRuntimeAssembly(MetadataReader ecmaMetadataReader, string assemblyPath = null)
         {
-            return s_EcmaAssemblyDispenser.GetOrAdd(new EcmaRuntimeAssemblyKey(ecmaMetadataReader));
+            return s_EcmaAssemblyDispenser.GetOrAdd(new EcmaRuntimeAssemblyKey(ecmaMetadataReader, assemblyPath));
         }
 
         private static readonly Dispenser<EcmaRuntimeAssemblyKey, RuntimeAssembly> s_EcmaAssemblyDispenser =
@@ -55,15 +55,16 @@ namespace System.Reflection.Runtime.Assemblies.EcmaFormat
                 DispenserScenario.Scope_Assembly,
                 delegate (EcmaRuntimeAssemblyKey assemblyDefinition)
                 {
-                    return (RuntimeAssembly)new EcmaFormatRuntimeAssembly(assemblyDefinition.Reader);
+                    return (RuntimeAssembly)new EcmaFormatRuntimeAssembly(assemblyDefinition.Reader, assemblyDefinition.AssemblyPath);
                 }
         );
 
         private struct EcmaRuntimeAssemblyKey : IEquatable<EcmaRuntimeAssemblyKey>
         {
-            public EcmaRuntimeAssemblyKey(MetadataReader reader)
+            public EcmaRuntimeAssemblyKey(MetadataReader reader, string assemblyPath)
             {
                 Reader = reader;
+                AssemblyPath = assemblyPath;
             }
 
             public override bool Equals(Object obj)
@@ -86,6 +87,7 @@ namespace System.Reflection.Runtime.Assemblies.EcmaFormat
             }
 
             public MetadataReader Reader { get; }
+            public string AssemblyPath { get; }
         }
     }
 }

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Dispensers.cs
@@ -14,7 +14,6 @@ using System.Reflection.Runtime.PropertyInfos;
 using Internal.Reflection.Core;
 using Internal.Reflection.Core.Execution;
 
-
 //=================================================================================================================
 // This file collects the various chokepoints that create the various Runtime*Info objects. This allows
 // easy reviewing of the overall caching and unification policy.
@@ -35,8 +34,7 @@ namespace System.Reflection.Runtime.Assemblies
         /// </summary>
         internal static RuntimeAssembly GetRuntimeAssembly(RuntimeAssemblyName assemblyRefName)
         {
-            RuntimeAssembly result;
-            Exception assemblyLoadException = TryGetRuntimeAssembly(assemblyRefName, out result);
+            Exception assemblyLoadException = TryGetRuntimeAssembly(assemblyRefName, out RuntimeAssembly result);
             if (assemblyLoadException != null)
                 throw assemblyLoadException;
             return result;
@@ -48,9 +46,7 @@ namespace System.Reflection.Runtime.Assemblies
         internal static RuntimeAssembly GetRuntimeAssemblyFromByteArray(byte[] rawAssembly, byte[] pdbSymbolStore)
         {
             AssemblyBinder binder = ReflectionCoreExecution.ExecutionDomain.ReflectionDomainSetup.AssemblyBinder;
-            AssemblyBindResult bindResult;
-            Exception exception;
-            if (!binder.Bind(rawAssembly, pdbSymbolStore, out bindResult, out exception))
+            if (!binder.Bind(rawAssembly, pdbSymbolStore, out AssemblyBindResult bindResult, out Exception exception))
             {
                 if (exception != null)
                     throw exception;
@@ -59,6 +55,24 @@ namespace System.Reflection.Runtime.Assemblies
             }
 
             RuntimeAssembly result = GetRuntimeAssembly(bindResult);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns non-null or throws.
+        /// </summary>
+        internal static RuntimeAssembly GetRuntimeAssemblyFromPath(string assemblyPath)
+        {
+            AssemblyBinder binder = ReflectionCoreExecution.ExecutionDomain.ReflectionDomainSetup.AssemblyBinder;
+            if (!binder.Bind(assemblyPath, out AssemblyBindResult bindResult, out Exception exception))
+            {
+                if (exception != null)
+                    throw exception;
+                else
+                    throw new BadImageFormatException();
+            }
+
+            RuntimeAssembly result = GetRuntimeAssembly(bindResult, assemblyPath);
             return result;
         }
 
@@ -95,16 +109,14 @@ namespace System.Reflection.Runtime.Assemblies
                 delegate (RuntimeAssemblyName assemblyRefName)
                 {
                     AssemblyBinder binder = ReflectionCoreExecution.ExecutionDomain.ReflectionDomainSetup.AssemblyBinder;
-                    AssemblyBindResult bindResult;
-                    Exception exception;
-                    if (!binder.Bind(assemblyRefName, cacheMissedLookups: true, out bindResult, out exception))
+                    if (!binder.Bind(assemblyRefName, cacheMissedLookups: true, out AssemblyBindResult bindResult, out Exception exception))
                         return exception;
 
                     return GetRuntimeAssembly(bindResult);
                 }
         );
 
-        private static RuntimeAssembly GetRuntimeAssembly(AssemblyBindResult bindResult)
+        private static RuntimeAssembly GetRuntimeAssembly(AssemblyBindResult bindResult, string assemblyPath = null)
         {
             RuntimeAssembly result = null;
 
@@ -112,7 +124,7 @@ namespace System.Reflection.Runtime.Assemblies
             if (result != null)
                 return result;
 
-            GetEcmaRuntimeAssembly(bindResult, ref result);
+            GetEcmaRuntimeAssembly(bindResult, assemblyPath, ref result);
             if (result != null)
                 return result;
 
@@ -121,7 +133,7 @@ namespace System.Reflection.Runtime.Assemblies
 
         // Use C# partial method feature to avoid complex #if logic, whichever code files are included will drive behavior
         static partial void GetNativeFormatRuntimeAssembly(AssemblyBindResult bindResult, ref RuntimeAssembly runtimeAssembly);
-        static partial void GetEcmaRuntimeAssembly(AssemblyBindResult bindResult, ref RuntimeAssembly runtimeAssembly);
+        static partial void GetEcmaRuntimeAssembly(AssemblyBindResult bindResult, string assemblyPath, ref RuntimeAssembly runtimeAssembly);
     }
 }
 

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ReflectionCoreCallbacksImplementation.cs
@@ -48,6 +48,14 @@ namespace System.Reflection.Runtime.General
             return RuntimeAssembly.GetRuntimeAssemblyFromByteArray(rawAssembly, pdbSymbolStore);
         }
 
+        public sealed override Assembly Load(string assemblyPath)
+        {
+            if (assemblyPath == null)
+                throw new ArgumentNullException(nameof(assemblyPath));
+
+            return RuntimeAssembly.GetRuntimeAssemblyFromPath(assemblyPath);
+        }
+
         //
         // This overload of GetMethodForHandle only accepts handles for methods declared on non-generic types (the method, however,
         // can be an instance of a generic method.) To resolve handles for methods declared on generic types, you must pass

--- a/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ThunkedApis.cs
+++ b/src/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/ThunkedApis.cs
@@ -58,7 +58,7 @@ namespace System.Reflection.Runtime.Assemblies
             return GetManifestResourceStream(sb.ToString());
         }
 
-        public sealed override string Location
+        public override string Location
         {
             get
             {
@@ -69,7 +69,24 @@ namespace System.Reflection.Runtime.Assemblies
             }
         }
 
-        public sealed override string CodeBase { get { throw new PlatformNotSupportedException(); } }
+        public sealed override string CodeBase
+        {
+            get
+            {
+                var assemblyPath = Location;
+                if (string.IsNullOrEmpty(assemblyPath))
+                {
+                    assemblyPath = Path.Combine(AppContext.BaseDirectory, typeof(object).Assembly.ManifestModule.Name);
+                }
+                assemblyPath = assemblyPath.Replace('\\', '/');
+                if (assemblyPath.StartsWith('/'))
+                {
+                    return "file://" + assemblyPath;
+                }
+                return "file:///" + assemblyPath;
+            }
+        }
+
         public sealed override Assembly GetSatelliteAssembly(CultureInfo culture) { throw new PlatformNotSupportedException(); }
         public sealed override Assembly GetSatelliteAssembly(CultureInfo culture, Version version) { throw new PlatformNotSupportedException(); }
         public sealed override AssemblyName[] GetReferencedAssemblies() { throw new PlatformNotSupportedException(); }
@@ -94,7 +111,7 @@ namespace System.Reflection.Runtime.EventInfos
 {
     internal abstract partial class RuntimeEventInfo
     {
-        public sealed override MethodInfo GetAddMethod(bool nonPublic) =>  AddMethod.FilterAccessor(nonPublic);
+        public sealed override MethodInfo GetAddMethod(bool nonPublic) => AddMethod.FilterAccessor(nonPublic);
         public sealed override MethodInfo GetRemoveMethod(bool nonPublic) => RemoveMethod.FilterAccessor(nonPublic);
         public sealed override MethodInfo GetRaiseMethod(bool nonPublic) => RaiseMethod?.FilterAccessor(nonPublic);
     }
@@ -106,7 +123,7 @@ namespace System.Reflection.Runtime.MethodInfos
     {
         public sealed override MethodImplAttributes GetMethodImplementationFlags() => MethodImplementationFlags;
         public sealed override ICustomAttributeProvider ReturnTypeCustomAttributes => ReturnParameter;
-        
+
         // Partial trust doesn't exist in Aot so these legacy apis are meaningless. Will report everything as SecurityCritical by fiat.
         public sealed override bool IsSecurityCritical => true;
         public sealed override bool IsSecuritySafeCritical => false;

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
@@ -34,6 +34,8 @@ namespace Internal.Reflection.Core
 
         public abstract bool Bind(byte[] rawAssembly, byte[] rawSymbolStore, out AssemblyBindResult result, out Exception exception);
 
+        public abstract bool Bind(string assemblyPath, out AssemblyBindResult bindResult, out Exception exception);
+
         public abstract IList<AssemblyBindResult> GetLoadedAssemblies();
     }
 }

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.Ecma.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.Ecma.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+#nullable enable
 
 using System;
 using System.Reflection;
@@ -18,6 +19,8 @@ using System.Reflection.PortableExecutable;
 using System.Reflection.Metadata;
 using System.Collections.Immutable;
 
+using System.IO.MemoryMappedFiles;
+
 namespace Internal.Reflection.Execution
 {
     //=============================================================================================================================
@@ -32,33 +35,49 @@ namespace Internal.Reflection.Execution
         /// Abstraction to hold PE data for an ECMA module
         private class PEInfo
         {
-            public PEInfo(RuntimeAssemblyName name, MetadataReader reader, PEReader pe)
+            public PEInfo(RuntimeAssemblyName name, MetadataReader? reader, PEReader? pe, MemoryMappedViewAccessor? memoryMappedView = null)
             {
                 Name = name;
                 Reader = reader;
                 PE = pe;
+                MemoryMappedView = memoryMappedView;
             }
 
             public readonly RuntimeAssemblyName Name;
-            public readonly MetadataReader Reader;
-            public readonly PEReader PE;
+            public readonly MetadataReader? Reader;
+            public readonly PEReader? PE;
+            public readonly MemoryMappedViewAccessor? MemoryMappedView;
         }
 
         private static LowLevelList<PEInfo> s_ecmaLoadedAssemblies = new LowLevelList<PEInfo>();
 
-        partial void BindEcmaByteArray(byte[] rawAssembly, byte[] rawSymbolStore, ref AssemblyBindResult bindResult, ref Exception exception, ref bool? result)
+        partial void BindEcmaByteArray(byte[] rawAssembly, byte[]? rawSymbolStore, ref AssemblyBindResult bindResult, ref Exception? exception, ref bool? result)
         {
-            // 1. Load byte[] into immutable array for use by PEReader/MetadataReader
+            // Load byte[] into immutable array for use by PEReader/MetadataReader
             ImmutableArray<byte> assemblyData = ImmutableArray.Create(rawAssembly);
             PEReader pe = new PEReader(assemblyData);
+
+            BindEcma(pe, null, out bindResult, out exception, out result);
+        }
+
+        partial void BindEcmaFilePath(string assemblyPath, ref AssemblyBindResult bindResult, ref Exception? exception, ref bool? result)
+        {
+            // Get a PEReader over a MemoryMappedView of the PE file
+            PEReader pe = OpenPEFile(assemblyPath, out var memoryMappedView);
+
+            BindEcma(pe, memoryMappedView, out bindResult, out exception, out result);
+        }
+
+        private void BindEcma(PEReader pe, MemoryMappedViewAccessor? memoryMappedView, out AssemblyBindResult bindResult, out Exception? exception, out bool? result)
+        {
             MetadataReader reader = pe.GetMetadataReader();
 
-            // 2. Create AssemblyName from MetadataReader
+            // 1. Create AssemblyName from MetadataReader
             RuntimeAssemblyName runtimeAssemblyName = reader.GetAssemblyDefinition().ToRuntimeAssemblyName(reader);
 
-            lock(s_ecmaLoadedAssemblies)
+            lock (s_ecmaLoadedAssemblies)
             {
-                // 3. Attempt to bind to already loaded assembly
+                // 2. Attempt to bind to already loaded assembly
                 if (Bind(runtimeAssemblyName, cacheMissedLookups: false, out bindResult, out exception))
                 {
                     result = true;
@@ -66,15 +85,15 @@ namespace Internal.Reflection.Execution
                 }
                 exception = null;
 
-                // 4. If that fails, then add newly created metareader to global cache of byte array loaded modules
-                PEInfo peinfo = new PEInfo(runtimeAssemblyName, reader, pe);
+                // 3. If that fails, then add newly created metareader to global cache of loaded modules
+                PEInfo peinfo = new PEInfo(runtimeAssemblyName, reader, pe, memoryMappedView);
 
                 s_ecmaLoadedAssemblies.Add(peinfo);
                 ModuleList moduleList = ModuleList.Instance;
                 ModuleInfo newModuleInfo = new EcmaModuleInfo(moduleList.SystemModule.Handle, pe, reader);
                 moduleList.RegisterModule(newModuleInfo);
 
-                // 5. Then try to load by name again. This load should always succeed
+                // 4. Then try to load by name again. This load should always succeed
                 if (Bind(runtimeAssemblyName, cacheMissedLookups: true, out bindResult, out exception))
                 {
                     result = true;
@@ -86,9 +105,47 @@ namespace Internal.Reflection.Execution
             }
         }
 
+        public static unsafe PEReader OpenPEFile(string filePath, out MemoryMappedViewAccessor mappedViewAccessor)
+        {
+            // System.Reflection.Metadata has heuristic that tries to save virtual address space. This heuristic does not work
+            // well for us since it can make IL access very slow (call to OS for each method IL query). We will map the file
+            // ourselves to get the desired performance characteristics reliably.
+
+            FileStream? fileStream = null;
+            MemoryMappedFile? mappedFile = null;
+            MemoryMappedViewAccessor? accessor = null;
+            try
+            {
+                // Create stream because CreateFromFile(string, ...) uses FileShare.None which is too strict
+                fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, false);
+                mappedFile = MemoryMappedFile.CreateFromFile(
+                    fileStream, null, fileStream.Length, MemoryMappedFileAccess.Read, HandleInheritability.None, true);
+                accessor = mappedFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+
+                var safeBuffer = accessor.SafeMemoryMappedViewHandle;
+                var peReader = new PEReader((byte*)safeBuffer.DangerousGetHandle(), (int)safeBuffer.ByteLength);
+
+                // MemoryMappedFile does not need to be kept around. MemoryMappedViewAccessor is enough.
+
+                mappedViewAccessor = accessor;
+                accessor = null;
+
+                return peReader;
+            }
+            finally
+            {
+                if (accessor != null)
+                    accessor.Dispose();
+                if (mappedFile != null)
+                    mappedFile.Dispose();
+                if (fileStream != null)
+                    fileStream.Dispose();
+            }
+        }
+
         partial void BindEcmaAssemblyName(RuntimeAssemblyName refName, bool cacheMissedLookups, ref AssemblyBindResult result, ref Exception exception, ref Exception preferredException, ref bool foundMatch)
         {
-            lock(s_ecmaLoadedAssemblies)
+            lock (s_ecmaLoadedAssemblies)
             {
                 for (int i = 0; i < s_ecmaLoadedAssemblies.Count; i++)
                 {
@@ -117,8 +174,8 @@ namespace Internal.Reflection.Execution
                         // Not found in already loaded list, attempt to source assembly from disk
                         foreach (string filePath in FilePathsForAssembly(refName))
                         {
-                            FileStream ownedFileStream = null;
-                            PEReader ownedPEReader = null;
+                            PEReader? ownedPEReader = null;
+                            MemoryMappedViewAccessor? ownedMemoryMappedView = null;
                             try
                             {
                                 if (!RuntimeAugments.FileExists(filePath))
@@ -126,17 +183,13 @@ namespace Internal.Reflection.Execution
 
                                 try
                                 {
-                                    ownedFileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                                    ownedPEReader = OpenPEFile(filePath, out ownedMemoryMappedView);
                                 }
-                                catch (System.IO.IOException)
+                                catch (IOException)
                                 {
                                     // Failure to open a file is not fundamentally an assembly load error, but it does indicate this file cannot be used
                                     continue;
                                 }
-
-                                ownedPEReader = new PEReader(ownedFileStream);
-                                // FileStream ownership transferred to ownedPEReader
-                                ownedFileStream = null;
 
                                 if (!ownedPEReader.HasMetadata)
                                     continue;
@@ -150,13 +203,14 @@ namespace Internal.Reflection.Execution
                                     continue;
 
                                 // This is the one we are looking for, add it to the list of loaded assemblies
-                                PEInfo peinfo = new PEInfo(runtimeAssemblyName, reader, ownedPEReader);
+                                PEInfo peinfo = new PEInfo(runtimeAssemblyName, reader, ownedPEReader, ownedMemoryMappedView);
 
                                 s_ecmaLoadedAssemblies.Add(peinfo);
 
                                 // At this point the PE reader is no longer owned by this code, but is owned by the s_ecmaLoadedAssemblies list
                                 PEReader pe = ownedPEReader;
                                 ownedPEReader = null;
+                                ownedMemoryMappedView = null;
 
                                 ModuleList moduleList = ModuleList.Instance;
                                 ModuleInfo newModuleInfo = new EcmaModuleInfo(moduleList.SystemModule.Handle, pe, reader);
@@ -168,19 +222,16 @@ namespace Internal.Reflection.Execution
                             }
                             finally
                             {
-                                if (ownedFileStream != null)
-                                    ownedFileStream.Dispose();
-
-                                if (ownedPEReader != null)
-                                    ownedPEReader.Dispose();
+                                ownedPEReader?.Dispose();
+                                ownedMemoryMappedView?.Dispose();
                             }
                         }
                     }
-                    catch (System.IO.IOException)
+                    catch (IOException)
                     { }
-                    catch (System.ArgumentException)
+                    catch (ArgumentException)
                     { }
-                    catch (System.BadImageFormatException badImageFormat)
+                    catch (BadImageFormatException badImageFormat)
                     {
                         exception = badImageFormat;
                     }

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
@@ -34,9 +34,25 @@ namespace Internal.Reflection.Execution
 
         public static AssemblyBinderImplementation Instance { get; } = new AssemblyBinderImplementation();
 
+        partial void BindEcmaFilePath(string assemblyPath, ref AssemblyBindResult bindResult, ref Exception exception, ref bool? result);
         partial void BindEcmaByteArray(byte[] rawAssembly, byte[] rawSymbolStore, ref AssemblyBindResult bindResult, ref Exception exception, ref bool? result);
         partial void BindEcmaAssemblyName(RuntimeAssemblyName refName, bool cacheMissedLookups, ref AssemblyBindResult result, ref Exception exception, ref Exception preferredException, ref bool resultBoolean);
         partial void InsertEcmaLoadedAssemblies(List<AssemblyBindResult> loadedAssemblies);
+
+        public sealed override bool Bind(string assemblyPath, out AssemblyBindResult bindResult, out Exception exception)
+        {
+            bool? result = null;
+            exception = null;
+            bindResult = default(AssemblyBindResult);
+
+            BindEcmaFilePath(assemblyPath, ref bindResult, ref exception, ref result);
+
+            // If the Ecma assembly binder isn't linked in, simply throw PlatformNotSupportedException
+            if (!result.HasValue)
+                throw new PlatformNotSupportedException();
+            else
+                return result.Value;
+        }
 
         public sealed override bool Bind(byte[] rawAssembly, byte[] rawSymbolStore, out AssemblyBindResult bindResult, out Exception exception)
         {

--- a/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -47,6 +47,8 @@
     <ReferencePath Include="$(FrameworkReferencePath)\System.Runtime.dll" />
     <ReferencePath Include="$(FrameworkReferencePath)\System.Collections.Immutable.dll" />
     <ReferencePath Include="$(FrameworkReferencePath)\System.Reflection.Metadata.dll" />
+    <ReferencePath Include="$(FrameworkReferencePath)\System.IO.MemoryMappedFiles.dll" />
+    <ReferencePath Include="$(FrameworkReferencePath)\System.Runtime.InteropServices.dll" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Private.CoreLib\src\System.Private.CoreLib.csproj" />


### PR DESCRIPTION
for Assemblies loaded through `Assembly.LoadFile`, e.g. when using the JIT prototype.
For an Assembly loaded through...

CoreRT `Assembly.Load`:
```
Location: <empty string>
CodeBase: file:///C:/CoreRTJIT/CoreRTJIT/bin/Debug/netcoreapp3.1/win-x64/publish/System.Private.CoreLib.dll
```
CoreCLR `Assembly.Load`:
```
Location: <empty string>
CodeBase: file:///C:/Program Files/dotnet/shared/Microsoft.NETCore.App/3.1.1/System.Private.CoreLib.dll
```
CoreRT `Assembly.LoadFile`
```
Location: C:\CoreRTJIT\JitTest\bin\Debug\netcoreapp3.1\JitTest.dll
CodeBase: file:///C:/CoreRTJIT/JitTest/bin/Debug/netcoreapp3.1/JitTest.dll
```
CoreCLR  `Assembly.LoadFile`
```
Location: C:\CoreRTJIT\JitTest\bin\Debug\netcoreapp3.1\JitTest.dll
CodeBase: file:///C:/CoreRTJIT/JitTest/bin/Debug/netcoreapp3.1/JitTest.dll
```

It's a bit strange that CoreCLR returns `System.Private.CoreLib.dll`  for CodeBase as the [documentation says](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.codebase?view=netcore-3.1#remarks) it should
> If the assembly was loaded as a byte array, using an overload of the Load method that takes an array of bytes, this property returns the location of the caller of the method, not the location of the loaded assembly.

Where i would expect "caller of the method" to be the user executable, but oh well.