### PR TITLE
Delete strong name matching from assembly binder to match CoreCLR

### DIFF
--- a/src/System.Private.CoreLib/src/System/Reflection/AssemblyNameHelpers.cs
+++ b/src/System.Private.CoreLib/src/System/Reflection/AssemblyNameHelpers.cs
@@ -44,23 +44,6 @@ namespace System.Reflection
         }
 
         //
-        // Ensure that the PublicKeyOrPublicKeyToken (if non-null) is the short token form.
-        //
-        public static RuntimeAssemblyName CanonicalizePublicKeyToken(this RuntimeAssemblyName name)
-        {
-            AssemblyNameFlags flags = name.Flags;
-            if ((flags & AssemblyNameFlags.PublicKey) == 0)
-                return name;
-
-            flags &= ~AssemblyNameFlags.PublicKey;
-            byte[] publicKeyOrToken = name.PublicKeyOrToken;
-            if (publicKeyOrToken != null)
-                publicKeyOrToken = ComputePublicKeyToken(publicKeyOrToken);
-
-            return new RuntimeAssemblyName(name.Name, name.Version, name.CultureName, flags, publicKeyOrToken);
-        }
-
-        //
         // These helpers convert between the combined flags+contentType+processorArchitecture value and the separated parts.
         //
         // Since these are only for trusted callers, they do NOT check for out of bound bits. 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
@@ -57,12 +57,6 @@ namespace Internal.Reflection.Execution
             ReflectionExecutionDomainCallbacksImplementation runtimeCallbacks = new ReflectionExecutionDomainCallbacksImplementation(executionDomain, executionEnvironment);
             RuntimeAugments.Initialize(runtimeCallbacks);
 
-            DefaultAssemblyNamesForGetType =
-                new String[]
-                {
-                    AssemblyBinder.DefaultAssemblyNameForGetType,
-                };
-
             ExecutionEnvironment = executionEnvironment;
         }
 
@@ -83,7 +77,7 @@ namespace Internal.Reflection.Execution
         {
             LowLevelListWithIList<String> defaultAssemblies = new LowLevelListWithIList<String>();
             defaultAssemblies.Add(callingAssemblyName);
-            defaultAssemblies.AddRange(DefaultAssemblyNamesForGetType);
+            defaultAssemblies.Add(AssemblyBinder.DefaultAssemblyNameForGetType);
             return ReflectionCoreExecution.ExecutionDomain.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, defaultAssemblies);
         }
 
@@ -119,8 +113,6 @@ namespace Internal.Reflection.Execution
         }
 
         internal static ExecutionEnvironmentImplementation ExecutionEnvironment { get; private set; }
-
-        internal static IList<string> DefaultAssemblyNamesForGetType;
     }
 }
 

--- a/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
+++ b/src/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecutionDomainCallbacksImplementation.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 
 using Internal.Runtime.Augments;
 
+using Internal.Reflection.Core;
 using Internal.Reflection.Core.Execution;
 using Internal.Reflection.Execution.PayForPlayExperience;
 using Internal.Reflection.Extensions.NonPortable;
@@ -33,17 +34,11 @@ namespace Internal.Reflection.Execution
 
         public sealed override Type GetType(string typeName, Func<AssemblyName, Assembly> assemblyResolver, Func<Assembly, string, bool, Type> typeResolver, bool throwOnError, bool ignoreCase, string defaultAssemblyName)
         {
-            if (defaultAssemblyName == null)
-            {
-                return _executionDomain.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, ReflectionExecution.DefaultAssemblyNamesForGetType);
-            }
-            else
-            {
-                LowLevelListWithIList<String> defaultAssemblies = new LowLevelListWithIList<String>();
+            LowLevelListWithIList<String> defaultAssemblies = new LowLevelListWithIList<String>();
+            if (defaultAssemblyName != null)
                 defaultAssemblies.Add(defaultAssemblyName);
-                defaultAssemblies.AddRange(ReflectionExecution.DefaultAssemblyNamesForGetType);
-                return _executionDomain.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, defaultAssemblies);
-            }
+            defaultAssemblies.Add(AssemblyBinder.DefaultAssemblyNameForGetType);
+            return _executionDomain.GetType(typeName, assemblyResolver, typeResolver, throwOnError, ignoreCase, defaultAssemblies);
         }
 
         public sealed override bool IsReflectionBlocked(RuntimeTypeHandle typeHandle)

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Core/AssemblyBinder.cs
@@ -28,7 +28,7 @@ namespace Internal.Reflection.Core
     //
     public abstract class AssemblyBinder
     {
-        public const String DefaultAssemblyNameForGetType = "System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
+        public const String DefaultAssemblyNameForGetType = "System.Private.CoreLib";
 
         public abstract bool Bind(RuntimeAssemblyName refName, bool cacheMissedLookups, out AssemblyBindResult result, out Exception exception);
 

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.Ecma.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.Ecma.cs
@@ -54,7 +54,7 @@ namespace Internal.Reflection.Execution
             MetadataReader reader = pe.GetMetadataReader();
 
             // 2. Create AssemblyName from MetadataReader
-            RuntimeAssemblyName runtimeAssemblyName = reader.GetAssemblyDefinition().ToRuntimeAssemblyName(reader).CanonicalizePublicKeyToken();
+            RuntimeAssemblyName runtimeAssemblyName = reader.GetAssemblyDefinition().ToRuntimeAssemblyName(reader);
 
             lock(s_ecmaLoadedAssemblies)
             {
@@ -143,7 +143,7 @@ namespace Internal.Reflection.Execution
 
                                 MetadataReader reader = ownedPEReader.GetMetadataReader();
                                 // Create AssemblyName from MetadataReader
-                                RuntimeAssemblyName runtimeAssemblyName = reader.GetAssemblyDefinition().ToRuntimeAssemblyName(reader).CanonicalizePublicKeyToken();
+                                RuntimeAssemblyName runtimeAssemblyName = reader.GetAssemblyDefinition().ToRuntimeAssemblyName(reader);
 
                                 // If assembly name doesn't match, it isn't the one we're looking for. Continue to look for more assemblies
                                 if (!AssemblyNameMatches(refName, runtimeAssemblyName, ref preferredException))

--- a/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Reflection/Execution/AssemblyBinderImplementation.cs
@@ -61,31 +61,9 @@ namespace Internal.Reflection.Execution
 
             Exception preferredException = null;
 
-            refName = refName.CanonicalizePublicKeyToken();
-
-            // At least one real-world app calls Type.GetType() for "char" using the assembly name "mscorlib". To accomodate this,
-            // we will adopt the desktop CLR rule that anything named "mscorlib" automatically binds to the core assembly.
-            bool useMscorlibNameCompareFunc = false;
-            RuntimeAssemblyName compareRefName = refName;
-            if (refName.Name == "mscorlib")
-            {
-                useMscorlibNameCompareFunc = true;
-                compareRefName = AssemblyNameParser.Parse(AssemblyBinder.DefaultAssemblyNameForGetType);
-            }
-
             foreach (KeyValuePair<RuntimeAssemblyName, ScopeDefinitionGroup> group in ScopeGroups)
             {
-                bool nameMatches;
-                if (useMscorlibNameCompareFunc)
-                {
-                    nameMatches = MscorlibAssemblyNameMatches(compareRefName, group.Key);
-                }
-                else
-                {
-                    nameMatches = AssemblyNameMatches(refName, group.Key, ref preferredException);
-                }
-
-                if (nameMatches)
+                if (AssemblyNameMatches(refName, group.Key, ref preferredException))
                 {
                     if (foundMatch)
                     {
@@ -135,30 +113,6 @@ namespace Internal.Reflection.Execution
         }
 
         //
-        // Name match routine for mscorlib references
-        //
-        private bool MscorlibAssemblyNameMatches(RuntimeAssemblyName coreAssemblyName, RuntimeAssemblyName defName)
-        {
-            //
-            // The defName came from trusted metadata so it should be fully specified.
-            //
-            Debug.Assert(defName.Version != null);
-            Debug.Assert(defName.CultureName != null);
-
-            Debug.Assert((coreAssemblyName.Flags & AssemblyNameFlags.PublicKey) == 0);
-            Debug.Assert((defName.Flags & AssemblyNameFlags.PublicKey) == 0);
-
-            if (defName.Name != coreAssemblyName.Name)
-                return false;
-            byte[] defPkt = defName.PublicKeyOrToken;
-            if (defPkt == null)
-                return false;
-            if (!ArePktsEqual(defPkt, coreAssemblyName.PublicKeyOrToken))
-                return false;
-            return true;
-        }
-
-        //
         // Encapsulates the assembly ref->def matching policy.
         //
         private bool AssemblyNameMatches(RuntimeAssemblyName refName, RuntimeAssemblyName defName, ref Exception preferredException)
@@ -168,9 +122,6 @@ namespace Internal.Reflection.Execution
             //
             Debug.Assert(defName.Version != null);
             Debug.Assert(defName.CultureName != null);
-
-            Debug.Assert((defName.Flags & AssemblyNameFlags.PublicKey) == 0);
-            Debug.Assert((refName.Flags & AssemblyNameFlags.PublicKey) == 0);
 
             if (!(refName.Name.Equals(defName.Name, StringComparison.OrdinalIgnoreCase)))
                 return false;
@@ -190,22 +141,7 @@ namespace Internal.Reflection.Execution
                     return false;
             }
 
-            AssemblyNameFlags materialRefNameFlags = refName.Flags.ExtractAssemblyNameFlags();
-            AssemblyNameFlags materialDefNameFlags = defName.Flags.ExtractAssemblyNameFlags();
-            if (materialRefNameFlags != materialDefNameFlags)
-            {
-                return false;
-            }
-
-            byte[] refPublicKeyToken = refName.PublicKeyOrToken;
-            if (refPublicKeyToken != null)
-            {
-                byte[] defPublicKeyToken = defName.PublicKeyOrToken;
-                if (defPublicKeyToken == null)
-                    return false;
-                if (!ArePktsEqual(refPublicKeyToken, defPublicKeyToken))
-                    return false;
-            }
+            // Strong names are ignored in .NET Core
 
             return true;
         }
@@ -284,7 +220,7 @@ namespace Internal.Reflection.Execution
         {
             foreach (ScopeDefinitionHandle scopeDefinitionHandle in reader.ScopeDefinitions)
             {
-                RuntimeAssemblyName defName = scopeDefinitionHandle.ToRuntimeAssemblyName(reader).CanonicalizePublicKeyToken();
+                RuntimeAssemblyName defName = scopeDefinitionHandle.ToRuntimeAssemblyName(reader);
                 ScopeDefinitionGroup scopeDefinitionGroup;
                 if (groups.TryGetValue(defName, out scopeDefinitionGroup))
                 {
@@ -296,18 +232,6 @@ namespace Internal.Reflection.Execution
                     groups.Add(defName, scopeDefinitionGroup);
                 }
             }
-        }
-
-        private static bool ArePktsEqual(byte[] pkt1, byte[] pkt2)
-        {
-            if (pkt1.Length != pkt2.Length)
-                return false;
-            for (int i = 0; i < pkt1.Length; i++)
-            {
-                if (pkt1[i] != pkt2[i])
-                    return false;
-            }
-            return true;
         }
 
         private volatile KeyValuePair<RuntimeAssemblyName, ScopeDefinitionGroup>[] _scopeGroups;

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -54,8 +54,8 @@ internal class ReflectionTest
         TestReflectionInvoke.Run();
 #if !CODEGEN_CPP
         TestByRefReturnInvoke.Run();
-#endif
         TestAssemblyLoad.Run();
+#endif
         return 100;
     }
 

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -55,6 +55,7 @@ internal class ReflectionTest
 #if !CODEGEN_CPP
         TestByRefReturnInvoke.Run();
 #endif
+        TestAssemblyLoad.Run();
         return 100;
     }
 
@@ -1087,11 +1088,18 @@ internal class ReflectionTest
                     throw new Exception("List");
             }
 
-            Console.WriteLine("Search in mscorlib");
+            Console.WriteLine("Search in system assembly");
             {
                 Type t = Type.GetType("System.Runtime.CompilerServices.SuppressIldasmAttribute", throwOnError: false);
                 if (t == null)
                     throw new Exception("SuppressIldasmAttribute");
+            }
+
+            Console.WriteLine("Search in mscorlib");
+            {
+                Type t = Type.GetType("System.Runtime.CompilerServices.CompilerGlobalScopeAttribute, mscorlib", throwOnError: false);
+                if (t == null)
+                    throw new Exception("CompilerGlobalScopeAttribute");
             }
 #endif
 #endif
@@ -1140,6 +1148,16 @@ internal class ReflectionTest
             Type enumType = mi.GetParameters()[0].ParameterType;
             if (Enum.GetUnderlyingType(enumType) != typeof(int))
                 throw new Exception();
+        }
+    }
+
+    class TestAssemblyLoad
+    {
+        public static void Run()
+        {
+            Assert.Equal("System.Private.CoreLib", Assembly.Load("System.Private.CoreLib, PublicKeyToken=cccccccccccccccc").GetName().Name);
+            Assert.Equal("System.Console", Assembly.Load("System.Console, PublicKeyToken=cccccccccccccccc").GetName().Name);
+            Assert.Equal("mscorlib", Assembly.Load("mscorlib, PublicKeyToken=cccccccccccccccc").GetName().Name);
         }
     }
 

--- a/tests/src/Simple/Reflection/Reflection.cs
+++ b/tests/src/Simple/Reflection/Reflection.cs
@@ -1079,20 +1079,20 @@ internal class ReflectionTest
                     throw new Exception("PartialCanon");
             }
 
-#if !MULTIMODULE_BUILD
 #if !CODEGEN_CPP // https://github.com/dotnet/corert/issues/7799
-            Console.WriteLine("Search through a forwarder");
-            {
-                Type t = Type.GetType("System.Collections.Generic.List`1, System.Collections", throwOnError: false);
-                if (t == null)
-                    throw new Exception("List");
-            }
-
             Console.WriteLine("Search in system assembly");
             {
                 Type t = Type.GetType("System.Runtime.CompilerServices.SuppressIldasmAttribute", throwOnError: false);
                 if (t == null)
                     throw new Exception("SuppressIldasmAttribute");
+            }
+
+#if !MULTIMODULE_BUILD
+            Console.WriteLine("Search through a forwarder");
+            {
+                Type t = Type.GetType("System.Collections.Generic.List`1, System.Collections", throwOnError: false);
+                if (t == null)
+                    throw new Exception("List");
             }
 
             Console.WriteLine("Search in mscorlib");
@@ -1157,7 +1157,9 @@ internal class ReflectionTest
         {
             Assert.Equal("System.Private.CoreLib", Assembly.Load("System.Private.CoreLib, PublicKeyToken=cccccccccccccccc").GetName().Name);
             Assert.Equal("System.Console", Assembly.Load("System.Console, PublicKeyToken=cccccccccccccccc").GetName().Name);
+#if !MULTIMODULE_BUILD
             Assert.Equal("mscorlib", Assembly.Load("mscorlib, PublicKeyToken=cccccccccccccccc").GetName().Name);
+#endif
         }
     }
 


### PR DESCRIPTION
Also, delete special casing of mscorlib