### PR TITLE
Fix running test

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "native-tools": {
     "cmake": "3.14.2",
-    "python": "2.7.15"
+    "python": "3.7.3"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19115.1",

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "native-tools": {
     "cmake": "3.14.2",
-    "python": "3.7.3"
+    "python3": "3.7.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19115.1",

--- a/tests/CoreCLR/runtest.py
+++ b/tests/CoreCLR/runtest.py
@@ -1816,7 +1816,10 @@ if sys.version_info.major < 3:
         return unicode(s, "utf-8")
 else:
     def to_unicode(s):
-        return str(s, "utf-8")
+        if not isinstance(s, str):
+            return str(s, "utf-8")
+        else:
+            return s
 
 def delete_existing_wrappers(test_location):
     """ Delete the existing xunit wrappers

--- a/tests/CoreCLR/runtest.py
+++ b/tests/CoreCLR/runtest.py
@@ -1816,10 +1816,7 @@ if sys.version_info.major < 3:
         return unicode(s, "utf-8")
 else:
     def to_unicode(s):
-        if not isinstance(s, str):
-            return str(s, "utf-8")
-        else:
-            return s
+        return s
 
 def delete_existing_wrappers(test_location):
     """ Delete the existing xunit wrappers

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -466,7 +466,7 @@ goto :eof
         )
         call %CoreRT_TestRoot%\CoreCLR\build-and-run-test.cmd !TestFolderName! !TestFileName!
     ) else (
-        set __RunTestCommand=python runtest.py -arch %CoreRT_BuildArch% -build_type %CoreRT_BuildType% -test_native_bin_location !CoreRT_TestExtRepo_CoreCLR! -test_location %CoreRT_TestRoot%\CoreCLR -core_root !CoreRT_TestExtRepo_CoreCLR!\Tests\Core_Root -coreclr_repo_location %CoreRT_TestRoot%.. %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile%
+        set __RunTestCommand=python3 runtest.py -arch %CoreRT_BuildArch% -build_type %CoreRT_BuildType% -test_native_bin_location !CoreRT_TestExtRepo_CoreCLR! -test_location %CoreRT_TestRoot%\CoreCLR -core_root !CoreRT_TestExtRepo_CoreCLR!\Tests\Core_Root -coreclr_repo_location %CoreRT_TestRoot%.. %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile%
         if not "%CoreRT_GCStressLevel%" == "" ( set __RunTestCommand=!__RunTestCommand! gcstresslevel !CoreRT_GCStressLevel! )
         echo !__RunTestCommand!
         call !__RunTestCommand!


### PR DESCRIPTION
without that code I have stack trace on Python 3.7.1
when run `tests\runtest.cmd /coreclr Top200`
```
Traceback (most recent call last):
  File "runtest.py", line 2450, in <module>
    sys.exit(main(args))
  File "runtest.py", line 2423, in main
    lambda path: do_setup(host_os,
  File "runtest.py", line 550, in create_and_use_test_env
    ret_code = func(None)
  File "runtest.py", line 2433, in <lambda>
    test_filter_path))
  File "runtest.py", line 2356, in do_setup
    build_test_wrappers(host_os, arch, build_type, coreclr_repo_location, test_location, None, test_filter_path)
  File "runtest.py", line 1871, in build_test_wrappers
    delete_existing_wrappers(to_unicode(test_location))
  File "runtest.py", line 1822, in to_unicode
    return str(s, "utf-8")
TypeError: decoding str is not supported
```