### PR TITLE
Work around non-portable win/osx RIDs

### DIFF
--- a/src/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
+++ b/src/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
@@ -1,16 +1,24 @@
 <Project 
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+
     <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->
     <!-- Define the name of the runtime specific compiler package to import -->
-    <RuntimeIlcPackageName Condition="'$(RuntimeIdentifier)' != ''">runtime.$(RuntimeIdentifier).Microsoft.DotNet.ILCompiler</RuntimeIlcPackageName>
+    <PortableRuntimeIdentifier>$(RuntimeIdentifier)</PortableRuntimeIdentifier>
+    <PortableRuntimeIdentifier Condition="$(RuntimeIdentifier.StartsWith('win'))">win-$(PlatformTarget)</PortableRuntimeIdentifier>
+    <PortableRuntimeIdentifier Condition="$(RuntimeIdentifier.StartsWith('osx'))">osx-$(PlatformTarget)</PortableRuntimeIdentifier>
+    <RuntimeIlcPackageName>runtime.$(PortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler</RuntimeIlcPackageName>
     <IlcCalledViaPackage>true</IlcCalledViaPackage>
-   
+
+  </PropertyGroup>
+
+  <PropertyGroup>
+
     <!-- If CoreRT is being consumed via its package, runtime-specific properties must be set before compilation can proceed -->
     <ImportRuntimeIlcPackageTargetDependsOn>RunResolvePackageDependencies</ImportRuntimeIlcPackageTargetDependsOn>
     <IlcSetupPropertiesDependsOn>ImportRuntimeIlcPackageTarget</IlcSetupPropertiesDependsOn>
     <IlcDynamicBuildPropertyDependencies>SetupProperties</IlcDynamicBuildPropertyDependencies>
-    
+
   </PropertyGroup>
 
   <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->


### PR DESCRIPTION
e.g. `win10-x64` -> `win-x64`