### PR TITLE
Rewrite RhCreateGenericInstanceDescForType2 in managed code

### DIFF
--- a/src/Native/Runtime/RuntimeInstance.h
+++ b/src/Native/Runtime/RuntimeInstance.h
@@ -214,17 +214,6 @@ public:
 
     bool AddDynamicThreadStaticGcData(UInt32 uiTlsIndex, UInt32 uiThreadStaticOffset, StaticGcDesc *pGcStaticsDesc);
 
-    bool CreateGenericAndStaticInfo(EEType *             pEEType,
-                                    EEType *             pTemplateType,
-                                    UInt32               arity,
-                                    UInt32               nonGcStaticDataSize,
-                                    UInt32               nonGCStaticDataOffset,
-                                    UInt32               gcStaticDataSize,
-                                    UInt32               threadStaticOffset,
-                                    StaticGcDesc *       pGcStaticsDesc,
-                                    StaticGcDesc *       pThreadStaticsDesc,
-                                    UInt32*              pGenericVarianceFlags);
-
     bool UnifyGenerics(GenericUnificationDesc *descs, UInt32 descCount, void  **pIndirCells, UInt32 indirCellCount);
 
 #ifdef FEATURE_PROFILING

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -558,20 +558,15 @@ public:
     bool HasDynamicallyAllocatedDispatchMap()
         { return (get_RareFlags() & HasDynamicallyAllocatedDispatchMapFlag) != 0; }
 
-    inline void set_GenericComposition(GenericComposition *);
-
     // Retrieve template used to create the dynamic type
     EEType * get_DynamicTemplateType();
 
     bool HasDynamicGcStatics() { return (get_RareFlags() & IsDynamicTypeWithGcStaticsFlag) != 0; }
-    void set_DynamicGcStatics(UInt8 *pStatics);
 
     bool HasDynamicNonGcStatics() { return (get_RareFlags() & IsDynamicTypeWithNonGcStaticsFlag) != 0; }
-    void set_DynamicNonGcStatics(UInt8 *pStatics);
 
     bool HasDynamicThreadStatics() { return (get_RareFlags() & IsDynamicTypeWithThreadStaticsFlag) != 0; }
     UInt32 get_DynamicThreadStaticOffset();
-    void set_DynamicThreadStaticOffset(UInt32 threadStaticOffset);
 
     UInt32 GetHashCode();
 
@@ -662,22 +657,6 @@ class GenericComposition
     GenericVarianceType m_variance[/*arity*/1];
 
 public:
-    static size_t GetSize(UInt16 arity, bool hasVariance)
-    {
-        size_t cbSize = offsetof(GenericComposition, m_arguments[arity]);
-        if (hasVariance)
-            cbSize += sizeof(GenericVarianceType)*arity;
-
-        return cbSize;
-    }
-
-    void Init(UInt16 arity, bool hasVariance)
-    {
-        memset(this, 0, GetSize(arity, hasVariance));
-        m_arity = arity;
-        m_hasVariance = hasVariance;
-    }
-
     UInt32 GetArity()
     {
         return m_arity;
@@ -692,8 +671,6 @@ public:
     }
 #endif
     GenericVarianceType *GetVariance();
-
-    void SetVariance(UInt32 index, GenericVarianceType variance);
 
     bool Equals(GenericComposition *that);
 };

--- a/src/Native/Runtime/inc/eetype.inl
+++ b/src/Native/Runtime/inc/eetype.inl
@@ -354,15 +354,6 @@ inline UInt8 EEType::GetNullableValueOffset()
     return pOptFields->GetNullableValueOffset(0) + 1;
 }
 
-inline void EEType::set_GenericComposition(GenericComposition *pGenericComposition)
-{
-    ASSERT(IsGeneric() && IsDynamicType());
-
-    UInt32 cbOffset = GetFieldOffset(ETF_GenericComposition);
-
-    *(GenericComposition **)((UInt8*)this + cbOffset) = pGenericComposition;
-}
-
 inline EEType * EEType::get_DynamicTemplateType()
 {
     ASSERT(IsDynamicType());
@@ -376,32 +367,11 @@ inline EEType * EEType::get_DynamicTemplateType()
 #endif
 }
 
-inline void EEType::set_DynamicGcStatics(UInt8 *pStatics)
-{
-    UInt32 cbOffset = GetFieldOffset(ETF_DynamicGcStatics);
-
-    *(UInt8**)((UInt8*)this + cbOffset) = pStatics;
-}
-
-inline void EEType::set_DynamicNonGcStatics(UInt8 *pStatics)
-{
-    UInt32 cbOffset = GetFieldOffset(ETF_DynamicNonGcStatics);
-
-    *(UInt8**)((UInt8*)this + cbOffset) = pStatics;
-}
-
 inline UInt32 EEType::get_DynamicThreadStaticOffset()
 {
     UInt32 cbOffset = GetFieldOffset(ETF_DynamicThreadStaticOffset);
 
     return *(UInt32*)((UInt8*)this + cbOffset);
-}
-
-inline void EEType::set_DynamicThreadStaticOffset(UInt32 threadStaticOffset)
-{
-    UInt32 cbOffset = GetFieldOffset(ETF_DynamicThreadStaticOffset);
-
-    *(UInt32*)((UInt8*)this + cbOffset) = threadStaticOffset;
 }
 
 inline DynamicModule * EEType::get_DynamicModule()
@@ -752,13 +722,6 @@ inline GenericVarianceType *GenericComposition::GetVariance()
 {
     ASSERT(m_hasVariance);
     return (GenericVarianceType *)(((UInt8 *)this) + offsetof(GenericComposition, m_arguments[m_arity]));
-}
-
-inline void GenericComposition::SetVariance(UInt32 index, GenericVarianceType variance)
-{
-    ASSERT(index < m_arity);
-    GenericVarianceType *pVariance = GetVariance();
-    pVariance[index] = variance;
 }
 
 #endif // __eetype_inl__

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -596,17 +596,6 @@ namespace Internal.Runtime.Augments
             return RuntimeImports.RhGetGCDescSize(eeType);
         }
 
-        public static unsafe bool CreateGenericInstanceDescForType(RuntimeTypeHandle typeHandle, int arity, int nonGcStaticDataSize,
-            int nonGCStaticDataOffset, int gcStaticDataSize, int threadStaticsOffset, IntPtr gcStaticsDesc, IntPtr threadStaticsDesc, int[] genericVarianceFlags)
-        {
-            EETypePtr eeType = CreateEETypePtr(typeHandle);
-            fixed (int* pGenericVarianceFlags = genericVarianceFlags)
-            {
-                return RuntimeImports.RhCreateGenericInstanceDescForType2(eeType, arity, nonGcStaticDataSize, nonGCStaticDataOffset, gcStaticDataSize,
-                    threadStaticsOffset, gcStaticsDesc.ToPointer(), threadStaticsDesc.ToPointer(), pGenericVarianceFlags);
-            }
-        }
-
         public static int GetInterfaceCount(RuntimeTypeHandle typeHandle)
         {
             return typeHandle.ToEETypePtr().Interfaces.Count;

--- a/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -436,11 +436,6 @@ namespace System.Runtime
         internal static extern int RhGetGCDescSize(EETypePtr eeType);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhCreateGenericInstanceDescForType2")]
-        internal static extern unsafe bool RhCreateGenericInstanceDescForType2(EETypePtr pEEType, int arity, int nonGcStaticDataSize,
-            int nonGCStaticDataOffset, int gcStaticDataSize, int threadStaticsOffset, void* pGcStaticsDesc, void* pThreadStaticsDesc, int* pGenericVarianceFlags);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhNewInterfaceDispatchCell")]
         internal static extern unsafe IntPtr RhNewInterfaceDispatchCell(EETypePtr pEEType, int slotNumber);
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -62,6 +62,16 @@ namespace Internal.Runtime.TypeLoader
             rtth.ToEETypePtr()->GenericDefinition = genericDefinitionHandle.ToEETypePtr();
         }
 
+        public static unsafe void SetGenericVariance(this RuntimeTypeHandle rtth, int argumentIndex, GenericVariance variance)
+        {
+            rtth.ToEETypePtr()->GenericVariance[argumentIndex] = variance;
+        }
+
+        public static unsafe void SetGenericArity(this RuntimeTypeHandle rtth, uint arity)
+        {
+            rtth.ToEETypePtr()->GenericArity = arity;
+        }
+
         public static unsafe void SetGenericArgument(this RuntimeTypeHandle rtth, int argumentIndex, RuntimeTypeHandle argumentType)
         {
             rtth.ToEETypePtr()->GenericArguments[argumentIndex].Value = argumentType.ToEETypePtr();
@@ -142,6 +152,8 @@ namespace Internal.Runtime.TypeLoader
             DynamicModule* dynamicModulePtr = null;
             IntPtr gcStaticData = IntPtr.Zero;
             IntPtr gcStaticsIndirection = IntPtr.Zero;
+            IntPtr nonGcStaticData = IntPtr.Zero;
+            IntPtr genericComposition = IntPtr.Zero;
 
             try
             {
@@ -241,12 +253,14 @@ namespace Internal.Runtime.TypeLoader
 
                     if (state.TypeBeingBuilt.HasVariance)
                     {
-                        state.GenericVarianceFlags = new int[state.TypeBeingBuilt.Instantiation.Length];
+                        state.GenericVarianceFlags = new GenericVariance[state.TypeBeingBuilt.Instantiation.Length];
                         int i = 0;
 
                         foreach (GenericParameterDesc gpd in state.TypeBeingBuilt.GetTypeDefinition().Instantiation)
                         {
-                            state.GenericVarianceFlags[i] = (int)gpd.Variance;
+                            Debug.Assert((int)Internal.Runtime.GenericVariance.Covariant == (int)Internal.TypeSystem.GenericVariance.Covariant);
+                            Debug.Assert((int)Internal.Runtime.GenericVariance.Contravariant == (int)Internal.TypeSystem.GenericVariance.Contravariant);
+                            state.GenericVarianceFlags[i] = (GenericVariance)gpd.Variance;
                             i++;
                         }
                         Debug.Assert(i == state.GenericVarianceFlags.Length);
@@ -616,19 +630,7 @@ namespace Internal.Runtime.TypeLoader
                 {
                     // Use object as the template type for non-template based EETypes. This will
                     // allow correct Module identification for types.
-
-                    if (state.TypeBeingBuilt.HasVariance)
-                    {
-                        // TODO! We need to have a variant EEType here if the type has variance, as the 
-                        // CreateGenericInstanceDescForType requires it. However, this is a ridiculous api surface
-                        // When we remove GenericInstanceDescs from the product, get rid of this weird special
-                        // case
-                        pEEType->DynamicTemplateType = typeof(IEnumerable<int>).TypeHandle.ToEETypePtr();
-                    }
-                    else
-                    {
-                        pEEType->DynamicTemplateType = typeof(object).TypeHandle.ToEETypePtr();
-                    }
+                    pEEType->DynamicTemplateType = typeof(object).TypeHandle.ToEETypePtr();
                 }
 
                 int nonGCStaticDataOffset = 0;
@@ -677,27 +679,22 @@ namespace Internal.Runtime.TypeLoader
 
                 if (isGeneric)
                 {
-                    if (!RuntimeAugments.CreateGenericInstanceDescForType(*(RuntimeTypeHandle*)&pEEType, arity, state.NonGcDataSize, nonGCStaticDataOffset,
-                        state.GcDataSize, (int)state.ThreadStaticOffset, state.GcStaticDesc, state.ThreadStaticDesc, state.GenericVarianceFlags))
+                    genericComposition = MemoryHelpers.AllocateMemory(EEType.GetGenericCompositionSize(arity, pEEType->HasGenericVariance));
+                    pEEType->SetGenericComposition(genericComposition);
+
+                    if (state.NonGcDataSize > 0)
                     {
-                        throw new OutOfMemoryException();
+                        nonGcStaticData = MemoryHelpers.AllocateMemory(state.NonGcDataSize);
+                        MemoryHelpers.Memset(nonGcStaticData, state.NonGcDataSize, 0);
+                        Debug.Assert(nonGCStaticDataOffset <= state.NonGcDataSize);
+                        pEEType->DynamicNonGcStaticsData = (IntPtr)((byte*)nonGcStaticData + nonGCStaticDataOffset);
                     }
                 }
-                else
+
+                if (!isGenericEETypeDef && state.ThreadDataSize != 0)
                 {
-                    Debug.Assert(arity == 0 || isGenericEETypeDef);
-                    // We don't need to report the non-gc and gc static data regions and allocate them for non-generics, 
-                    // as we currently place these fields directly into the image
-                    if (!isGenericEETypeDef && state.ThreadDataSize != 0)
-                    {
-                        // Types with thread static fields ALWAYS get a GID. The GID is used to perform GC 
-                        // and lifetime management of the thread static data. However, these GIDs are only used for that
-                        // so the specified GcDataSize, etc are 0
-                        if (!RuntimeAugments.CreateGenericInstanceDescForType(*(RuntimeTypeHandle*)&pEEType, 0, 0, 0, 0, (int)state.ThreadStaticOffset, IntPtr.Zero, state.ThreadStaticDesc, null))
-                        {
-                            throw new OutOfMemoryException();
-                        }
-                    }
+                    // TODO: thread statics
+                    throw new NotSupportedException();
                 }
 
                 if (state.Dictionary != null)
@@ -729,6 +726,10 @@ namespace Internal.Runtime.TypeLoader
                         RuntimeAugments.RhHandleFree(gcStaticData);
                     if (gcStaticsIndirection != IntPtr.Zero)
                         MemoryHelpers.FreeMemory(gcStaticsIndirection);
+                    if (genericComposition != IntPtr.Zero)
+                        MemoryHelpers.FreeMemory(genericComposition);
+                    if (nonGcStaticData != IntPtr.Zero)
+                        MemoryHelpers.FreeMemory(nonGcStaticData);
                 }
             }
         }

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -613,9 +613,9 @@ namespace Internal.Runtime.TypeLoader
                     case BagElementKind.GenericVarianceInfo:
                         TypeLoaderLogger.WriteLine("Found BagElementKind.GenericVarianceInfo");
                         NativeParser varianceInfoParser = typeInfoParser.GetParserFromRelativeOffset();
-                        state.GenericVarianceFlags = new int[varianceInfoParser.GetSequenceCount()];
+                        state.GenericVarianceFlags = new GenericVariance[varianceInfoParser.GetSequenceCount()];
                         for (int i = 0; i < state.GenericVarianceFlags.Length; i++)
-                            state.GenericVarianceFlags[i] = checked((int)varianceInfoParser.GetUnsigned());
+                            state.GenericVarianceFlags[i] = checked((GenericVariance)varianceInfoParser.GetUnsigned());
                         break;
 
                     case BagElementKind.FieldLayout:
@@ -1319,8 +1319,16 @@ namespace Internal.Runtime.TypeLoader
 
                     state.HalfBakedRuntimeTypeHandle.SetGenericDefinition(GetRuntimeTypeHandle(typeAsDefType.GetTypeDefinition()));
                     Instantiation instantiation = typeAsDefType.Instantiation;
+                    state.HalfBakedRuntimeTypeHandle.SetGenericArity((uint)instantiation.Length);
                     for (int argIndex = 0; argIndex < instantiation.Length; argIndex++)
+                    {
                         state.HalfBakedRuntimeTypeHandle.SetGenericArgument(argIndex, GetRuntimeTypeHandle(instantiation[argIndex]));
+                        if (state.GenericVarianceFlags != null)
+                        {
+                            Debug.Assert(state.GenericVarianceFlags.Length == instantiation.Length);
+                            state.HalfBakedRuntimeTypeHandle.SetGenericVariance(argIndex, state.GenericVarianceFlags[argIndex]);
+                        }
+                    }
                 }
 
                 FinishBaseTypeAndDictionaries(type, state);

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -530,7 +530,7 @@ namespace Internal.Runtime.TypeLoader
         public bool AllocatedThreadStaticGCDesc;
         public uint ThreadStaticOffset;
         public uint NumSealedVTableEntries;
-        public int[] GenericVarianceFlags;
+        public GenericVariance[] GenericVarianceFlags;
 
         // Sentinel static to allow us to initialize _instanceLayout to something
         // and then detect that InstanceGCLayout should return null


### PR DESCRIPTION
Quoting from a (David's?) comment I'm deleting: "this is a ridiculous API". The API has a long history and there's no reason for it to exist anymore. Inlining the functionality it was providing into the runtime type loader.

This lets us delete a bunch of EEType knowledge from the unmanaged runtime.