### PR TITLE
Take advantage of new EETypeElementType values

### DIFF
--- a/src/Common/src/Internal/Runtime/EEType.Constants.cs
+++ b/src/Common/src/Internal/Runtime/EEType.Constants.cs
@@ -27,10 +27,7 @@ namespace Internal.Runtime
         /// </summary>
         RelatedTypeViaIATFlag = 0x0004,
 
-        /// <summary>
-        /// This EEType represents a value type.
-        /// </summary>
-        ValueTypeFlag = 0x0008,
+        // Unused = 0x0008,
 
         /// <summary>
         /// This EEType represents a type which requires finalization.
@@ -58,10 +55,7 @@ namespace Internal.Runtime
         /// </summary>
         OptionalFieldsFlag = 0x0100,
 
-        /// <summary>
-        /// This EEType represents an interface.
-        /// </summary>
-        IsInterfaceFlag = 0x0200,
+        // Unused = 0x0200,
 
         /// <summary>
         /// This type is generic.

--- a/src/Common/src/Internal/Runtime/EEType.cs
+++ b/src/Common/src/Internal/Runtime/EEType.cs
@@ -379,7 +379,8 @@ namespace Internal.Runtime
         {
             get
             {
-                return IsParameterizedType && ParameterizedTypeShape >= SZARRAY_BASE_SIZE;
+                EETypeElementType elementType = ElementType;
+                return elementType == EETypeElementType.Array || elementType == EETypeElementType.SzArray;
             }
         }
 
@@ -405,7 +406,7 @@ namespace Internal.Runtime
         {
             get
             {
-                return IsArray && ParameterizedTypeShape == SZARRAY_BASE_SIZE;
+                return ElementType == EETypeElementType.SzArray;
             }
         }
 
@@ -544,8 +545,7 @@ namespace Internal.Runtime
         {
             get
             {
-                return IsParameterizedType &&
-                    ParameterizedTypeShape == ParameterizedTypeShapeConstants.Pointer;
+                return ElementType == EETypeElementType.Pointer;
             }
         }
 
@@ -553,8 +553,7 @@ namespace Internal.Runtime
         {
             get
             {
-                return IsParameterizedType &&
-                    ParameterizedTypeShape == ParameterizedTypeShapeConstants.ByRef;
+                return ElementType == EETypeElementType.ByRef;
             }
         }
 
@@ -562,7 +561,7 @@ namespace Internal.Runtime
         {
             get
             {
-                return ((_usFlags & (ushort)EETypeFlags.IsInterfaceFlag) != 0);
+                return ElementType == EETypeElementType.Interface;
             }
         }
 
@@ -725,7 +724,7 @@ namespace Internal.Runtime
         {
             get
             {
-                return ((_usFlags & (ushort)EETypeFlags.ValueTypeFlag) != 0);
+                return ElementType < EETypeElementType.Class;
             }
         }
 

--- a/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -45,17 +45,12 @@ namespace Internal.Runtime
 
         public static UInt16 ComputeFlags(TypeDesc type)
         {
-            UInt16 flags = (UInt16)EETypeKind.CanonicalEEType;
+            UInt16 flags = type.IsParameterizedType ?
+                (UInt16)EETypeKind.ParameterizedEEType : (UInt16)EETypeKind.CanonicalEEType;
 
-            if (type.IsInterface)
-            {
-                flags |= (UInt16)EETypeFlags.IsInterfaceFlag;
-            }
-
-            if (type.IsValueType)
-            {
-                flags |= (UInt16)EETypeFlags.ValueTypeFlag;
-            }
+            // The top 5 bits of flags are used to convey enum underlying type, primitive type, or mark the type as being System.Array
+            EETypeElementType elementType = ComputeEETypeElementType(type);
+            flags |= (UInt16)((UInt16)elementType << (UInt16)EETypeFlags.ElementTypeShift);
 
             if (type.IsGenericDefinition)
             {
@@ -63,11 +58,6 @@ namespace Internal.Runtime
 
                 // Generic type definition EETypes don't set the other flags.
                 return flags;
-            }
-
-            if (type.IsArray || type.IsPointer || type.IsByRef)
-            {
-                flags = (UInt16)EETypeKind.ParameterizedEEType;
             }
 
             if (type.HasFinalizer)
@@ -100,19 +90,6 @@ namespace Internal.Runtime
                     flags |= (UInt16)EETypeFlags.GenericVarianceFlag;
                 }
             }
-
-            flags |= ComputeElementTypeFlags(type);
-
-            return flags;
-        }
-
-        public static UInt16 ComputeElementTypeFlags(TypeDesc type)
-        {
-            UInt16 flags = 0;
-
-            // The top 5 bits of flags are used to convey enum underlying type, primitive type, or mark the type as being System.Array
-            EETypeElementType elementType = ComputeEETypeElementType(type);
-            flags |= (UInt16)((UInt16)elementType << (UInt16)EETypeFlags.ElementTypeShift);
 
             return flags;
         }

--- a/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/Common/src/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -65,19 +65,18 @@ namespace Internal.Runtime
                 flags |= (UInt16)EETypeFlags.HasFinalizerFlag;
             }
 
-            if (!type.IsCanonicalSubtype(CanonicalFormKind.Universal))
+            if (type.IsDefType
+                && !type.IsCanonicalSubtype(CanonicalFormKind.Universal)
+                && ((DefType)type).ContainsGCPointers)
             {
-                if (type.IsDefType && ((DefType)type).ContainsGCPointers)
+                flags |= (UInt16)EETypeFlags.HasPointersFlag;
+            }
+            else if (type.IsArray && !type.IsCanonicalSubtype(CanonicalFormKind.Universal))
+            {
+                var arrayElementType = ((ArrayType)type).ElementType;
+                if ((arrayElementType.IsValueType && ((DefType)arrayElementType).ContainsGCPointers) || arrayElementType.IsGCPointer)
                 {
                     flags |= (UInt16)EETypeFlags.HasPointersFlag;
-                }
-                else if (type.IsArray)
-                {
-                    var arrayElementType = ((ArrayType)type).ElementType;
-                    if ((arrayElementType.IsValueType && ((DefType)arrayElementType).ContainsGCPointers) || arrayElementType.IsGCPointer)
-                    {
-                        flags |= (UInt16)EETypeFlags.HasPointersFlag;
-                    }
                 }
             }
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -44,11 +44,7 @@ namespace ILCompiler.DependencyAnalysis
             dataBuilder.AddSymbol(this);
             EETypeRareFlags rareFlags = 0;
 
-            short flags = (short)EETypeKind.GenericTypeDefEEType;
-            if (_type.IsValueType)
-                flags |= (short)EETypeFlags.ValueTypeFlag;
-            if (_type.IsInterface)
-                flags |= (short)EETypeFlags.IsInterfaceFlag;
+            ushort flags = EETypeBuilderHelpers.ComputeFlags(_type);
             if (factory.TypeSystemContext.HasLazyStaticConstructor(_type))
                 rareFlags = rareFlags | EETypeRareFlags.HasCctorFlag;
             if (_type.IsByRefLike)
@@ -58,12 +54,10 @@ namespace ILCompiler.DependencyAnalysis
                 _optionalFieldsBuilder.SetFieldValue(EETypeOptionalFieldTag.RareFlags, (uint)rareFlags);
 
             if (HasOptionalFields)
-                flags |= (short)EETypeFlags.OptionalFieldsFlag;
-
-            flags |= (short)EETypeBuilderHelpers.ComputeElementTypeFlags(_type);
+                flags |= (ushort)EETypeFlags.OptionalFieldsFlag;
 
             dataBuilder.EmitShort((short)_type.Instantiation.Length);
-            dataBuilder.EmitShort(flags);
+            dataBuilder.EmitUShort(flags);
             dataBuilder.EmitInt(0);         // Base size is always 0
             dataBuilder.EmitZeroPointer();  // No related type
             dataBuilder.EmitShort(0);       // No VTable

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -260,8 +260,7 @@ private:
         // through m_pRelatedType to get to the related type in the other module.
         RelatedTypeViaIATFlag   = 0x0004,
 
-        // This EEType represents a value type
-        ValueTypeFlag           = 0x0008,
+        // Unused           = 0x0008,
 
         // This EEType represents a type which requires finalization
         HasFinalizerFlag        = 0x0010,
@@ -279,8 +278,7 @@ private:
         // This type has optional fields present.
         OptionalFieldsFlag      = 0x0100,
 
-        // This EEType represents an interface.
-        IsInterfaceFlag         = 0x0200,
+        // Unused         = 0x0200,
 
         // This type is generic.
         IsGenericFlag           = 0x0400,
@@ -392,9 +390,11 @@ public:
     bool IsRelatedTypeViaIAT()
         { return ((m_usFlags & (UInt16)RelatedTypeViaIATFlag) != 0); }
 
-    // PREFER: get_ParameterizedTypeShape() >= SZARRAY_BASE_SIZE
     bool IsArray()
-        { return IsParameterizedType() && get_ParameterizedTypeShape() > 1 /* ParameterizedTypeShapeConstants.ByRef */; }
+    {
+        EETypeElementType elementType = GetElementType();
+        return elementType == ElementType_Array || elementType == ElementType_SzArray;
+    }
 
     bool IsParameterizedType()
         { return (get_Kind() == ParameterizedEEType); }
@@ -406,7 +406,7 @@ public:
         { return get_Kind() == CanonicalEEType; }
 
     bool IsInterface()
-        { return ((m_usFlags & (UInt16)IsInterfaceFlag) != 0); }
+        { return GetElementType() == ElementType_Interface; }
 
     EEType * get_CanonicalEEType();
 
@@ -420,7 +420,7 @@ public:
     UInt32 get_ParameterizedTypeShape() { return m_uBaseSize; }
 
     bool get_IsValueType()
-        { return ((m_usFlags & (UInt16)ValueTypeFlag) != 0); }
+        { return GetElementType() < ElementType_Class; }
 
     bool HasFinalizer()
     {

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -221,11 +221,7 @@ namespace Internal.Runtime.TypeLoader
                 {
                     flags = (ushort)EETypeKind.GenericTypeDefEEType;
                     isValueType = state.TypeBeingBuilt.IsValueType;
-                    if (isValueType)
-                        flags |= (ushort)EETypeFlags.ValueTypeFlag;
-
-                    if (state.TypeBeingBuilt.IsInterface)
-                        flags |= (ushort)EETypeFlags.IsInterfaceFlag;
+                    flags = EETypeBuilderHelpers.ComputeFlags(state.TypeBeingBuilt);
                     hasFinalizer = false;
                     isArray = false;
                     isNullable = false;
@@ -1048,6 +1044,9 @@ namespace Internal.Runtime.TypeLoader
             state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->RelatedParameterType = pointeeTypeHandle.ToEETypePtr();
 
             // We used a pointer as a template. We need to make this a byref.
+            Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ElementType == EETypeElementType.Pointer);
+            state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->Flags = EETypeBuilderHelpers.ComputeFlags(byRefType);
+            Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ElementType == EETypeElementType.ByRef);
             Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ParameterizedTypeShape == ParameterizedTypeShapeConstants.Pointer);
             state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ParameterizedTypeShape = ParameterizedTypeShapeConstants.ByRef;
 
@@ -1071,7 +1070,7 @@ namespace Internal.Runtime.TypeLoader
                 Debug.Assert(IntPtr.Zero == state.GcStaticDesc);
                 Debug.Assert(IntPtr.Zero == state.ThreadStaticDesc);
 
-                // Pointers and ByRefs only differ by the ParameterizedTypeShape value.
+                // Pointers and ByRefs only differ by the ParameterizedTypeShape and ElementType value.
                 RuntimeTypeHandle templateTypeHandle = typeof(void*).TypeHandle;
 
                 pTemplateEEType = templateTypeHandle.ToEETypePtr();

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -1383,8 +1383,14 @@ namespace Internal.Runtime.TypeLoader
                     state.HalfBakedRuntimeTypeHandle.SetRelatedParameterType(GetRuntimeTypeHandle(((ByRefType)type).ParameterType));
 
                     // We used a pointer type for the template because they're similar enough. Adjust this to be a ByRef.
-                    unsafe { Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ParameterizedTypeShape == ParameterizedTypeShapeConstants.Pointer); }
-                    state.HalfBakedRuntimeTypeHandle.SetParameterizedTypeShape(ParameterizedTypeShapeConstants.ByRef);
+                    unsafe
+                    {
+                        Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ParameterizedTypeShape == ParameterizedTypeShapeConstants.Pointer);
+                        state.HalfBakedRuntimeTypeHandle.SetParameterizedTypeShape(ParameterizedTypeShapeConstants.ByRef);
+                        Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ElementType == EETypeElementType.Pointer);
+                        state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->Flags = EETypeBuilderHelpers.ComputeFlags(type);
+                        Debug.Assert(state.HalfBakedRuntimeTypeHandle.ToEETypePtr()->ElementType == EETypeElementType.ByRef);
+                    }
                 }
             }
             else


### PR DESCRIPTION
After #8004, some information in EEType was duplicated. This frees up two bits in the main flags, and makes a couple checks easier.

I'm keeping the ParameterizedTypeShape concept because it makes casting Sz/Md arrays easier.