### PR TITLE
Hopefully this will break,

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "native-tools": {
     "cmake": "3.14.2",
-    "python": "2.7.15"
+    "python": "3.7.3"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19115.1",

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "native-tools": {
     "cmake": "3.14.2",
-    "python": "3.7.3"
+    "python3": "3.7.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19115.1",

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -466,7 +466,7 @@ goto :eof
         )
         call %CoreRT_TestRoot%\CoreCLR\build-and-run-test.cmd !TestFolderName! !TestFileName!
     ) else (
-        set __RunTestCommand=python runtest.py -arch %CoreRT_BuildArch% -build_type %CoreRT_BuildType% -test_native_bin_location !CoreRT_TestExtRepo_CoreCLR! -test_location %CoreRT_TestRoot%\CoreCLR -core_root !CoreRT_TestExtRepo_CoreCLR!\Tests\Core_Root -coreclr_repo_location %CoreRT_TestRoot%.. %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile%
+        set __RunTestCommand=python3 runtest.py -arch %CoreRT_BuildArch% -build_type %CoreRT_BuildType% -test_native_bin_location !CoreRT_TestExtRepo_CoreCLR! -test_location %CoreRT_TestRoot%\CoreCLR -core_root !CoreRT_TestExtRepo_CoreCLR!\Tests\Core_Root -coreclr_repo_location %CoreRT_TestRoot%.. %CoreCLRExcludeText% %CoreRT_CoreCLRTargetsFile%
         if not "%CoreRT_GCStressLevel%" == "" ( set __RunTestCommand=!__RunTestCommand! gcstresslevel !CoreRT_GCStressLevel! )
         echo !__RunTestCommand!
         call !__RunTestCommand!


### PR DESCRIPTION
since it will be aligned with my observations regarding Python code
submitted in #8021 and confirmed by @yowl I belive that currently
running tests is broken, and need more proof for my hypothesis.

Also 3.7.3 is last version in `netcorenativeassets` container,
but `dotnet/runtime` state that 3.7.4 is required.
Maybe at least 3.7.4 should be uploaded to be aligned
with dotnet/runtime
And last request, if this fails, can I submit PR to dotnet/runtime?
since most likely it is broken there as well.