### PR TITLE
Do not overwrite metadataGenerationOptions

### DIFF
--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -496,7 +496,7 @@ namespace ILCompiler
                     ? new FrameworkStringResourceBlockingPolicy()
                     : (ManifestResourceBlockingPolicy)new NoManifestResourceBlockingPolicy();
 
-                metadataGenerationOptions = UsageBasedMetadataGenerationOptions.AnonymousTypeHeuristic;
+                metadataGenerationOptions |= UsageBasedMetadataGenerationOptions.AnonymousTypeHeuristic;
                 if (_completeTypesMetadata)
                     metadataGenerationOptions |= UsageBasedMetadataGenerationOptions.CompleteTypesOnly;
                 if (_scanReflection)

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -746,6 +746,12 @@ namespace PInvokeTests
             public int f3;
         }
 
+        [StructLayout(LayoutKind.Sequential)]
+        public class ClassForTestingFlowAnalysis
+        {
+            public int Field;
+        }
+
         private static void TestStruct()
         {
             Console.WriteLine("Testing Structs");
@@ -983,6 +989,9 @@ namespace PInvokeTests
             {
                 Marshal.FreeHGlobal(nbc_memory);
             }
+
+            int cftf_size = Marshal.SizeOf(typeof(ClassForTestingFlowAnalysis));
+            ThrowIfNotEquals(4, cftf_size, "ClassForTestingFlowAnalysis marshalling Marshal API failed");
         }
     }
 


### PR DESCRIPTION
Plus test coverage.

Fixes the issue reported in #7995.