### PR TITLE
Delete unnecessary native runtime EEType knowledge

### DIFF
--- a/src/Native/Runtime/inc/rhbinder.h
+++ b/src/Native/Runtime/inc/rhbinder.h
@@ -585,16 +585,6 @@ struct EETypeRef
     }
 };
 
-// Generic type parameter variance type (these are allowed only on generic interfaces or delegates). The type
-// values must correspond to those defined in the CLR as CorGenericParamAttr (see corhdr.h).
-enum GenericVarianceType : UInt8
-{
-    GVT_NonVariant = 0,
-    GVT_Covariant = 1,
-    GVT_Contravariant = 2,
-    GVT_ArrayCovariant = 0x20,
-};
-
 // Blobs are opaque data passed from the compiler, through the binder and into the native image. At runtime we
 // provide a simple API to retrieve these blobs (they're keyed by a simple integer ID). Blobs are passed to
 // the binder from the compiler and stored in native images by the binder in a sequential stream, each blob


### PR DESCRIPTION
EEType knowledge is triplicated in the compiler, EEType.cs, and the native runtime. The fewer places know about it, the easier it is to maintain/audit.

I think it would be ideal if the native runtime only knows about the fields that are common to all EETypes and doesn't know about optional fields/rare flags stuff.

There is one last spot accessing the EEType optional fields/RareFlags data structure after this - the Align8 rare flag. I'm wondering whether we should just expose an `RhIsAlign8` method out of the managed runtime for the native runtime to call.