### PR TITLE
Move IsDynamicType flag out of rare flags

### DIFF
--- a/src/Common/src/Internal/Runtime/EEType.Constants.cs
+++ b/src/Common/src/Internal/Runtime/EEType.Constants.cs
@@ -27,7 +27,10 @@ namespace Internal.Runtime
         /// </summary>
         RelatedTypeViaIATFlag = 0x0004,
 
-        // Unused = 0x0008,
+        /// <summary>
+        /// This type was dynamically allocated at runtime.
+        /// </summary>
+        IsDynamicTypeFlag = 0x0008,
 
         /// <summary>
         /// This EEType represents a type which requires finalization.
@@ -118,10 +121,7 @@ namespace Internal.Runtime
 
         // UNUSED = 0x00000008,
 
-        /// <summary>
-        /// This EEType was created by generic instantiation loader
-        /// </summary>
-        IsDynamicTypeFlag = 0x00000010,
+        // UNUSED = 0x00000010,
 
         /// <summary>
         /// This EEType has a Class Constructor

--- a/src/Common/src/Internal/Runtime/EEType.cs
+++ b/src/Common/src/Internal/Runtime/EEType.cs
@@ -585,7 +585,7 @@ namespace Internal.Runtime
         {
             get
             {
-                return (RareFlags & EETypeRareFlags.IsDynamicTypeFlag) != 0;
+                return (_usFlags & (ushort)EETypeFlags.IsDynamicTypeFlag) != 0;
             }
         }
 
@@ -1349,7 +1349,7 @@ namespace Internal.Runtime
             }
             if (IsGeneric)
             {
-                if ((rareFlags & EETypeRareFlags.IsDynamicTypeFlag) != 0 || !SupportsRelativePointers)
+                if (IsDynamicType || !SupportsRelativePointers)
                     cbOffset += (uint)IntPtr.Size;
                 else
                     cbOffset += 4;
@@ -1362,7 +1362,7 @@ namespace Internal.Runtime
             }
             if (IsGeneric)
             {
-                if ((rareFlags & EETypeRareFlags.IsDynamicTypeFlag) != 0 || !SupportsRelativePointers)
+                if (IsDynamicType || !SupportsRelativePointers)
                     cbOffset += (uint)IntPtr.Size;
                 else
                     cbOffset += 4;

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -159,7 +159,7 @@ private:
         // through m_pRelatedType to get to the related type in the other module.
         RelatedTypeViaIATFlag   = 0x0004,
 
-        // Unused           = 0x0008,
+        IsDynamicTypeFlag       = 0x0008,
 
         // This EEType represents a type which requires finalization
         HasFinalizerFlag        = 0x0010,
@@ -203,8 +203,7 @@ public:
 
         // unused               = 0x00000008,
 
-        // This EEType was created by dynamic type loader
-        IsDynamicTypeFlag       = 0x00000010,
+        // unused               = 0x00000010,
 
         // This EEType has a Class Constructor
         HasCctorFlag            = 0x0000020,
@@ -396,7 +395,7 @@ public:
 
     // Determine whether a type was created by dynamic type loader
     bool IsDynamicType()
-        { return (get_RareFlags() & IsDynamicTypeFlag) != 0; }
+        { return (m_usFlags & IsDynamicTypeFlag) != 0; }
 
     UInt32 GetHashCode();
 

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -258,6 +258,8 @@ namespace Internal.Runtime.TypeLoader
                     }
                 }
 
+                flags |= (ushort)EETypeFlags.IsDynamicTypeFlag;
+
                 // TODO! Change to if template is Universal or non-Existent
                 if (state.TypeSize.HasValue)
                 {
@@ -300,7 +302,6 @@ namespace Internal.Runtime.TypeLoader
                     optionalFields = new OptionalFieldsRuntimeBuilder(pTemplateEEType != null ? pTemplateEEType->OptionalFieldsPtr : null);
 
                     UInt32 rareFlags = optionalFields.GetFieldValue(EETypeOptionalFieldTag.RareFlags, 0);
-                    rareFlags |= (uint)EETypeRareFlags.IsDynamicTypeFlag;          // Set the IsDynamicTypeFlag
 
                     if (state.NumSealedVTableEntries > 0)
                         rareFlags |= (uint)EETypeRareFlags.HasSealedVTableEntriesFlag;


### PR DESCRIPTION
Some parts of the EEType (sealed vtable pointer, generic composition) are stored as relative pointers, unless the type is dynamic (or we are on a platform that doesn't support relative pointers), in which case they're stored as a full pointer.

We can do the same things to a couple other rarely needed pointers (type manager, finalizer, optional fields), but since IsDynamicType is stored in rare flags, we can't because by the time we can read rare flags we already had to skip these fields.

Moving IsDynamicType to the main flags lets us accomplish this.