### PR TITLE
Wrap LINQ object array delegate thunk in a try/finally

### DIFF
--- a/tests/src/Simple/Delegates/Delegates.cs
+++ b/tests/src/Simple/Delegates/Delegates.cs
@@ -52,7 +52,9 @@ public class BringUpTests
             result = Fail;
         }
 
+#if !CODEGEN_CPP
         TestLinqExpressions.Run();
+#endif
 
         return result;
     }


### PR DESCRIPTION
This ensures we copy back byref args. It wasn't possible when this code was originally witten because the IL generator couldn't generate finallys.

Closes #2910.