### PR TITLE
WASM: remove assert for old version of emscripten for 64 bit interlocked exchange

### DIFF
--- a/src/Native/Runtime/unix/PalRedhawkInline.h
+++ b/src/Native/Runtime/unix/PalRedhawkInline.h
@@ -43,11 +43,7 @@ FORCEINLINE Int32 PalInterlockedCompareExchange(_Inout_ _Interlocked_operand_ In
 
 FORCEINLINE Int64 PalInterlockedCompareExchange64(_Inout_ _Interlocked_operand_ Int64 volatile *pDst, Int64 iValue, Int64 iComparand)
 {
-#if defined(_WASM_)
-    PORTABILITY_ASSERT("Emscripten does not support 64-bit atomics until version 1.37.33");
-#else // _WASM_
     return __sync_val_compare_and_swap(pDst, iComparand, iValue);
-#endif // _WASM_
 }
 
 #if defined(_AMD64_) || defined(_ARM64_)

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -331,6 +331,8 @@ internal static class Program
 
         TestImplicitUShortToUInt();
 
+        TestInterlockedExchange();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -362,8 +364,6 @@ internal static class Program
         // use array of size 1MB, then iterate 5*1024 times
         for(var i = 0; i < 5 * 1024; i++)
         {
-            PrintString("i is ");
-            PrintLine(i.ToString());
             var a = new int[256 * 1024]; // ints are 4 bytes so this is 1MB
         }
         for(var i = 0; i < 3; i++)
@@ -1395,6 +1395,17 @@ internal static class Program
         uint start;
         start = ReadUInt16();
         EndTest(start == 0x0000828f);
+    }
+
+    static void TestInterlockedExchange()
+    {
+        StartTest("InterlockedExchange");
+        int exInt1 = 1;
+        Interlocked.Exchange(ref exInt1, 2);
+
+        long exLong1 = 1;
+        Interlocked.Exchange(ref exLong1, 3);
+        EndTest(exInt1 == 2 && exLong1 == 3);
     }
 
     static ushort ReadUInt16()


### PR DESCRIPTION
We've moved on to a version of emscripten that now supports 64 bit interlocked exchange, and while we don't have threads yet, this assert can be removed.
Added a test for int and long which used to fail and now passes.

Also removed a bit of GC debug printf that just slowed down the testing.