### PR TITLE
Add support for generating the bss section

### DIFF
--- a/src/Native/ObjWriter/objwriter.cpp
+++ b/src/Native/ObjWriter/objwriter.cpp
@@ -217,6 +217,8 @@ MCSection *ObjectWriter::GetSection(const char *SectionName,
     Section = ObjFileInfo->getReadOnlySection();
   } else if (strcmp(SectionName, "xdata") == 0) {
     Section = ObjFileInfo->getXDataSection();
+  } else if (strcmp(SectionName, "bss") == 0) {
+      Section = ObjFileInfo->getBSSSection();
   } else {
     Section = GetSpecificSection(SectionName, attributes, ComdatName);
   }


### PR DESCRIPTION
From Wikipedia: "BSS (from Block Started by Symbol) is a pseudo-operation in UA-SAP (United Aircraft Symbolic Assembly Program), the assembler developed in the mid-1950s for the IBM 704."

70 years later we still name the section of the executable that holds uninitialized data BSS.