### PR TITLE
Avoid placing finalizers in the vtable

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -762,6 +762,11 @@ namespace ILCompiler.DependencyAnalysis
             {
                 MethodDesc declMethod = virtualSlots[i];
 
+                // Object.Finalize shouldn't get a virtual slot. Finalizer is stored in an optional field
+                // instead: most EEType don't have a finalizer, but all EETypes contain Object's vtable.
+                // This lets us save a pointer (+reloc) on most EETypes.
+                Debug.Assert(!declType.IsObject || declMethod.Name != "Finalize");
+
                 // No generic virtual methods can appear in the vtable!
                 Debug.Assert(!declMethod.HasInstantiation);
 

--- a/src/ILCompiler.Compiler/src/Compiler/RootingHelpers.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/RootingHelpers.cs
@@ -48,8 +48,16 @@ namespace ILCompiler
 
             if (type.IsDefType)
             {
+                bool hasFinalizer = type.HasFinalizer || type.IsObject;
+
                 foreach (var method in type.GetMethods())
                 {
+                    // We don't root finalizers because they're not directly callable and they will get
+                    // generated if needed. We also need to prevent a VirtualMethodUse of Object::Finalize
+                    // from entering the system.
+                    if (hasFinalizer && method.IsFinalizer)
+                        continue;
+
                     if (method.HasInstantiation)
                     {
                         // Generic methods on generic types could end up as Foo<object>.Bar<__Canon>(),


### PR DESCRIPTION
Reflection rooting could sometimes make it so that `Object.Finalize` got a vtable slot. Saves 27 kB on a Hello World (with the default settings that reflection-root all user code).