### PR TITLE
Add Dockerfile for building Wasm in Debian 10 Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+#Start from a slimmed down image of Debian 10 (Buster)
+FROM debian:buster-slim AS LLVM9
+
+#Install LLVM 9 so we can get libLLVM.so version 9 for Debian Buster
+RUN apt-get update && apt-get -y install wget gnupg && \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add - && \
+    printf "\ndeb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main\ndeb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main\n" >> /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && apt-get -y install -t llvm-toolchain-buster-9 clang-tools-9
+
+
+#************************************************************************
+#************************************************************************
+
+
+#Start again from a slimmed down image of Debian 10 (Buster)
+#This is the container we'll use to build CoreRT for wasm.
+FROM debian:buster-slim
+
+#Install prerequisites for ILC and Emscripten
+RUN apt-get update && apt-get -y install cmake clang libicu-dev uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev libtinfo5 git python2.7 wget
+
+#Copy libLLVM.so version 9 from LLVM9 image that we made above
+#This is needed by ILC Wasm - but since otherwise the build runs smoother with the clang 7
+#which is the default version on Debian Buster, we don't want to overwrite the whole installation of llvm to v9.
+COPY --from=LLVM9 /usr/lib/llvm-9/lib/libLLVM.so /usr/lib/libLLVM.so
+
+#Use /d as a basis for our installation (development dir)
+WORKDIR /d
+
+#Install Emscripten version 1.39.12 into /d/emsdk
+RUN git clone https://github.com/emscripten-core/emsdk.git --depth=1 --branch=1.39.12 && \
+    cd emsdk && \
+    ./emsdk install latest && \
+    ./emsdk activate latest
+
+#Copy corert files into /d/corert
+WORKDIR /d/corert
+COPY . .
+
+#Use bash (not sh) for these scripts
+SHELL ["/bin/bash", "-c"]
+
+#Compile CoreRT/ILC for Wasm:
+RUN cd /d/emsdk && . ./emsdk_env.sh && \
+    export EMSCRIPTEN=/d/emsdk/upstream/emscripten && \
+    export CppCompilerAndLinker=clang-7 && \
+    export PATH=$PATH:/usr/lib/llvm-7/bin && \
+    cd /d/corert && ./build.sh wasm
+
+CMD ["/bin/bash"]

--- a/samples/HelloWasm/Dockerfile
+++ b/samples/HelloWasm/Dockerfile
@@ -1,0 +1,11 @@
+FROM corert/wasm AS corertwasmbuild
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS sdk
+
+COPY --from=corertwasmbuild /d/corert/bin/WebAssembly.wasm.Debug /ILC
+
+WORKDIR /d
+COPY . .
+
+RUN export IlcPath=/ILC && \
+    dotnet publish -r wasm

--- a/samples/HelloWasm/HelloWasm.csproj
+++ b/samples/HelloWasm/HelloWasm.csproj
@@ -1,0 +1,12 @@
+<Project>
+  <Import Project="$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildSDKsPath)\Microsoft.NET.Sdk\Sdk\Sdk.targets" />
+  <Import Project="$(IlcPath)\build\Microsoft.NETCore.Native.targets" />
+
+</Project>

--- a/samples/HelloWasm/Program.cs
+++ b/samples/HelloWasm/Program.cs
@@ -44,4 +44,7 @@ internal static class Program
         PrintString("\n");
     }
 
+    [DllImport("*")]
+    private static unsafe extern int printf(byte* str, byte* unused);
+
 }

--- a/samples/HelloWasm/Program.cs
+++ b/samples/HelloWasm/Program.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using System.Reflection;
+
+internal static class Program
+{
+
+    public struct TwoByteStr
+    {
+        public byte first;
+        public byte second;
+    }
+
+    private static unsafe int Main(string[] args)
+    {
+        PrintLine("Starting " + 1);
+
+        return 100;
+    }
+
+    private static unsafe void PrintString(string s)
+    {
+        int length = s.Length;
+        fixed (char* curChar = s)
+        {
+            for (int i = 0; i < length; i++)
+            {
+                TwoByteStr curCharStr = new TwoByteStr();
+                curCharStr.first = (byte)(*(curChar + i));
+                printf((byte*)&curCharStr, null);
+            }
+        }
+    }
+
+    public static void PrintLine(string s)
+    {
+        PrintString(s);
+        PrintString("\n");
+    }
+
+}

--- a/samples/HelloWasm/Program.cs
+++ b/samples/HelloWasm/Program.cs
@@ -19,7 +19,7 @@ internal static class Program
 
     private static unsafe int Main(string[] args)
     {
-        PrintLine("Starting " + 1);
+        PrintLine("Hello Wasm World");
 
         return 100;
     }

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -313,7 +313,7 @@ See the LICENSE file in the project root for more information.
     
     <PropertyGroup>
       <EmccArgs>&quot;$(NativeObject)&quot; -o &quot;$(NativeBinary)&quot; -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 --emrun </EmccArgs>
-      <EmccArgs Condition="'$(Platform)'=='wasm'">$(EmccArgs) &quot;$(IlcPath)/sdk/libPortableRuntime.a&quot; &quot;$(IlcPath)/sdk/libbootstrappercpp.a&quot; &quot;$(IlcPath)/sdk/libSystem.Private.CoreLib.Native.a&quot; </EmccArgs>
+      <EmccArgs Condition="'$(Platform)'=='wasm'">$(EmccArgs) &quot;$(IlcPath)/sdk/libPortableRuntime.bc&quot; &quot;$(IlcPath)/sdk/libbootstrappercpp.bc&quot; &quot;$(IlcPath)/sdk/libSystem.Private.CoreLib.Native.bc&quot; </EmccArgs>
       <EmccArgs Condition="'$(Configuration)'=='Release'">$(EmccArgs) -O2 --llvm-lto 2</EmccArgs>
       <EmccArgs Condition="'$(Configuration)'=='Debug'">$(EmccArgs) -g3</EmccArgs>
     </PropertyGroup>

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -44,12 +44,14 @@ internal static class Program
         (*targetAddr) = 1;
         EndTest(tempInt2 == 1 && tempInt == 9);
 
+#if TARGET_WINDOWS
         StartTest("Inline assign byte Test");
         EndTest(ILHelpers.ILHelpersTest.InlineAssignByte() == 100);
 
         StartTest("dup test");
         int dupTestInt = 9;
         EndTest(ILHelpers.ILHelpersTest.DupTest(ref dupTestInt) == 209 && dupTestInt == 209);
+#endif
 
         TestClass tempObj = new TestDerivedClass(1337);
         tempObj.TestMethod("Hello");
@@ -274,6 +276,7 @@ internal static class Program
 
         TestTryFinally();
 
+#if TARGET_WINDOWS
         StartTest("RVA static field test");
         int rvaFieldValue = ILHelpers.ILHelpersTest.StaticInitedInt;
         if (rvaFieldValue == 0x78563412)
@@ -284,6 +287,7 @@ internal static class Program
         {
             FailTest(rvaFieldValue.ToString());
         }
+#endif
 
         TestNativeCallback();
 


### PR DESCRIPTION
Since I saw the work in https://github.com/dotnet/corert/pull/8082 I thought it would be interesting to see if the Wasm leg could be built in Docker.

Based on this we could make it possible for people to have fully self-contained Wasm examples that run with no dependencies on anything but Docker. I think that would be a nice alternative vs having to set up Emscripten etc.

Here's an attempt at that. Right now it works with a Dockerfile in the root of corert.
We could then use that image as a basis for a .NET Sdk based image where we copy over the ILC binaries/output dir. This again could be used in a self-contained example as mentioned, which will then build cross-plat with little to no setup. I think that would lower the burden of entry into testing the Wasm stuff.

I had to ugly hack src/BuildIntegration/Microsoft.NETCore.Native.targets to accept ".bc" bitcode files from Emscripten em++, since for some reason it doesn't produce the ".a" files expected. They work though. `em++` says while building the portable runtime:
```
em++: warning: Assuming object file output in the absence of `-c`, based on output filename. Add with `-c` or `-r` to avoid this warning [-Wemcc]
```

I also had to put an if-def around the calls to `ILHelpers` in HelloWasm since those are only built on Windows it appears.

Let me know if this could be of interest, or if it's better suited to have in an external repo where we just pull in the corert source code instead of hosting the Dockerfile directly here.