### PR TITLE
Restore application manifest in dependency graph viewer

### DIFF
--- a/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/ILCompiler-DependencyGraph-Viewer.csproj
+++ b/src/ILCompiler.DependencyAnalysisFramework/ILCompiler-DependencyGraph-Viewer/ILCompiler-DependencyGraph-Viewer.csproj
@@ -7,6 +7,8 @@
 
     <RootNamespace>DependencyLogViewer</RootNamespace>
     <AssemblyName>ILCompiler-DependencyGraph-Viewer</AssemblyName>
+
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This line got lost in #7958. Makes the dependency viewer auto-prompt for elevation.