### PR TITLE
Wasm: Do not build wasm when running `build`

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -176,7 +176,7 @@ for /f "delims=" %%a in ('dir /s /aD /b %CoreRT_TestRoot%\src\%CoreRT_TestName%'
                     set /a __CppTotalTests=!__CppTotalTests!+1
                 )
             )
-            if /i not "%CoreRT_TestCompileMode%" == "cpp" (
+            if /i "%CoreRT_TestCompileMode%" == "wasm" (
                 if exist "!__SourceFolder!\wasm" (
                     set __Mode=wasm
                     call :CompileFile !__SourceFolder! !__SourceFileName! !__SourceFileProj! %__LogDir%\!__RelativePath!

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -314,8 +314,6 @@ goto :eof
         set __Extension=exe
 
         if /i "%__Mode%"=="wasm" (
-            REM Skip running if this is WASM build-only testing running in a different architecture's build
-            if /i not "%CoreRT_BuildArch%"=="wasm" (goto :RecordTestResult)
             set __Extension=js
         )
 


### PR DESCRIPTION
Following on from https://github.com/dotnet/corert/pull/7137#discussion_r408403714 this PR removes the building of the wasm enabled test projects, Generics and HelloWorld, when running `build`.