### PR TITLE
Speed up typeof(Foo) and Object.GetType by 50+%

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <RyuJITVersion Condition="'$(RyuJITVersion)' == ''">5.0.0-preview.4.20205.13</RyuJITVersion>
-    <ObjectWriterVersion Condition="'$(ObjectWriterVersion)' == ''">1.0.0-alpha-28810-03</ObjectWriterVersion>
+    <ObjectWriterVersion Condition="'$(ObjectWriterVersion)' == ''">1.0.0-alpha-28820-01</ObjectWriterVersion>
     <RuntimeLibrariesVersion Condition="'$(RuntimeLibrariesVersion)' == ''">5.0.0-preview.2.20153.3</RuntimeLibrariesVersion>
     <CoreFxUapVersion Condition="'$(CoreFxUapVersion)' == ''">4.7.0-preview6.19265.2</CoreFxUapVersion>
     <MicrosoftNETCoreAppPackageVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)' == ''">2.1.14</MicrosoftNETCoreAppPackageVersion>

--- a/dependencies.props
+++ b/dependencies.props
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <RyuJITVersion Condition="'$(RyuJITVersion)' == ''">5.0.0-preview.4.20205.13</RyuJITVersion>
-    <ObjectWriterVersion Condition="'$(ObjectWriterVersion)' == ''">1.0.0-alpha-28204-03</ObjectWriterVersion>
+    <ObjectWriterVersion Condition="'$(ObjectWriterVersion)' == ''">1.0.0-alpha-28810-03</ObjectWriterVersion>
     <RuntimeLibrariesVersion Condition="'$(RuntimeLibrariesVersion)' == ''">5.0.0-preview.2.20153.3</RuntimeLibrariesVersion>
     <CoreFxUapVersion Condition="'$(CoreFxUapVersion)' == ''">4.7.0-preview6.19265.2</CoreFxUapVersion>
     <MicrosoftNETCoreAppPackageVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)' == ''">2.1.14</MicrosoftNETCoreAppPackageVersion>

--- a/src/Common/src/Internal/Runtime/EEType.Constants.cs
+++ b/src/Common/src/Internal/Runtime/EEType.Constants.cs
@@ -184,6 +184,7 @@ namespace Internal.Runtime
     {
         ETF_InterfaceMap,
         ETF_TypeManagerIndirection,
+        ETF_WritableData,
         ETF_Finalizer,
         ETF_OptionalFieldsPtr,
         ETF_SealedVirtualSlots,
@@ -295,5 +296,11 @@ namespace Internal.Runtime
     internal static class StringComponentSize
     {
         public const int Value = sizeof(char);
+    }
+
+    internal static class WritableData
+    {
+        public static int GetSize(int pointerSize) => pointerSize;
+        public static int GetAlignment(int pointerSize) => pointerSize;
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/GenericDefinitionEETypeNode.cs
@@ -64,6 +64,7 @@ namespace ILCompiler.DependencyAnalysis
             dataBuilder.EmitShort(0);       // No interface map
             dataBuilder.EmitInt(_type.GetHashCode());
             OutputTypeManagerIndirection(factory, ref dataBuilder);
+            OutputWritableData(factory, ref dataBuilder);
             OutputOptionalFields(factory, ref dataBuilder);
 
             return dataBuilder.ToObjectData();

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ObjectNodeSection.cs
@@ -39,16 +39,17 @@ namespace ILCompiler.DependencyAnalysis
         {
             get
             {
-                return this == DataSection || this == ReadOnlyDataSection || this == FoldableReadOnlyDataSection || this == TextSection || this == XDataSection;
+                return this == DataSection || this == ReadOnlyDataSection || this == FoldableReadOnlyDataSection || this == TextSection || this == XDataSection || this == BssSection;
             }
         }
                
         public static readonly ObjectNodeSection XDataSection = new ObjectNodeSection("xdata", SectionType.ReadOnly);
         public static readonly ObjectNodeSection DataSection = new ObjectNodeSection("data", SectionType.Writeable);
         public static readonly ObjectNodeSection ReadOnlyDataSection = new ObjectNodeSection("rdata", SectionType.ReadOnly);
-        public static readonly ObjectNodeSection FoldableReadOnlyDataSection = new ObjectNodeSection("rdata$F", SectionType.ReadOnly);
+        public static readonly ObjectNodeSection FoldableReadOnlyDataSection = new ObjectNodeSection("rdata", SectionType.ReadOnly);
         public static readonly ObjectNodeSection TextSection = new ObjectNodeSection("text", SectionType.Executable);
         public static readonly ObjectNodeSection TLSSection = new ObjectNodeSection("TLS", SectionType.Writeable);
+        public static readonly ObjectNodeSection BssSection = new ObjectNodeSection("bss", SectionType.Writeable);
         public static readonly ObjectNodeSection ManagedCodeWindowsContentSection = new ObjectNodeSection(".managedcode$I", SectionType.Executable);
         public static readonly ObjectNodeSection FoldableManagedCodeWindowsContentSection = new ObjectNodeSection(".managedcode$I", SectionType.Executable);
         public static readonly ObjectNodeSection ManagedCodeUnixContentSection = new ObjectNodeSection("__managedcode", SectionType.Executable);

--- a/src/Native/Runtime/inc/eetype.h
+++ b/src/Native/Runtime/inc/eetype.h
@@ -16,6 +16,10 @@ struct TypeManagerHandle;
 class DynamicModule;
 struct EETypeRef;
 
+#if !defined(USE_PORTABLE_HELPERS)
+#define SUPPORTS_WRITABLE_DATA 1
+#endif
+
 //-------------------------------------------------------------------------------------------------
 // Array of these represents the interfaces implemented by a type
 
@@ -86,6 +90,7 @@ enum EETypeField
 {
     ETF_InterfaceMap,
     ETF_TypeManagerIndirection,
+    ETF_WritableData,
     ETF_Finalizer,
     ETF_OptionalFieldsPtr,
     ETF_SealedVirtualSlots,

--- a/src/Native/Runtime/inc/eetype.inl
+++ b/src/Native/Runtime/inc/eetype.inl
@@ -165,6 +165,15 @@ __forceinline UInt32 EEType::GetFieldOffset(EETypeField eField)
     }
     cbOffset += relativeOrFullPointerOffset;
 
+#if SUPPORTS_WRITABLE_DATA
+    // Followed by writable data.
+    if (eField == ETF_WritableData)
+    {
+        return cbOffset;
+    }
+    cbOffset += relativeOrFullPointerOffset;
+#endif
+
     // Followed by the pointer to the finalizer method.
     if (eField == ETF_Finalizer)
     {

--- a/src/System.Private.CoreLib/shared/System/Nullable.cs
+++ b/src/System.Private.CoreLib/shared/System/Nullable.cs
@@ -111,7 +111,7 @@ namespace System
                 {
                     if (nullableEEType.IsNullable)
                     {
-                        return Internal.Reflection.Core.NonPortable.RuntimeTypeUnifier.GetRuntimeTypeForEEType(nullableEEType.NullableType);
+                        return Type.GetTypeFromEETypePtr(nullableEEType.NullableType);
                     }
                 }
                 return null;

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeTypeUnifier.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeTypeUnifier.cs
@@ -47,7 +47,7 @@ namespace Internal.Reflection.Core.NonPortable
         {
             // If writable data is supported, we shouldn't be using the hashtable - the runtime type
             // is accessible through a couple indirections from the EETypePtr which is much faster.
-            Debug.Assert(Internal.Runtime.EEType.SupportsWritableData);
+            Debug.Assert(!Internal.Runtime.EEType.SupportsWritableData);
             return RuntimeTypeHandleToTypeCache.Table.GetOrAdd(eeType.RawValue);
         }
 
@@ -78,10 +78,6 @@ namespace Internal.Reflection.Core.NonPortable
         public static Type GetRuntimeTypeBypassCache(EETypePtr eeType)
         {
             RuntimeTypeHandle runtimeTypeHandle = new RuntimeTypeHandle(eeType);
-
-            // Desktop compat: Allows Type.GetTypeFromHandle(default(RuntimeTypeHandle)) to map to null.
-            if (runtimeTypeHandle.IsNull)
-                return null;
 
             ReflectionExecutionDomainCallbacks callbacks = RuntimeAugments.Callbacks;
 

--- a/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeTypeUnifier.cs
+++ b/src/System.Private.CoreLib/src/Internal/Reflection/Core/NonPortable/RuntimeTypeUnifier.cs
@@ -43,11 +43,13 @@ namespace Internal.Reflection.Core.NonPortable
         //
         // Retrieves the unified Type object for given RuntimeTypeHandle (this is basically the Type.GetTypeFromHandle() api without the input validation.)
         //
-        public static Type GetTypeForRuntimeTypeHandle(RuntimeTypeHandle runtimeTypeHandle)
-            => RuntimeTypeHandleToTypeCache.Table.GetOrAdd(runtimeTypeHandle.RawValue);
-
         internal static Type GetRuntimeTypeForEEType(EETypePtr eeType)
-            => RuntimeTypeHandleToTypeCache.Table.GetOrAdd(eeType.RawValue);
+        {
+            // If writable data is supported, we shouldn't be using the hashtable - the runtime type
+            // is accessible through a couple indirections from the EETypePtr which is much faster.
+            Debug.Assert(Internal.Runtime.EEType.SupportsWritableData);
+            return RuntimeTypeHandleToTypeCache.Table.GetOrAdd(eeType.RawValue);
+        }
 
         //
         // TypeTable mapping raw RuntimeTypeHandles (normalized or otherwise) to Types.
@@ -65,51 +67,58 @@ namespace Internal.Reflection.Core.NonPortable
             protected sealed override Type Factory(IntPtr rawRuntimeTypeHandleKey)
             {
                 EETypePtr eeType = new EETypePtr(rawRuntimeTypeHandleKey);
-                RuntimeTypeHandle runtimeTypeHandle = new RuntimeTypeHandle(eeType);
-
-                // Desktop compat: Allows Type.GetTypeFromHandle(default(RuntimeTypeHandle)) to map to null.
-                if (runtimeTypeHandle.IsNull)
-                    return null;
-
-                ReflectionExecutionDomainCallbacks callbacks = RuntimeAugments.Callbacks;
-
-                if (eeType.IsDefType)
-                {
-                    if (eeType.IsGenericTypeDefinition)
-                    {
-                        return callbacks.GetNamedTypeForHandle(runtimeTypeHandle, isGenericTypeDefinition: true);
-                    }
-                    else if (eeType.IsGeneric)
-                    {
-                        return callbacks.GetConstructedGenericTypeForHandle(runtimeTypeHandle);
-                    }
-                    else
-                    {
-                        return callbacks.GetNamedTypeForHandle(runtimeTypeHandle, isGenericTypeDefinition: false);
-                    }
-                }
-                else if (eeType.IsArray)
-                {
-                    if (!eeType.IsSzArray)
-                        return callbacks.GetMdArrayTypeForHandle(runtimeTypeHandle, eeType.ArrayRank);
-                    else
-                        return callbacks.GetArrayTypeForHandle(runtimeTypeHandle);
-                }
-                else if (eeType.IsPointer)
-                {
-                    return callbacks.GetPointerTypeForHandle(runtimeTypeHandle);
-                }
-                else if (eeType.IsByRef)
-                {
-                    return callbacks.GetByRefTypeForHandle(runtimeTypeHandle);
-                }
-                else
-                {
-                    throw new ArgumentException(SR.Arg_InvalidRuntimeTypeHandle);
-                }
+                return GetRuntimeTypeBypassCache(eeType);
             }
 
             public static readonly RuntimeTypeHandleToTypeCache Table = new RuntimeTypeHandleToTypeCache();
+        }
+
+        // This bypasses the CoreLib's unifier, but there's another unifier deeper within the reflection stack:
+        // this code is safe to call without locking. See comment above.
+        public static Type GetRuntimeTypeBypassCache(EETypePtr eeType)
+        {
+            RuntimeTypeHandle runtimeTypeHandle = new RuntimeTypeHandle(eeType);
+
+            // Desktop compat: Allows Type.GetTypeFromHandle(default(RuntimeTypeHandle)) to map to null.
+            if (runtimeTypeHandle.IsNull)
+                return null;
+
+            ReflectionExecutionDomainCallbacks callbacks = RuntimeAugments.Callbacks;
+
+            if (eeType.IsDefType)
+            {
+                if (eeType.IsGenericTypeDefinition)
+                {
+                    return callbacks.GetNamedTypeForHandle(runtimeTypeHandle, isGenericTypeDefinition: true);
+                }
+                else if (eeType.IsGeneric)
+                {
+                    return callbacks.GetConstructedGenericTypeForHandle(runtimeTypeHandle);
+                }
+                else
+                {
+                    return callbacks.GetNamedTypeForHandle(runtimeTypeHandle, isGenericTypeDefinition: false);
+                }
+            }
+            else if (eeType.IsArray)
+            {
+                if (!eeType.IsSzArray)
+                    return callbacks.GetMdArrayTypeForHandle(runtimeTypeHandle, eeType.ArrayRank);
+                else
+                    return callbacks.GetArrayTypeForHandle(runtimeTypeHandle);
+            }
+            else if (eeType.IsPointer)
+            {
+                return callbacks.GetPointerTypeForHandle(runtimeTypeHandle);
+            }
+            else if (eeType.IsByRef)
+            {
+                return callbacks.GetByRefTypeForHandle(runtimeTypeHandle);
+            }
+            else
+            {
+                throw new ArgumentException(SR.Arg_InvalidRuntimeTypeHandle);
+            }
         }
     }
 }

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SynchronizedMethodHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SynchronizedMethodHelpers.cs
@@ -56,7 +56,7 @@ namespace Internal.Runtime.CompilerHelpers
 
         private static object GetStaticLockObject(IntPtr pEEType)
         {
-            return Internal.Reflection.Core.NonPortable.RuntimeTypeUnifier.GetRuntimeTypeForEEType(new System.EETypePtr(pEEType));
+            return Type.GetTypeFromEETypePtr(new EETypePtr(pEEType));
         }
     }
 }

--- a/src/System.Private.CoreLib/src/System/EETypePtr.cs
+++ b/src/System.Private.CoreLib/src/System/EETypePtr.cs
@@ -16,6 +16,8 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
+using Internal.Runtime.CompilerServices;
+
 using EEType = Internal.Runtime.EEType;
 using EETypeElementType = Internal.Runtime.EETypeElementType;
 using EETypeRef = Internal.Runtime.EETypeRef;
@@ -434,6 +436,12 @@ namespace System
             {
                 return RuntimeImports.GetRhCorElementTypeInfo(CorElementType);
             }
+        }
+
+        internal ref T GetWritableData<T>() where T : unmanaged
+        {
+            Debug.Assert(Internal.Runtime.WritableData.GetSize(IntPtr.Size) == sizeof(T));
+            return ref Unsafe.AsRef<T>((void*)_value->WritableData);
         }
 
         [Intrinsic]

--- a/src/System.Private.CoreLib/src/System/Object.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Object.CoreRT.cs
@@ -43,7 +43,7 @@ namespace System
         [Intrinsic]
         public Type GetType()
         {
-            return RuntimeTypeUnifier.GetRuntimeTypeForEEType(EETypePtr);
+            return Type.GetTypeFromEETypePtr(EETypePtr);
         }
 
         internal EETypePtr EETypePtr

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreRT.cs
@@ -301,7 +301,7 @@ namespace System.Runtime.CompilerServices
 
             if (eeTypePtr.IsNullable)
             {
-                return GetUninitializedObject(RuntimeTypeUnifier.GetRuntimeTypeForEEType(eeTypePtr.NullableType));
+                return GetUninitializedObject(Type.GetTypeFromEETypePtr(eeTypePtr.NullableType));
             }
 
             // Triggering the .cctor here is slightly different than desktop/CoreCLR, which 

--- a/src/System.Private.CoreLib/src/System/Type.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Type.CoreRT.cs
@@ -7,8 +7,10 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 using Internal.Runtime.Augments;
+using Internal.Runtime.CompilerServices;
 using Internal.Reflection.Augments;
 using Internal.Reflection.Core.NonPortable;
+using System.Runtime.InteropServices;
 
 namespace System
 {
@@ -17,7 +19,48 @@ namespace System
         public bool IsInterface => (GetAttributeFlagsImpl() & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface;
 
         [Intrinsic]
-        public static Type GetTypeFromHandle(RuntimeTypeHandle handle) => RuntimeTypeUnifier.GetTypeForRuntimeTypeHandle(handle);
+        public static Type GetTypeFromHandle(RuntimeTypeHandle handle) => handle.IsNull ? null : GetTypeFromEETypePtr(handle.ToEETypePtr());
+
+        internal static Type GetTypeFromEETypePtr(EETypePtr eeType)
+        {
+            // If we support the writable data section on EETypes, the runtime type associated with the EEType
+            // is cached there. If writable data is not supported, we need to do a lookup in the runtime type
+            // unifier's hash table.
+            if (Internal.Runtime.EEType.SupportsWritableData)
+            {
+                ref GCHandle handle = ref eeType.GetWritableData<GCHandle>();
+                if (handle.IsAllocated)
+                {
+                    return Unsafe.As<Type>(handle.Target);
+                }
+                else
+                {
+                    return GetTypeFromEETypePtrSlow(eeType, ref handle);
+                }
+            }
+            else
+            {
+                return RuntimeTypeUnifier.GetRuntimeTypeForEEType(eeType);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Type GetTypeFromEETypePtrSlow(EETypePtr eeType, ref GCHandle handle)
+        {
+            // Note: this is bypassing the "fast" unifier cache (based on a simple IntPtr
+            // identity of EEType pointers). There is another unifier behind that cache
+            // that ensures this code is race-free.
+            Type result = RuntimeTypeUnifier.GetRuntimeTypeBypassCache(eeType);
+            GCHandle tempHandle = GCHandle.Alloc(result);
+
+            // We don't want to leak a handle if there's a race
+            if (Interlocked.CompareExchange(ref Unsafe.As<GCHandle, IntPtr>(ref handle), (IntPtr)tempHandle, default) != default)
+            {
+                tempHandle.Free();
+            }
+
+            return result;
+        }
 
         [Intrinsic]
         public static Type GetType(string typeName) => GetType(typeName, throwOnError: false, ignoreCase: false);

--- a/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -144,6 +144,7 @@ namespace Internal.Runtime.TypeLoader
             bool successful = false;
             IntPtr eeTypePtrPlusGCDesc = IntPtr.Zero;
             IntPtr dynamicDispatchMapPtr = IntPtr.Zero;
+            IntPtr writableDataPtr = IntPtr.Zero;
             DynamicModule* dynamicModulePtr = null;
             IntPtr gcStaticData = IntPtr.Zero;
             IntPtr gcStaticsIndirection = IntPtr.Zero;
@@ -566,6 +567,13 @@ namespace Internal.Runtime.TypeLoader
                     }
                 }
 
+                if (EEType.SupportsWritableData)
+                {
+                    writableDataPtr = MemoryHelpers.AllocateMemory(WritableData.GetSize(IntPtr.Size));
+                    MemoryHelpers.Memset(writableDataPtr, WritableData.GetSize(IntPtr.Size), 0);
+                    pEEType->WritableData = writableDataPtr;
+                }
+
                 // Create a new DispatchMap for the type
                 if (requiresDynamicDispatchMap)
                 {
@@ -711,6 +719,8 @@ namespace Internal.Runtime.TypeLoader
                         MemoryHelpers.FreeMemory(genericComposition);
                     if (nonGcStaticData != IntPtr.Zero)
                         MemoryHelpers.FreeMemory(nonGcStaticData);
+                    if (writableDataPtr != IntPtr.Zero)
+                        MemoryHelpers.FreeMemory(writableDataPtr);
                 }
             }
         }


### PR DESCRIPTION
This adds a general purpose concept of "writable data" to the EEType data structure. This points to a block of memory whose purpose is defined by the class library (we can potentially cache all sorts of stuff there).

The writable data is used to hold a GC handle to the runtime `System.Type` instance associated with the EEType. This bypasses the hashtable lookup that has been used before.

I'm seeing more than 50% TP improvement against best case scenarios with the hashtable (best case defined as "the thing we're looking for is the first entry in the hashtable bucket").

Both CoreCLR and Mono use a similar approach. CoreRT was lagging in perf because of the hashtable lookup: this brings us much closer. We're still not as fast as CoreCLR, but getting faster than this would have impacts elsewhere (in terms of working set and size on disk). The implementation I chose for CoreRT (optional relative pointer field) has minimal working set impact.