### PR TITLE
Allow generic types through marshalling infra

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/NativeStructType.cs
@@ -37,14 +37,6 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override Instantiation Instantiation
-        {
-            get
-            {
-                return ManagedStructType.Instantiation;
-            }
-        }
-
         public override PInvokeStringFormat PInvokeStringFormat
         {
             get
@@ -147,7 +139,6 @@ namespace Internal.TypeSystem.Interop
 
         public NativeStructType(ModuleDesc owningModule, MetadataType managedStructType, InteropStateManager interopStateManager)
         {
-            Debug.Assert(managedStructType.IsTypeDefinition);
             Debug.Assert(!managedStructType.IsGenericDefinition);
 
             Module = owningModule;

--- a/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreRT.cs
@@ -41,7 +41,7 @@ namespace System.Runtime.InteropServices
             if (String.IsNullOrEmpty(fieldName))
                 throw new ArgumentNullException(nameof(fieldName));
 
-            if (t.TypeHandle.IsGenericType() || t.TypeHandle.IsGenericTypeDefinition())
+            if (t.TypeHandle.IsGenericTypeDefinition())
                 throw new ArgumentException(SR.Argument_NeedNonGenericType, nameof(t));
 
             return new IntPtr(RuntimeAugments.InteropCallbacks.GetStructFieldOffset(t.TypeHandle, fieldName));


### PR DESCRIPTION
This might require other fixes once we actually run CoreCLR tests for the newly allowed marshalling of blittable generics, but this is enough to restore compatible behavior with `Marshal.OffsetOf<SomeGenericType<Arg>>("foo")`.

CLR didn't do a good job blocking generics in that particular code path and there is code out there taking advantage of that.

Fixes a compiler crash that would happen because the instantiation on the native type was unexpected.