### PR TITLE
If ICastable is not defined in Runtime library, do not perform specific processing

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -272,12 +272,12 @@ namespace ILCompiler.DependencyAnalysis
         {
             DefType closestDefType = _type.GetClosestDefType();
 
-            if (_type.RuntimeInterfaces.Length > 0 && !factory.VTable(closestDefType).HasFixedSlots && factory.HasICastableInterface)
+            if (_type.RuntimeInterfaces.Length > 0 && !factory.VTable(closestDefType).HasFixedSlots)
             {
                 foreach (var implementedInterface in _type.RuntimeInterfaces)
                 {
                     // If the type implements ICastable, the methods are implicitly necessary
-                    if (implementedInterface == factory.ICastableInterface)
+                    if (factory.IsICastableInterface(implementedInterface))
                     {
                         MethodDesc isInstDecl = implementedInterface.GetKnownMethod("IsInstanceOfInterface", null);
                         MethodDesc getImplTypeDecl = implementedInterface.GetKnownMethod("GetImplType", null);
@@ -563,11 +563,11 @@ namespace ILCompiler.DependencyAnalysis
                 flags |= (UInt16)EETypeFlags.GenericVarianceFlag;
             }
 
-            if (!(this is CanonicalDefinitionEETypeNode) && factory.HasICastableInterface)
+            if (!(this is CanonicalDefinitionEETypeNode))
             {
                 foreach (DefType itf in _type.RuntimeInterfaces)
                 {
-                    if (itf == factory.ICastableInterface)
+                    if (factory.IsICastableInterface(itf))
                     {
                         flags |= (UInt16)EETypeFlags.ICastableFlag;
                         break;
@@ -999,12 +999,12 @@ namespace ILCompiler.DependencyAnalysis
         /// </summary>
         protected virtual void ComputeICastableVirtualMethodSlots(NodeFactory factory)
         {
-            if (_type.IsInterface || !EmitVirtualSlotsAndInterfaces || !factory.HasICastableInterface)
+            if (_type.IsInterface || !EmitVirtualSlotsAndInterfaces)
                 return;
 
             foreach (DefType itf in _type.RuntimeInterfaces)
             {
-                if (itf == factory.ICastableInterface)
+                if (factory.IsICastableInterface(itf))
                 {
                     MethodDesc isInstDecl = itf.GetKnownMethod("IsInstanceOfInterface", null);
                     MethodDesc getImplTypeDecl = itf.GetKnownMethod("GetImplType", null);

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -272,7 +272,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             DefType closestDefType = _type.GetClosestDefType();
 
-            if (_type.RuntimeInterfaces.Length > 0 && !factory.VTable(closestDefType).HasFixedSlots)
+            if (_type.RuntimeInterfaces.Length > 0 && !factory.VTable(closestDefType).HasFixedSlots && factory.HasICastableInterface)
             {
                 foreach (var implementedInterface in _type.RuntimeInterfaces)
                 {
@@ -563,7 +563,7 @@ namespace ILCompiler.DependencyAnalysis
                 flags |= (UInt16)EETypeFlags.GenericVarianceFlag;
             }
 
-            if (!(this is CanonicalDefinitionEETypeNode))
+            if (!(this is CanonicalDefinitionEETypeNode) && factory.HasICastableInterface)
             {
                 foreach (DefType itf in _type.RuntimeInterfaces)
                 {
@@ -999,7 +999,7 @@ namespace ILCompiler.DependencyAnalysis
         /// </summary>
         protected virtual void ComputeICastableVirtualMethodSlots(NodeFactory factory)
         {
-            if (_type.IsInterface || !EmitVirtualSlotsAndInterfaces)
+            if (_type.IsInterface || !EmitVirtualSlotsAndInterfaces || !factory.HasICastableInterface)
                 return;
 
             foreach (DefType itf in _type.RuntimeInterfaces)

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -892,26 +892,17 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        private TypeDesc _systemICastableType;
-        private bool? _hasSystemICastableType;
+        private object _systemICastableTypeOrPlaceholder;
 
-        public TypeDesc ICastableInterface
+        public bool IsICastableInterface(TypeDesc type)
         {
-            get
+            if (_systemICastableTypeOrPlaceholder == null)
             {
-                if (_systemICastableType == null && _hasSystemICastableType == null)
-                {
-                    _systemICastableType = _context.SystemModule.GetType("System.Runtime.CompilerServices", "ICastable", false);
-                    _hasSystemICastableType = _systemICastableType != null;
-                }
-                return _systemICastableType;
+                _systemICastableTypeOrPlaceholder = _context.SystemModule.GetType("System.Runtime.CompilerServices", "ICastable", false) ?? new object();
             }
+            return type == _systemICastableTypeOrPlaceholder;
         }
 
-        public bool HasICastableInterface
-        {
-            get => this.ICastableInterface != null
-        }
 
         private NodeCache<MethodDesc, VirtualMethodUseNode> _virtMethods;
 

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -893,17 +893,24 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         private TypeDesc _systemICastableType;
+        private bool? _hasSystemICastableType;
 
         public TypeDesc ICastableInterface
         {
             get
             {
-                if (_systemICastableType == null)
+                if (_systemICastableType == null && _hasSystemICastableType == null)
                 {
-                    _systemICastableType = _context.SystemModule.GetKnownType("System.Runtime.CompilerServices", "ICastable");
+                    _systemICastableType = _context.SystemModule.GetType("System.Runtime.CompilerServices", "ICastable", false);
+                    _hasSystemICastableType = _systemICastableType != null;
                 }
                 return _systemICastableType;
             }
+        }
+
+        public bool HasICastableInterface
+        {
+            get => this.ICastableInterface != null
         }
 
         private NodeCache<MethodDesc, VirtualMethodUseNode> _virtMethods;


### PR DESCRIPTION
I see references to have ICastable removed, but anyway there nothing specific in my code which seems to be require presence of this interface in custom classlib

Closes #8101