### PR TITLE
Allow publishing of ilc with newer SDKs

### DIFF
--- a/buildscripts/build-managed.cmd
+++ b/buildscripts/build-managed.cmd
@@ -39,13 +39,6 @@ dir /b "%__DotNetCliPath%\sdk"
 "%__DotNetCliPath%\dotnet.exe" msbuild "%__ProjectDir%\build.proj" /nologo /t:Restore /flp:v=normal;LogFile="%__BuildLog%" /p:NuPkgRid=%__NugetRuntimeId% /maxcpucount /p:OSGroup=%__BuildOS% /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% %__ExtraMsBuildParams%
 IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
 
-rem Buildtools tooling is not capable of publishing netcoreapp currently. Use helper projects to publish skeleton of
-rem the standalone app that the build injects actual binaries into later.
-"%__DotNetCliPath%\dotnet.exe" restore "%__SourceDir%\ILCompiler\netcoreapp\ilc.csproj" -r %__NugetRuntimeId%
-IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
-"%__DotNetCliPath%\dotnet.exe" publish "%__SourceDir%\ILCompiler\netcoreapp\ilc.csproj" -r %__NugetRuntimeId% -o "%__RootBinDir%\%__BuildOS%.%__BuildArch%.%__BuildType%\tools"
-IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
-
 "%__DotNetCliPath%\dotnet.exe" restore "%__SourceDir%\ILVerify\netcoreapp\ILVerify.csproj" -r %__NugetRuntimeId%
 IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
 "%__DotNetCliPath%\dotnet.exe" publish "%__SourceDir%\ILVerify\netcoreapp\ILVerify.csproj" -r %__NugetRuntimeId% -o "%__RootBinDir%\%__BuildOS%.%__BuildArch%.%__BuildType%\ILVerify"
@@ -64,6 +57,8 @@ echo ILCompiler build failed with exit code %ERRORLEVEL%. Refer !__BuildLog! for
 exit /b %ERRORLEVEL%
 
 :AfterILCompilerBuild
+"%__DotNetCliPath%\dotnet.exe" publish "%__SourceDir%\ILCompiler\netcoreapp\ilc.csproj" -r %__NugetRuntimeId% -o "%__RootBinDir%\%__BuildOS%.%__BuildArch%.%__BuildType%\tools"
+IF ERRORLEVEL 1 exit /b %ERRORLEVEL%
 
 :VsDevGenerateRespFiles
 if defined __SkipVsDev goto :AfterVsDevGenerateRespFiles

--- a/buildscripts/build-managed.sh
+++ b/buildscripts/build-managed.sh
@@ -42,22 +42,15 @@ build_managed_corert()
         exit $BUILDERRORLEVEL
     fi
 
-    # Buildtools tooling is not capable of publishing netcoreapp currently. Use helper projects to publish skeleton of
-    # the standalone app that the build injects actual binaries into later.
-    $__dotnetclipath/dotnet restore $__sourceroot/ILCompiler/netcoreapp/ilc.csproj -r $__NugetRuntimeId
+    $__ProjectRoot/Tools/msbuild.sh "$__buildproj" /m /nologo /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__buildlog" /t:Build /p:RepoPath=$__ProjectRoot /p:RepoLocalBuild="true" /p:NuPkgRid=$__NugetRuntimeId /p:OSGroup=$__BuildOS /p:Configuration=$__BuildType /p:Platform=$__buildarch /p:COMPUTERNAME=$(hostname) /p:USERNAME=$(id -un) $__UnprocessedBuildArgs $__ExtraMsBuildArgs
     export BUILDERRORLEVEL=$?
-    if [ $BUILDERRORLEVEL != 0 ]; then
-        exit $BUILDERRORLEVEL
-    fi
+
     $__dotnetclipath/dotnet publish $__sourceroot/ILCompiler/netcoreapp/ilc.csproj -r $__NugetRuntimeId -o $__ProductBinDir/tools
     export BUILDERRORLEVEL=$?
     if [ $BUILDERRORLEVEL != 0 ]; then
         exit $BUILDERRORLEVEL
     fi
     chmod +x $__ProductBinDir/tools/ilc
-
-    $__ProjectRoot/Tools/msbuild.sh "$__buildproj" /m /nologo /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__buildlog" /t:Build /p:RepoPath=$__ProjectRoot /p:RepoLocalBuild="true" /p:NuPkgRid=$__NugetRuntimeId /p:OSGroup=$__BuildOS /p:Configuration=$__BuildType /p:Platform=$__buildarch /p:COMPUTERNAME=$(hostname) /p:USERNAME=$(id -un) $__UnprocessedBuildArgs $__ExtraMsBuildArgs
-    export BUILDERRORLEVEL=$?
 
     echo
 

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -12,7 +12,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.ThreadPool">
-      <Version>4.0.10</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/ILCompiler.RyuJit/src/ILCompiler.RyuJit.csproj
+++ b/src/ILCompiler.RyuJit/src/ILCompiler.RyuJit.csproj
@@ -21,10 +21,10 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.ThreadPool">
-      <Version>4.0.10</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.Thread">
-      <Version>4.0.0</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/ILCompiler/netcoreapp/ilc.cs
+++ b/src/ILCompiler/netcoreapp/ilc.cs
@@ -1,9 +1,9 @@
 using System;
 
-class Program
+internal static class Program
 {
-    static void Main()
+    internal static int Main(string[] args)
     {
-        Console.WriteLine("Hello world!");
+        return ILCompiler.Program.Main(args);
     }
 }

--- a/src/ILCompiler/netcoreapp/ilc.csproj
+++ b/src/ILCompiler/netcoreapp/ilc.csproj
@@ -27,6 +27,10 @@
     <PackageReference Include="System.CommandLine">
       <Version>0.1.0-e160909-1</Version>
     </PackageReference>
+
+    <Reference Include="ILCompiler">
+      <HintPath>$(PublishDir)\ILCompiler.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/src/ILCompiler/src/ILCompiler.csproj
+++ b/src/ILCompiler/src/ILCompiler.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>ILCompiler</RootNamespace>
-    <AssemblyName>ilc</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <CopyNugetImplementations>false</CopyNugetImplementations>

--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -18,7 +18,7 @@ using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler
 {
-    internal class Program
+    public class Program
     {
         private const string DefaultSystemModule = "System.Private.CoreLib";
 
@@ -803,7 +803,7 @@ namespace ILCompiler
             return false;
         }
 
-        private static int Main(string[] args)
+        public static int Main(string[] args)
         {
 #if DEBUG
             try


### PR DESCRIPTION
This is to address #8084 - there shouldn't be any observable changes, however, it does mean that you are able to run `dotnet publish` on the ilc project with your local SDK so hopefully it's of some use to others.