### PR TITLE
Add sample CMake configuration for VS

### DIFF
--- a/src/Native/CMakeSettings.json
+++ b/src/Native/CMakeSettings.json
@@ -1,0 +1,22 @@
+﻿{
+    // See https://go.microsoft.com//fwlink//?linkid=834763 for more information about this file.
+    "configurations": [
+        {
+            "name": "Windows_NT.x64.Debug",
+            "generator": "Visual Studio 16 2019 Win64",
+            "configurationType": "Debug",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "buildRoot": "${projectDir}\\..\\..\\bin\\obj\\Native\\${name}",
+            "installRoot": "${projectDir}\\..\\..\\bin\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "variables": [
+                {
+                    "name": "CLR_CMAKE_TARGET_ARCH",
+                    "value": "x64"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This allows to view native cmponents inside VS CMake Targets view without much efforts.
I try to mimic setup for `gen-buildsys-win.bat` for Windows only.
Maybe maintaining this file in addition to `gen-buildsys-win.bat` then it can be found his place in the documentation somewhere.
I prefer to work inside Visual Studio and having such file significantly improve discoverability for native components from which CoreRT made up of.

![image](https://user-images.githubusercontent.com/4257079/80095726-376b9580-858a-11ea-9b96-c2fc97cad870.png)
