### PR TITLE
Wasm: Make offset used in unbox stub match RhUnbox/RhBox

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -548,7 +548,9 @@ namespace ILCompiler
 
                 // unbox to get a pointer to the value type
                 codeStream.EmitLdArg(0);
-                codeStream.Emit(ILOpcode.ldflda, emit.NewToken(boxedValueField));
+                MetadataType helperType = Context.SystemModule.GetKnownType("System", "Object");
+                MethodDesc helperMethod = helperType.GetKnownMethod("GetRawData", null);
+                codeStream.Emit(ILOpcode.call, emit.NewToken(helperMethod));
 
                 // Load rest of the arguments
                 for (int i = 0; i < _targetMethod.Signature.Length; i++)

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -293,8 +293,6 @@ namespace ILCompiler
                 // to the same __unreachable method body) so that the various places that store pointers to
                 // them because they want to be able to extract the target instance method can use the same
                 // mechanism they use for everything else at runtime.
-                // The main difference is that the "Boxed_ValueType" version has no fields. Reference types
-                // cannot have byref-like fields.
             }
 
             public override ClassLayoutMetadata GetClassLayout() => default(ClassLayoutMetadata);

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -253,10 +253,6 @@ namespace ILCompiler
         /// </summary>
         private partial class BoxedValueType : MetadataType, INonEmittableType
         {
-            private const string BoxedValueFieldName = "BoxedValue";
-
-            public FieldDesc BoxedValue { get; }
-
             public MetadataType ValueTypeRepresented { get; }
 
             public override ModuleDesc Module { get; }
@@ -299,8 +295,6 @@ namespace ILCompiler
                 // mechanism they use for everything else at runtime.
                 // The main difference is that the "Boxed_ValueType" version has no fields. Reference types
                 // cannot have byref-like fields.
-                if (!valuetype.IsByRefLike)
-                    BoxedValue = new BoxedValueField(this);
             }
 
             public override ClassLayoutMetadata GetClassLayout() => default(ClassLayoutMetadata);
@@ -342,42 +336,12 @@ namespace ILCompiler
 
             public override FieldDesc GetField(string name)
             {
-                if (name == BoxedValueFieldName && BoxedValue != null)
-                    return BoxedValue;
-
                 return null;
             }
 
             public override IEnumerable<FieldDesc> GetFields()
             {
-                if (BoxedValue != null)
-                    return new FieldDesc[] { BoxedValue };
-
                 return Array.Empty<FieldDesc>();
-            }
-
-            /// <summary>
-            /// Synthetic field on <see cref="BoxedValueType"/>.
-            /// </summary>
-            private partial class BoxedValueField : FieldDesc
-            {
-                private BoxedValueType _owningType;
-
-                public override TypeSystemContext Context => _owningType.Context;
-                public override TypeDesc FieldType => _owningType.ValueTypeRepresented.InstantiateAsOpen();
-                public override bool HasRva => false;
-                public override bool IsInitOnly => false;
-                public override bool IsLiteral => false;
-                public override bool IsStatic => false;
-                public override bool IsThreadStatic => false;
-                public override DefType OwningType => _owningType;
-                public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => false;
-                public override string Name => BoxedValueFieldName;
-
-                public BoxedValueField(BoxedValueType owningType)
-                {
-                    _owningType = owningType;
-                }
             }
         }
 
@@ -452,7 +416,7 @@ namespace ILCompiler
 
             public override MethodIL EmitIL()
             {
-                if (_owningType.BoxedValue == null)
+                if (_owningType.ValueTypeRepresented.IsByRefLike)
                 {
                     // If this is the fake unboxing thunk for ByRef-like types, just make a method that throws.
                     return new ILStubMethodIL(this,
@@ -468,11 +432,10 @@ namespace ILCompiler
                 ILCodeStream codeStream = emit.NewCodeStream();
 
                 FieldDesc eeTypeField = Context.GetWellKnownType(WellKnownType.Object).GetKnownField("m_pEEType");
-                FieldDesc boxedValueField = _owningType.BoxedValue.InstantiateAsOpen();
 
                 // Load ByRef to the field with the value of the boxed valuetype
                 codeStream.EmitLdArg(0);
-                codeStream.Emit(ILOpcode.ldflda, emit.NewToken(boxedValueField));
+                codeStream.Emit(ILOpcode.ldflda, emit.NewToken(Context.SystemModule.GetKnownType("System.Runtime.CompilerServices", "RawData").GetField("Data")));
 
                 // Load the EEType of the boxed valuetype (this is the hidden generic context parameter expected
                 // by the (canonical) instance method, but normally not part of the signature in IL).
@@ -529,7 +492,7 @@ namespace ILCompiler
 
             public override MethodIL EmitIL()
             {
-                if (_owningType.BoxedValue == null)
+                if (_owningType.ValueTypeRepresented.IsByRefLike)
                 {
                     // If this is the fake unboxing thunk for ByRef-like types, just make a method that throws.
                     return new ILStubMethodIL(this,
@@ -544,13 +507,9 @@ namespace ILCompiler
                 ILEmitter emit = new ILEmitter();
                 ILCodeStream codeStream = emit.NewCodeStream();
 
-                FieldDesc boxedValueField = _owningType.BoxedValue.InstantiateAsOpen();
-
                 // unbox to get a pointer to the value type
                 codeStream.EmitLdArg(0);
-                MetadataType helperType = Context.SystemModule.GetKnownType("System", "Object");
-                MethodDesc helperMethod = helperType.GetKnownMethod("GetRawData", null);
-                codeStream.Emit(ILOpcode.call, emit.NewToken(helperMethod));
+                codeStream.Emit(ILOpcode.ldflda, emit.NewToken(Context.SystemModule.GetKnownType("System.Runtime.CompilerServices", "RawData").GetField("Data")));
 
                 // Load rest of the arguments
                 for (int i = 0; i < _targetMethod.Signature.Length; i++)

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.Sorting.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.Sorting.cs
@@ -17,16 +17,6 @@ namespace ILCompiler
             {
                 return comparer.Compare(ValueTypeRepresented, ((BoxedValueType)other).ValueTypeRepresented);
             }
-
-            partial class BoxedValueField
-            {
-                protected override int ClassCode => 1765873859;
-
-                protected override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
-                {
-                    return comparer.Compare(_owningType, ((BoxedValueField)other)._owningType);
-                }
-            }
         }
 
         partial class GenericUnboxingThunk

--- a/src/System.Private.CoreLib/src/System/Object.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Object.CoreRT.cs
@@ -59,12 +59,6 @@ namespace System
             return RuntimeImports.RhMemberwiseClone(this);
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private class RawData
-        {
-            public byte Data;
-        }
-
         internal ref byte GetRawData()
         {
             return ref Unsafe.As<RawData>(this).Data;

--- a/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreRT.cs
@@ -330,4 +330,10 @@ namespace System.Runtime.CompilerServices
 #endif
         public byte Data;
     }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal class RawData
+    {
+        public byte Data;
+    }
 }

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1,4 +1,3 @@
-
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1,3 +1,4 @@
+
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -91,6 +92,8 @@ internal static class Program
             PrintLine("Value:");
             PrintLine(boxedInt.ToString());
         }
+
+        TestBoxUnboxDifferentSizes();
 
         var boxedStruct = (object)new BoxStubTest { Value = "Boxed Stub Test: Ok." };
         PrintLine(boxedStruct.ToString());
@@ -383,6 +386,73 @@ internal static class Program
             PrintLine(GC.CollectionCount(i).ToString());
         }
         EndTest(true);
+    }
+
+    private static unsafe void TestBoxUnboxDifferentSizes()
+    {
+        StartTest("Box/Unbox different sizes");
+        var pass = true;
+        long longValue = Convert.ToInt64((object)11111111L);
+        if(longValue != 11111111L)
+        {
+            FailTest("Int64");
+            pass = false;
+        }
+
+        int intValue = Convert.ToInt32((object)11111111);
+        if (intValue != 11111111)
+        {
+            FailTest("Int32");
+            pass = false;
+        }
+
+        float singleValue = Convert.ToSingle((object)1f);
+        if (singleValue != 1f)
+        {
+            FailTest("Single");
+            pass = false;
+        }
+
+        double doubleValue = Convert.ToDouble((object)1D);
+        if (doubleValue != 1D)
+        {
+            FailTest("Double");
+            pass = false;
+        }
+
+        short s1 = 1;
+        short shortValue = Convert.ToInt16((object)s1);
+        if (shortValue != 1)
+        {
+            FailTest("Int16");
+            pass = false;
+        }
+
+        byte b1 = 1;
+        byte byteValue = Convert.ToByte((object)b1);
+        if (byteValue != 1)
+        {
+            FailTest("Byte");
+            pass = false;
+        }
+
+        var s = new StructWintIntf();
+        s.IntField = 11111111;
+        s.LongField = 222222222L;
+        IHasTwoFields hasTwoFields = (IHasTwoFields)s;
+
+        if(hasTwoFields.GetIntField() != 11111111)
+        {
+            FailTest("GetIntField");
+            pass = false;
+        }
+        if (hasTwoFields.GetLongField() != 222222222L)
+        {
+            FailTest("GetLongField");
+            pass = false;
+        }
+
+        EndTest(pass);
     }
 
     private static WeakReference MethodWithObjectInShadowStack()
@@ -835,7 +905,9 @@ internal static class Program
         var i = x.IntField;
         var classForMetaTestsType = typeof(ClassForMetaTests);
         FieldInfo[] fields = classForMetaTestsType.GetFields();
-        EndTest(fields.Length == 3);
+        PrintLine("Fields Length");
+        PrintLine(fields.Length.ToString());
+        EndTest(fields.Length == 4);
 
         StartTest("Type get string field via reflection");
         var stringFieldInfo = classForMetaTestsType.GetField("StringField");
@@ -860,6 +932,11 @@ internal static class Program
         StartTest("Type set static int field via reflection");
         staticIntFieldInfo.SetValue(x, 987);
         EndTest(ClassForMetaTests.StaticIntField == 987);
+
+        StartTest("Type set static long field via reflection");
+        var staticLongFieldInfo = classForMetaTestsType.GetField("StaticLongField");
+        staticLongFieldInfo.SetValue(x, 0x11111111);
+        EndTest(ClassForMetaTests.StaticLongField == 0x11111111L);
 
         var st = new StructForMetaTests();
         st.StringField = "xyz";
@@ -909,12 +986,14 @@ internal static class Program
         public string StringField;
 #pragma warning restore 0169
         public static int StaticIntField;
+        public static long StaticLongField;
 
         public ClassForMetaTests()
         {
             StringField = "ab";
             IntField = 12;
             StaticIntField = 23;
+            StaticLongField = 0x22222222;
         }
 
         public bool ReturnTrueIf1(int i)
@@ -936,6 +1015,28 @@ internal static class Program
     public struct StructForMetaTests
     {
         public string StringField;
+    }
+
+    public interface IHasTwoFields
+    {
+        int GetIntField();
+        long GetLongField();
+    }
+
+    public struct StructWintIntf : IHasTwoFields
+    {
+        public int IntField;
+        public long LongField;
+
+        public int GetIntField()
+        {
+            return IntField;
+        }
+
+        public long GetLongField()
+        {
+            return LongField;
+        }
     }
 
 
@@ -1570,7 +1671,7 @@ internal static class Program
         fi.SetValue(null, 1.1f);
         EndTest(1.1f == ClassWithFloat.F);
     }
-    
+
     static void TestInitializeArray()
     {
         StartTest("Test InitializeArray");


### PR DESCRIPTION
This PR fixes an issue with unboxing 64 bit value types.  This is part of trying the get `build wasm release` working again, #8012,  where I think the issues are related to padding/offsets of longs (and probably doubles) in the shadow stack.  The debug build is working at the moment, but that's probably more luck due to the different number of locals it creates.  The changes here bring the offset used in the unboxing stub into line with the offset used in RhUnbox, i.e. the one returned by `obj.GetRawData()` which is the offset of a byte field.  `long`s were using the field offset from `ldflda` which gets 8 byte aligned and hence does not match the offset for a `byte` (4).  Added a test for various box/unbox value types which was failing and now passes.

There's some additional discussion in the original task, #5005, where curiously the IL suggested uses `GetRawData` but for some reason, perhaps as `ldflda` is shorter and there were no failing tests at the time, it was not used.