### PR TITLE
Check if PortableThreadPoolEventSource is enabled before logging

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/PortableThreadPool.HillClimbing.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/PortableThreadPool.HillClimbing.cs
@@ -360,7 +360,6 @@ namespace System.Threading
                 // Record these numbers for posterity
                 //
 
-                PortableThreadPoolEventSource = PortableThreadPoolEventSource.Log;
                 if (log.IsEnabled())
                 {
                     log.WorkerThreadAdjustmentStats(sampleDurationSeconds, throughput, threadWaveComponent.Real, throughputWaveComponent.Real,

--- a/src/System.Private.CoreLib/shared/System/Threading/PortableThreadPool.HillClimbing.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/PortableThreadPool.HillClimbing.cs
@@ -186,8 +186,11 @@ namespace System.Threading
                 // Add the current thread count and throughput sample to our history
                 //
                 double throughput = numCompletions / sampleDurationSeconds;
-
-                PortableThreadPoolEventSource.Log.WorkerThreadAdjustmentSample(throughput);
+                PortableThreadPoolEventSource log = PortableThreadPoolEventSource.Log;
+                if (log.IsEnabled())
+                {
+                    log.WorkerThreadAdjustmentSample(throughput);
+                }
 
                 int sampleIndex = (int)(_totalSamples % _samplesToMeasure);
                 _samples[sampleIndex] = throughput;
@@ -357,8 +360,12 @@ namespace System.Threading
                 // Record these numbers for posterity
                 //
 
-                PortableThreadPoolEventSource.Log.WorkerThreadAdjustmentStats(sampleDurationSeconds, throughput, threadWaveComponent.Real, throughputWaveComponent.Real,
+                PortableThreadPoolEventSource = PortableThreadPoolEventSource.Log;
+                if (log.IsEnabled())
+                {
+                    log.WorkerThreadAdjustmentStats(sampleDurationSeconds, throughput, threadWaveComponent.Real, throughputWaveComponent.Real,
                     throughputErrorEstimate, _averageThroughputNoise, ratio.Real, confidence, _currentControlSetting, (ushort)newThreadWaveMagnitude);
+                }
 
 
                 //
@@ -415,7 +422,11 @@ namespace System.Threading
 
                 _logSize++;
 
-                PortableThreadPoolEventSource.Log.WorkerThreadAdjustmentAdjustment(throughput, newThreadCount, (int)stateOrTransition);
+                PortableThreadPoolEventSource log = PortableThreadPoolEventSource.Log;
+                if (log.IsEnabled())
+                {
+                    log.WorkerThreadAdjustmentAdjustment(throughput, newThreadCount, (int)stateOrTransition);
+                }
             }
 
             public void ForceChange(int newThreadCount, StateOrTransition state)

--- a/src/System.Private.CoreLib/shared/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -28,7 +28,11 @@ namespace System.Threading
 
             private static void WorkerThreadStart()
             {
-                PortableThreadPoolEventSource.Log.WorkerThreadStart(ThreadCounts.VolatileReadCounts(ref ThreadPoolInstance._separated.counts).numExistingThreads);
+                PortableThreadPoolEventSource log = PortableThreadPoolEventSource.Log;
+                if (log.IsEnabled())
+                {
+                    log.WorkerThreadStart(ThreadCounts.VolatileReadCounts(ref ThreadPoolInstance._separated.counts).numExistingThreads);
+                }
 
                 while (true)
                 {
@@ -53,6 +57,7 @@ namespace System.Threading
                     ThreadPoolInstance._hillClimbingThreadAdjustmentLock.Acquire();
                     try
                     {
+                        PortableThreadPoolEventSource log = PortableThreadPoolEventSource.Log;
                         // At this point, the thread's wait timed out. We are shutting down this thread.
                         // We are going to decrement the number of exisiting threads to no longer include this one
                         // and then change the max number of threads in the thread pool to reflect that we don't need as many
@@ -73,7 +78,11 @@ namespace System.Threading
                             if (oldCounts == counts)
                             {
                                 HillClimbing.ThreadPoolHillClimber.ForceChange(newCounts.numThreadsGoal, HillClimbing.StateOrTransition.ThreadTimedOut);
-                                PortableThreadPoolEventSource.Log.WorkerThreadStop(newCounts.numExistingThreads);
+
+                                if (log.IsEnabled())
+                                {
+                                    log.WorkerThreadStop(newCounts.numExistingThreads);
+                                }
                                 return;
                             }
                         }
@@ -91,7 +100,11 @@ namespace System.Threading
             /// <returns>If this thread was woken up before it timed out.</returns>
             private static bool WaitForRequest()
             {
-                PortableThreadPoolEventSource.Log.WorkerThreadWait(ThreadCounts.VolatileReadCounts(ref ThreadPoolInstance._separated.counts).numExistingThreads);
+                PortableThreadPoolEventSource log = PortableThreadPoolEventSource.Log;
+                if (log.IsEnabled())
+                {
+                    log.WorkerThreadWait(ThreadCounts.VolatileReadCounts(ref ThreadPoolInstance._separated.counts).numExistingThreads);
+                }
                 return s_semaphore.Wait(ThreadPoolThreadTimeoutMs);
             }
 

--- a/src/System.Private.CoreLib/shared/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -57,7 +57,6 @@ namespace System.Threading
                     ThreadPoolInstance._hillClimbingThreadAdjustmentLock.Acquire();
                     try
                     {
-                        PortableThreadPoolEventSource log = PortableThreadPoolEventSource.Log;
                         // At this point, the thread's wait timed out. We are shutting down this thread.
                         // We are going to decrement the number of exisiting threads to no longer include this one
                         // and then change the max number of threads in the thread pool to reflect that we don't need as many


### PR DESCRIPTION
Resolves https://github.com/dotnet/corert/issues/8116