### PR TITLE
Cast to proper type in nested generics

### DIFF
--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -2817,7 +2817,7 @@ namespace Internal.IL
 
             TypeDesc owningType = _writer.ConvertToCanonFormIfNecessary(field.OwningType, CanonicalFormKind.Specific);
             TypeDesc fieldType = _writer.ConvertToCanonFormIfNecessary(field.FieldType, CanonicalFormKind.Specific);
-            
+
             // TODO: Is this valid combination?
             if (!isStatic && !owningType.IsValueType && thisPtr.Kind != StackValueKind.ObjRef)
                 throw new InvalidProgramException();

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -2878,7 +2878,7 @@ namespace Internal.IL
             {
                 if (runtimeDeterminedOwningType.IsRuntimeDeterminedSubtype)
                 {
-                    fieldType = owningType.GetField(field.Name).FieldType;
+                    fieldType = _typeSystemContext.GetFieldForInstantiatedType(field.GetTypicalFieldDefinition(), (InstantiatedType)owningType).FieldType;
                 }
 
                 Append("(");
@@ -3723,4 +3723,3 @@ namespace Internal.IL
         }
     }
 }
-

--- a/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
+++ b/src/ILCompiler.CppCodeGen/src/CppCodeGen/ILToCppImporter.cs
@@ -2817,7 +2817,7 @@ namespace Internal.IL
 
             TypeDesc owningType = _writer.ConvertToCanonFormIfNecessary(field.OwningType, CanonicalFormKind.Specific);
             TypeDesc fieldType = _writer.ConvertToCanonFormIfNecessary(field.FieldType, CanonicalFormKind.Specific);
-
+            
             // TODO: Is this valid combination?
             if (!isStatic && !owningType.IsValueType && thisPtr.Kind != StackValueKind.ObjRef)
                 throw new InvalidProgramException();
@@ -2876,6 +2876,11 @@ namespace Internal.IL
             Append(" = ");
             if (!fieldType.IsValueType)
             {
+                if (runtimeDeterminedOwningType.IsRuntimeDeterminedSubtype)
+                {
+                    fieldType = owningType.GetField(field.Name).FieldType;
+                }
+
                 Append("(");
                 Append(_writer.GetCppSignatureTypeName(fieldType));
                 Append(")");


### PR DESCRIPTION
Make sure that when working with fields inside nested gnerics when invoke block in the shared instantiation, convert to type of field declared in shared instantiation.

I guard code which detect actual type of the field, since I do not sure that such conversion is appropriate everywhere.

Closes: #8118