### PR TITLE
Wasm: add support for exception filters

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
@@ -115,6 +115,7 @@ namespace Internal.IL
         static LLVMValueRef RhpThrowEx = default(LLVMValueRef);
         static LLVMValueRef RhpCallCatchFunclet = default(LLVMValueRef);
         static LLVMValueRef LlvmCatchFunclet = default(LLVMValueRef);
+        static LLVMValueRef LlvmFilterFunclet = default(LLVMValueRef);
         static LLVMValueRef LlvmFinallyFunclet = default(LLVMValueRef);
         static LLVMValueRef NullRefFunction = default(LLVMValueRef);
         static LLVMValueRef CkFinite32Function = default(LLVMValueRef);
@@ -174,6 +175,26 @@ namespace Internal.IL
             }
             LLVMValueRef leaveToILOffset = funcletBuilder.BuildCall(LlvmCatchFunclet.GetParam(1), llvmArgs.ToArray(), string.Empty);
             funcletBuilder.BuildRet(leaveToILOffset);
+            funcletBuilder.Dispose();
+        }
+
+        static void BuildFilterFunclet(LLVMModuleRef module, string funcletName, LLVMTypeRef[] funcletArgTypes, bool passGenericContext = false)
+        {
+            LlvmFilterFunclet = module.AddFunction(funcletName, LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32,
+                funcletArgTypes, false));
+            var block = LlvmFilterFunclet.AppendBasicBlock("Filter");
+            LLVMBuilderRef funcletBuilder = Context.CreateBuilder();
+            funcletBuilder.PositionAtEnd(block);
+
+            List<LLVMValueRef> llvmArgs = new List<LLVMValueRef>();
+            llvmArgs.Add(LlvmFilterFunclet.GetParam(2)); //shadow stack
+            llvmArgs.Add(LlvmFilterFunclet.GetParam(0)); // exception object
+            if (passGenericContext)
+            {
+                llvmArgs.Add(LlvmFilterFunclet.GetParam(3));
+            }
+            LLVMValueRef filterResult = funcletBuilder.BuildCall(LlvmFilterFunclet.GetParam(1), llvmArgs.ToArray(), string.Empty);
+            funcletBuilder.BuildRet(filterResult);
             funcletBuilder.Dispose();
         }
 

--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -275,16 +275,25 @@ extern "C" uint32_t RhpCallCatchFunclet(void * exceptionObj, void* pHandlerIP, v
         ? LlvmCatchFuncletGeneric(exceptionObj, pHandlerIP, pvRegDisplay, exInfo)
         : LlvmCatchFunclet(exceptionObj, pHandlerIP, pvRegDisplay);
 }
+
+extern "C" uint32_t LlvmFilterFunclet(void* exceptionObj, unsigned int pHandlerIP, void* pvRegDisplay);
+extern "C" uint32_t LlvmFilterFuncletGeneric(void* exceptionObj, unsigned int pHandlerIP, void* pvRegDisplay, void* genericContext);
+extern "C" uint32_t RhpCallFilterFunclet(void* exceptionObj, unsigned int pHandlerIP, void* shadowStack)
+{
+    return 0 /* how to tell we need the generic context ? */
+        ? LlvmFilterFuncletGeneric(exceptionObj, pHandlerIP, shadowStack, NULL /* generic context do we pass this? */)
+        : LlvmFilterFunclet(exceptionObj, pHandlerIP, shadowStack);
+}
 #else 
 extern "C" uint32_t RhpCallCatchFunclet(void *, void*, void*, void*)
 {
     throw "RhpCallCatchFunclet";
 }
-#endif
 extern "C" void* RhpCallFilterFunclet(void*, void*, void*)
 {
     throw "RhpCallFilterFunclet";
 }
+#endif
 
 #if defined(_WASM_)
 extern "C" void LlvmFinallyFunclet(void *finallyHandler, void *shadowStack);

--- a/src/Runtime.Base/src/System/Runtime/StackFrameIterator.wasm.cs
+++ b/src/Runtime.Base/src/System/Runtime/StackFrameIterator.wasm.cs
@@ -105,7 +105,9 @@ namespace System.Runtime
                     pEHClause._handlerAddress = (byte*)ReadUInt32(ref _currentPtr);
                     break;
                 case RhEHClauseKindWasm.RH_EH_CLAUSE_FILTER:
-                    pEHClause._filterOffset = GetUnsigned();
+                    AlignToSymbol();
+                    pEHClause._handlerAddress = (byte*)ReadUInt32(ref _currentPtr);
+                    pEHClause._filterAddress = (byte*)ReadUInt32(ref _currentPtr);
                     break;
             }
             return true;

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1338,6 +1338,8 @@ internal static class Program
         TestThrowInCatch();
 
         TestExceptionInGvmCall();
+        
+        TestFilter();
     }
 
     private static void TestTryCatchNoException()
@@ -1493,6 +1495,27 @@ internal static class Program
         var shouldBeTrue = CatchGvmThrownException(new DerivedThrows<string>(), (string)null);
 
         EndTest(shouldBeTrue && !shouldBeFalse);
+    }
+
+    private static unsafe void TestFilter()
+    {
+        StartTest("TestFilter");
+
+        int counter = 0;
+        try
+        {
+            counter++;
+            throw new Exception("Testing filter");
+        }
+        catch (Exception e) when (e.Message == "Testing filter" && counter++ > 0)
+        {
+            if (e.Message == "Testing filter")
+            {
+                counter++;
+            }
+            counter++;
+        }
+        EndTest(counter == 4);
     }
 
     class DerivedThrows<A> : GenBase<A>


### PR DESCRIPTION
This PR adds support for exception filters.  There's one nasty bit in here where it handles crudely the extra space used in the landing pad and first pass on the shadow stack, otherwise follows the pattern already there.  Not done passing in the generic context if required to the filter, I can't see how that's handled, I could just add a parameter to `RhpCallFilterFunclet` but non-Wasm must be doing it another way?

Added a test from the Simple/Exceptions project.