### PR TITLE
Expose `--ildump` via MSBuild property

### DIFF
--- a/Documentation/using-corert/troubleshooting-corert.md
+++ b/Documentation/using-corert/troubleshooting-corert.md
@@ -6,3 +6,4 @@ Sometimes you want to have more information how CoreRT work. ILC Compiler provid
 * `<IlcGenerateDgmlFile>true</IlcGenerateDgmlFile>`: Generates log files `ProjectName.codegen.dgml.xml` and `ProjectName.scan.dgml.xml` in DGML format.
 * `<IlcGenerateMapFile>true</IlcGenerateMapFile>`: Generates log files `ProjectName.map.xml` which describe layout of objects how CoreRT sees them.
 * `<IlcSingleThreaded>true</IlcSingleThreaded>`: Perform compilation on single thread.
+* `<IlcDumpIL>true</IlcDumpIL>`: Dump final IL after generatoin in the file `ProjectName.il`. This can be helpful when debugging IL transformation, like marshalling for example.

--- a/Documentation/using-corert/troubleshooting-corert.md
+++ b/Documentation/using-corert/troubleshooting-corert.md
@@ -6,4 +6,4 @@ Sometimes you want to have more information how CoreRT work. ILC Compiler provid
 * `<IlcGenerateDgmlFile>true</IlcGenerateDgmlFile>`: Generates log files `ProjectName.codegen.dgml.xml` and `ProjectName.scan.dgml.xml` in DGML format.
 * `<IlcGenerateMapFile>true</IlcGenerateMapFile>`: Generates log files `ProjectName.map.xml` which describe layout of objects how CoreRT sees them.
 * `<IlcSingleThreaded>true</IlcSingleThreaded>`: Perform compilation on single thread.
-* `<IlcDumpIL>true</IlcDumpIL>`: Dump final IL after generatoin in the file `ProjectName.il`. This can be helpful when debugging IL transformation, like marshalling for example.
+* `<IlcDumpGeneratedIL>true</IlcDumpGeneratedIL>`: Dump IL for method bodies the compiler generated on the fly into `ProjectName.il`. This can be helpful when debugging IL generation - e.g. marshalling. The compiler maps debug information to this file, so it's possible to step in it and set breakpoints.

--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -213,6 +213,7 @@ See the LICENSE file in the project root for more information.
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--removefeature:FrameworkStrings" />
       <IlcArg Condition="$(IlcInvariantGlobalization) == 'true'" Include="--removefeature:Globalization" />
       <IlcArg Condition="$(IlcSystemModule) != ''" Include="--systemmodule:$(IlcSystemModule)" />
+      <IlcArg Condition="$(IlcDumpIL) == 'true'" Include="--ildump:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).il" />
 
       <!-- Workaround for https://github.com/dotnet/corefx/issues/36723 -->
       <IlcArg Include="--removefeature:SerializationGuard" />


### PR DESCRIPTION
This can help with debugging marshalling for example.