### PR TITLE
Add simple marshaller which marshal only null COM interfaces

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -68,6 +68,7 @@ namespace Internal.TypeSystem.Interop
                 case MarshallerKind.BlittableStruct:
                 case MarshallerKind.Decimal:
                 case MarshallerKind.VoidReturn:
+                case MarshallerKind.ComInterface:
                     return type;
 
 #if !READYTORUN
@@ -562,6 +563,10 @@ namespace Internal.TypeSystem.Interop
                     return MarshallerKind.LayoutClass;
                 else
                     return MarshallerKind.Invalid;
+            }
+            else if (type.IsInterface)
+            {
+                return MarshallerKind.ComInterface;
             }
             else
                 return MarshallerKind.Invalid;

--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -68,7 +68,6 @@ namespace Internal.TypeSystem.Interop
                 case MarshallerKind.BlittableStruct:
                 case MarshallerKind.Decimal:
                 case MarshallerKind.VoidReturn:
-                case MarshallerKind.ComInterface:
                     return type;
 
 #if !READYTORUN
@@ -157,6 +156,9 @@ namespace Internal.TypeSystem.Interop
                 case MarshallerKind.LayoutClassPtr:
                 case MarshallerKind.AsAnyA:
                 case MarshallerKind.AsAnyW:
+                    return context.GetWellKnownType(WellKnownType.IntPtr);
+
+                case MarshallerKind.ComInterface:
                     return context.GetWellKnownType(WellKnownType.IntPtr);
 
                 case MarshallerKind.Unknown:

--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.Aot.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.Aot.cs
@@ -853,4 +853,31 @@ namespace Internal.TypeSystem.Interop
             codeStream.EmitLabel(lNull);
         }
     }
+
+    class ComInterfaceMarshaller : Marshaller
+    {
+        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            var helper = Context.GetHelperEntryPoint("InteropHelpers", "ConvertManagedComInterfaceToNative");
+            LoadManagedValue(codeStream);
+
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(helper));
+
+            StoreNativeValue(codeStream);
+        }
+
+        protected override void AllocAndTransformNativeToManaged(ILCodeStream codeStream)
+        {
+            ILEmitter emitter = _ilCodeStreams.Emitter;
+
+            var helper = Context.GetHelperEntryPoint("InteropHelpers", "ConvertNativeComInterfaceToManaged");
+            LoadManagedValue(codeStream);
+
+            codeStream.Emit(ILOpcode.call, emitter.NewToken(helper));
+
+            StoreNativeValue(codeStream);
+        }
+    }
 }

--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.Aot.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.Aot.cs
@@ -71,6 +71,8 @@ namespace Internal.TypeSystem.Interop
                     return new AsAnyMarshaller(isAnsi: true);
                 case MarshallerKind.AsAnyW:
                     return new AsAnyMarshaller(isAnsi: false);
+                case MarshallerKind.ComInterface:
+                    return new ComInterfaceMarshaller();
                 default:
                     // ensures we don't throw during create marshaller. We will throw NSE
                     // during EmitIL which will be handled and an Exception method body 

--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.cs
@@ -870,47 +870,6 @@ namespace Internal.TypeSystem.Interop
         }
     }
 
-    class ComInterfaceMarshaller : Marshaller
-    {
-        protected override void AllocAndTransformManagedToNative(ILCodeStream codeStream)
-        {
-
-            var context = this.Context;
-            ILEmitter emitter = _ilCodeStreams.Emitter;
-
-            // Check if we marshall null pointer
-            ILCodeLabel lNullInterface = emitter.NewCodeLabel();
-            LoadManagedValue(codeStream);
-            codeStream.Emit(ILOpcode.brfalse, lNullInterface);
-
-            MethodSignature ctorSignature = new MethodSignature(0, 0, context.GetWellKnownType(WellKnownType.Void),
-                new TypeDesc[] { context.GetWellKnownType(WellKnownType.String) });
-            MethodDesc exceptionCtor = context.GetWellKnownType(WellKnownType.Exception).GetKnownMethod(".ctor", ctorSignature);
-
-            codeStream.Emit(ILOpcode.ldstr, emitter.NewToken("Marhalling of non null interfaces does not supported."));
-            codeStream.Emit(ILOpcode.newobj, emitter.NewToken(exceptionCtor));
-            codeStream.Emit(ILOpcode.throw_);
-
-            // Fall through. If interface is null then no conversion is needed.
-            codeStream.EmitLabel(lNullInterface);
-            LoadManagedValue(codeStream);
-            StoreNativeValue(codeStream);
-        }
-
-        protected override void AllocAndTransformNativeToManaged(ILCodeStream codeStream)
-        {
-            var context = this.Context;
-            ILEmitter emitter = _ilCodeStreams.Emitter;
-            MethodSignature ctorSignature = new MethodSignature(0, 0, context.GetWellKnownType(WellKnownType.Void),
-                new TypeDesc[] { context.GetWellKnownType(WellKnownType.String) });
-            MethodDesc exceptionCtor = context.GetWellKnownType(WellKnownType.Exception).GetKnownMethod(".ctor", ctorSignature);
-
-            codeStream.Emit(ILOpcode.ldstr, emitter.NewToken("Marhalling of non null interfaces does not supported"));
-            codeStream.Emit(ILOpcode.newobj, emitter.NewToken(exceptionCtor));
-            codeStream.Emit(ILOpcode.throw_);
-        }
-    }
-
     class VoidReturnMarshaller : Marshaller
     {
         protected override void EmitMarshalReturnValueManagedToNative()

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -407,6 +407,26 @@ namespace Internal.Runtime.CompilerHelpers
             return PInvokeMarshal.GetCurrentCalleeDelegate<T>();
         }
 
+        public static object ConvertManagedComInterfaceToNative(object pUnk)
+        {
+            if (pUnk == null)
+            {
+                return null;
+            }
+
+            throw new PlatformNotSupportedException("Marhalling of non null COM interfaces does not supported");
+        }
+
+        public static object ConvertNativeComInterfaceToManaged(object pUnk)
+        {
+            if (pUnk == null)
+            {
+                return null;
+            }
+
+            throw new PlatformNotSupportedException("Marhalling of non null COM interfaces does not supported");
+        }
+
         internal static int AsAnyGetNativeSize(object o)
         {
             // Array, string and StringBuilder are not implemented.

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -414,7 +414,7 @@ namespace Internal.Runtime.CompilerHelpers
                 return IntPtr.Zero;
             }
 
-            throw new PlatformNotSupportedException("Marhalling of non null COM interfaces is not supported");
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         public static object ConvertNativeComInterfaceToManaged(IntPtr pUnk)
@@ -424,7 +424,7 @@ namespace Internal.Runtime.CompilerHelpers
                 return null;
             }
 
-            throw new PlatformNotSupportedException("Marhalling of non null COM interfaces is not supported");
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_ComInterop);
         }
 
         internal static int AsAnyGetNativeSize(object o)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -407,24 +407,24 @@ namespace Internal.Runtime.CompilerHelpers
             return PInvokeMarshal.GetCurrentCalleeDelegate<T>();
         }
 
-        public static object ConvertManagedComInterfaceToNative(object pUnk)
+        public static IntPtr ConvertManagedComInterfaceToNative(object pUnk)
         {
             if (pUnk == null)
             {
-                return null;
+                return IntPtr.Zero;
             }
 
-            throw new PlatformNotSupportedException("Marhalling of non null COM interfaces does not supported");
+            throw new PlatformNotSupportedException("Marhalling of non null COM interfaces is not supported");
         }
 
-        public static object ConvertNativeComInterfaceToManaged(object pUnk)
+        public static object ConvertNativeComInterfaceToManaged(IntPtr pUnk)
         {
-            if (pUnk == null)
+            if (pUnk == IntPtr.Zero)
             {
                 return null;
             }
 
-            throw new PlatformNotSupportedException("Marhalling of non null COM interfaces does not supported");
+            throw new PlatformNotSupportedException("Marhalling of non null COM interfaces is not supported");
         }
 
         internal static int AsAnyGetNativeSize(object o)

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -294,8 +294,10 @@ namespace PInvokeTests
             TestLayoutClass();
             TestAsAny();
             TestMarshalStructAPIs();
+#if TARGET_WINDOWS
             TestComInteropNullPointers();
-#endif            
+#endif
+#endif
             return 100;
         }
 

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -294,6 +294,7 @@ namespace PInvokeTests
             TestLayoutClass();
             TestAsAny();
             TestMarshalStructAPIs();
+            TestComInteropNullPointers();
 #endif            
             return 100;
         }
@@ -993,6 +994,12 @@ namespace PInvokeTests
             int cftf_size = Marshal.SizeOf(typeof(ClassForTestingFlowAnalysis));
             ThrowIfNotEquals(4, cftf_size, "ClassForTestingFlowAnalysis marshalling Marshal API failed");
         }
+
+        public static void TestComInteropNullPointers()
+        {
+            Console.WriteLine("Testing Marshal APIs for structs");
+            IntPtr result = UiaCore.UiaReturnRawElementProvider(IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, null);
+        }
     }
 
     public class SafeMemoryHandle : SafeHandle //SafeHandle subclass
@@ -1020,6 +1027,33 @@ namespace PInvokeTests
             return ReleaseMemory(handle);
         }
     } //end of SafeMemoryHandle class
+
+    internal static partial class UiaCore
+    {
+        [DllImport("UIAutomationCore.dll", CharSet = CharSet.Unicode)]
+        public static extern IntPtr UiaReturnRawElementProvider(IntPtr hwnd, IntPtr wParam, IntPtr lParam, IRawElementProviderSimple el);
+
+        [ComImport]
+        [ComVisible(true)]
+        [Guid("D6DD68D1-86FD-4332-8666-9ABEDEA2D24C")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        public interface IRawElementProviderSimple
+        {
+            ProviderOptions ProviderOptions { get; }
+
+            [return: MarshalAs(UnmanagedType.IUnknown)]
+            object GetPatternProvider(UIA patternId);
+
+            object GetPropertyValue(UIA propertyId);
+
+            IRawElementProviderSimple HostRawElementProvider { get; }
+        }
+
+        public enum UIA : int { }
+
+        [Flags]
+        public enum ProviderOptions { }
+    }
 
     public static class LowLevelExtensions
     {

--- a/tests/src/Simple/PInvoke/PInvoke.cs
+++ b/tests/src/Simple/PInvoke/PInvoke.cs
@@ -210,6 +210,9 @@ namespace PInvokeTests
         [DllImport("*", CallingConvention = CallingConvention.StdCall)]
         static extern bool IsNULL(SequentialStruct[] foo);
 
+        [DllImport("*", CallingConvention = CallingConvention.StdCall)]
+        static extern bool IsNULL(IComInterface foo);
+
         [StructLayout(LayoutKind.Sequential, CharSet= CharSet.Ansi, Pack = 4)]
         public unsafe struct InlineArrayStruct
         {
@@ -999,8 +1002,10 @@ namespace PInvokeTests
 
         public static void TestComInteropNullPointers()
         {
-            Console.WriteLine("Testing Marshal APIs for structs");
-            IntPtr result = UiaCore.UiaReturnRawElementProvider(IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, null);
+            Console.WriteLine("Testing Marshal APIs for COM interfaces");
+            IComInterface comPointer = null;
+            var result = IsNULL(comPointer);
+            ThrowIfNotEquals(true, IsNULL(comPointer), "COM interface marshalling null check failed");
         }
     }
 
@@ -1030,31 +1035,12 @@ namespace PInvokeTests
         }
     } //end of SafeMemoryHandle class
 
-    internal static partial class UiaCore
+    [ComImport]
+    [ComVisible(true)]
+    [Guid("D6DD68D1-86FD-4332-8666-9ABEDEA2D24C")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IComInterface
     {
-        [DllImport("UIAutomationCore.dll", CharSet = CharSet.Unicode)]
-        public static extern IntPtr UiaReturnRawElementProvider(IntPtr hwnd, IntPtr wParam, IntPtr lParam, IRawElementProviderSimple el);
-
-        [ComImport]
-        [ComVisible(true)]
-        [Guid("D6DD68D1-86FD-4332-8666-9ABEDEA2D24C")]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        public interface IRawElementProviderSimple
-        {
-            ProviderOptions ProviderOptions { get; }
-
-            [return: MarshalAs(UnmanagedType.IUnknown)]
-            object GetPatternProvider(UIA patternId);
-
-            object GetPropertyValue(UIA propertyId);
-
-            IRawElementProviderSimple HostRawElementProvider { get; }
-        }
-
-        public enum UIA : int { }
-
-        [Flags]
-        public enum ProviderOptions { }
     }
 
     public static class LowLevelExtensions


### PR DESCRIPTION
This idea was proposed by @MichalStrehovsky in #7994

Implemented only marshalling of `in` parameters, since this is case which I found in the stack trace of the issue. I think other directions can be implemented in same way, I just lack of examples for testing.

Tested code
```
// [DllImport(Libraries.UiaCore, CharSet = CharSet.Unicode)]
// public static extern IntPtr UiaReturnRawElementProvider(IntPtr hwnd, IntPtr wParam, IntPtr lParam, IRawElementProviderSimple el);
IntPtr result = UiaCore.UiaReturnRawElementProvider(IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, null);
```

Closes #7994