### PR TITLE
[Interpreter] Multi-dim Array and Object instantiation

### DIFF
--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -170,15 +170,10 @@ namespace Internal.Runtime.Augments
             EETypePtr eeTypePtr = typeHandleForArrayType.ToEETypePtr();
             Debug.Assert(eeTypePtr.IsArray);
 
-            int nArguments = arguments.Length;
-            int* pArguments = stackalloc int[nArguments];
-
-            for (int i = 0; i < nArguments; i++)
+            fixed (int* pArguments = arguments)
             {
-                pArguments[i] = arguments[i];
+                return ArrayHelpers.NewObjArray((IntPtr)eeTypePtr.ToPointer(), arguments.Length, pArguments);
             }
-
-            return ArrayHelpers.NewObjArray((IntPtr)eeTypePtr.ToPointer(), nArguments, pArguments);
         }
 
         public static ref byte GetSzArrayElementAddress(Array array, int index)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -25,6 +25,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
+using Internal.Runtime.CompilerHelpers;
 using Internal.Runtime.CompilerServices;
 
 #if TARGET_64BIT
@@ -159,6 +160,25 @@ namespace Internal.Runtime.Augments
                 pLengths[i] = lengths[i];
 
             return Array.NewMultiDimArray(typeHandleForArrayType.ToEETypePtr(), pLengths, lengths.Length);
+        }
+
+        // 
+        // Helper to create an array from a newobj instruction
+        // 
+        public static unsafe Array NewObjArray(RuntimeTypeHandle typeHandleForArrayType, int[] arguments)
+        {
+            EETypePtr eeTypePtr = typeHandleForArrayType.ToEETypePtr();
+            Debug.Assert(eeTypePtr.IsArray);
+
+            int nArguments = arguments.Length;
+            int* pArguments = stackalloc int[nArguments];
+
+            for (int i = 0; i < nArguments; i++)
+            {
+                pArguments[i] = arguments[i];
+            }
+
+            return ArrayHelpers.NewObjArray((IntPtr)eeTypePtr.ToPointer(), nArguments, pArguments);
         }
 
         public static ref byte GetSzArrayElementAddress(Array array, int index)

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ArrayHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ArrayHelpers.cs
@@ -18,7 +18,7 @@ namespace Internal.Runtime.CompilerHelpers
         /// Helper for array allocations via `newobj` IL instruction. Dimensions are passed in as block of integers.
         /// The content of the dimensions block may be modified by the helper.
         /// </summary>
-        private static unsafe Array NewObjArray(IntPtr pEEType, int nDimensions, int* pDimensions)
+        public static unsafe Array NewObjArray(IntPtr pEEType, int nDimensions, int* pDimensions)
         {
             EETypePtr eeType = new EETypePtr(pEEType);
             Debug.Assert(eeType.IsArray);

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -2679,7 +2679,7 @@ getvar:
                 
                 if (signature.Length == arrayType.Rank)
                 {
-                    lengths = new LowLevelList<int>();
+                    lengths = new LowLevelList<int>(signature.Length);
                     for (int i = arguments.Length - 1; i >= 0; i--)
                     {
                         lengths.Add(arguments[i].AsInt32());
@@ -2689,8 +2689,8 @@ getvar:
                 {
                     Debug.Assert(arrayType.Rank * 2 == signature.Length);
 
-                    lengths = new LowLevelList<int>();
-                    lowerBounds = new LowLevelList<int>();
+                    lengths = new LowLevelList<int>(arrayType.Rank);
+                    lowerBounds = new LowLevelList<int>(arrayType.Rank);
 
                     for (int i = arguments.Length - 1; i >= 0; i--)
                     {

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -2671,13 +2671,14 @@ getvar:
 
             if (owningType.IsArray)
             {
-                LowLevelList<int> lArguments = new LowLevelList<int>(arguments.Length);
+                int[] lArguments = new int[arguments.Length];
                 for (int i = arguments.Length - 1; i >= 0; i--)
                 {
-                    lArguments.Add(arguments[i].AsInt32());
+                    lArguments[i] = arguments[i].AsInt32();
                 }
 
-                Array array = RuntimeAugments.NewObjArray(owningType.GetRuntimeTypeHandle(), lArguments.ToArray());
+                Array.Reverse(lArguments);
+                Array array = RuntimeAugments.NewObjArray(owningType.GetRuntimeTypeHandle(), lArguments);
                 _stack.Push(StackItem.FromObjectRef(array));
                 return;
             }

--- a/src/System.Private.Interpreter/src/System.Private.Interpreter.csproj
+++ b/src/System.Private.Interpreter/src/System.Private.Interpreter.csproj
@@ -25,7 +25,6 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\ILReader.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\StackValueKind.cs" />
     <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelStack.cs" />
-    <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelList.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\LibraryInitializer.cs" />
     <Compile Include="Internal\Runtime\Interpreter\StackItem.cs" />
   </ItemGroup>

--- a/src/System.Private.Interpreter/src/System.Private.Interpreter.csproj
+++ b/src/System.Private.Interpreter/src/System.Private.Interpreter.csproj
@@ -25,6 +25,7 @@
     <Compile Include="..\..\Common\src\TypeSystem\IL\ILReader.cs" />
     <Compile Include="..\..\Common\src\TypeSystem\IL\StackValueKind.cs" />
     <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelStack.cs" />
+    <Compile Include="..\..\Common\src\System\Collections\Generic\LowLevelList.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\LibraryInitializer.cs" />
     <Compile Include="Internal\Runtime\Interpreter\StackItem.cs" />
   </ItemGroup>


### PR DESCRIPTION
Finally made out time to continue work on the interpreter till it attains some semblance of completion. This PR adds support for instantiating multi-dimensional arrays and reference objects. It interprets the following opcodes:

* `newobj`

which allows for scenarios like the following:

```csharp
class Program
{
    public static Program CreateInstance()
    {
        return new Program();
    }

    public static int[,] CreateArray()
    {
        return new int[2, 3];
    }
}
```

As with everything reflection based, CoreRT needs to be able to find the type metadata for whatever you're trying to instantiate. Constructors for the `System.String` type are notably problematic

cc @jkotas @MichalStrehovsky 