### PR TITLE
Wasm: Fix 2 issues with the filters.  

### DIFF
--- a/src/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
+++ b/src/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
@@ -29,6 +29,12 @@ namespace System.Runtime
             {
                 return idxTryLandingStart == _tryStartOffset;
             }
+
+            public bool ContainsCodeOffset(uint idxTryLandingStart)
+            {
+                return ((idxTryLandingStart >= _tryStartOffset) &&
+                        (idxTryLandingStart < _tryEndOffset));
+            }
         }
 
         // TODO: temporary to try things out, when working look to see how to refactor with FindFirstPassHandler
@@ -70,7 +76,7 @@ namespace System.Runtime
                 EHClauseIterator.RhEHClauseKindWasm clauseKind = ehClause._clauseKind;
                 if (((clauseKind != EHClauseIterator.RhEHClauseKindWasm.RH_EH_CLAUSE_TYPED) &&
                      (clauseKind != EHClauseIterator.RhEHClauseKindWasm.RH_EH_CLAUSE_FILTER))
-                    || !ehClause.TryStartsAt(idxTryLandingStart))
+                    || !ehClause.ContainsCodeOffset(idxTryLandingStart))
                 {
                     continue;
                 }

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1516,8 +1516,49 @@ internal static class Program
             counter++;
         }
         EndTest(counter == 4);
+        TestFilterNested();
     }
 
+    static string exceptionFlowSequence = "";
+    private static void TestFilterNested()
+    {
+        StartTest("TestFilterNested");
+        foreach (var exception in new Exception[]
+            {new ArgumentException(), new Exception(), new NullReferenceException()})
+        {
+            try
+            {
+                try
+                {
+                    try
+                    {
+                        throw exception;
+                    }
+                    catch (NullReferenceException) when (Print("inner"))
+                    {
+                        exceptionFlowSequence += "In inner catch";
+                    }
+                }
+                catch (ArgumentException)
+                {
+                    exceptionFlowSequence += "In middle catch";
+                }
+            }
+            catch (Exception) when (Print("outer"))
+            {
+                exceptionFlowSequence += "In outer catch";
+            }
+        }
+        PrintLine(exceptionFlowSequence);
+        EndTest(exceptionFlowSequence == @"In middle catchRunning outer filterIn outer catchRunning inner filterIn inner catch");
+    }
+
+    static bool Print(string s)
+    {
+        exceptionFlowSequence += $"Running {s} filter";
+        return true;
+    }
+    
     class DerivedThrows<A> : GenBase<A>
     {
         public override string GMethod1<T>(T t1, T t2) { throw new Exception("ToStringThrows"); }

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1340,6 +1340,8 @@ internal static class Program
         TestExceptionInGvmCall();
         
         TestFilter();
+
+        TestFilterNested();
     }
 
     private static void TestTryCatchNoException()
@@ -1516,7 +1518,6 @@ internal static class Program
             counter++;
         }
         EndTest(counter == 4);
-        TestFilterNested();
     }
 
     static string exceptionFlowSequence = "";


### PR DESCRIPTION
Trying the filter code with more than just the simplest example revealed a few bugs with this PR fixes.
Using the example from https://github.com/mono/mono/pull/19400#discussion_r412748672 it was evident that the filters were being tested in the wrong order and that the region detection was wrong.  Regions are now detected firstly in reverse order to get inner region detection first, and within the same try block regions are processed in order to get typed clause evaluation in the correct order.  The diff makes this difficult to see but the original for loop has been replaced with
```
            int i = _exceptionRegions.Length - 1;
            while (i >= 0)
            {
                int tryStart = _exceptionRegions[i].ILRegion.TryOffset;
                for (var j = 0; j < _exceptionRegions.Length; j++)
                {
                    ExceptionRegion exceptionRegion = _exceptionRegions[j];
                    if (exceptionRegion.ILRegion.TryOffset != tryStart) continue;
```

The other fix for region detection brings that part of the first pass handler more into line with `ExceptionHandling.cs` .   