### PR TITLE
Add disassembly viewer to MethodCodeNode

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <RyuJITVersion Condition="'$(RyuJITVersion)' == ''">5.0.0-preview.5.20230.9</RyuJITVersion>
     <ObjectWriterVersion Condition="'$(ObjectWriterVersion)' == ''">1.0.0-alpha-28820-01</ObjectWriterVersion>
+    <CoreDisToolsVersion Condition="'$(CoreDisToolsVersion)' == ''">1.0.1-prerelease-00005</CoreDisToolsVersion>
     <RuntimeLibrariesVersion Condition="'$(RuntimeLibrariesVersion)' == ''">5.0.0-preview.2.20153.3</RuntimeLibrariesVersion>
     <CoreFxUapVersion Condition="'$(CoreFxUapVersion)' == ''">4.7.0-preview6.19265.2</CoreFxUapVersion>
     <MicrosoftNETCoreAppPackageVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)' == ''">2.1.14</MicrosoftNETCoreAppPackageVersion>

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1079,6 +1079,11 @@ namespace ILCompiler.DependencyAnalysis
             return comparer.Compare(_type, ((EETypeNode)other)._type);
         }
 
+        public override string ToString()
+        {
+            return _type.ToString();
+        }
+
         private struct SlotCounter
         {
             private int _startBytes;

--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/ExternSymbolNode.cs
@@ -49,5 +49,10 @@ namespace ILCompiler.DependencyAnalysis
             return _name.CompareTo(((ExternSymbolNode)other)._name);
         }
 #endif
+
+        public override string ToString()
+        {
+            return _name.ToString();
+        }
     }
 }

--- a/src/ILCompiler.Compiler/src/Compiler/Disassembler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Disassembler.cs
@@ -21,6 +21,7 @@ namespace ILCompiler
         {
             var sb = new StringBuilder();
 
+#if TARGET_WINDOWS
             // The coredistools library is not available in release builds because
             // we don't want to ship yet another huge LLVM-based DLL.
 #if DEBUG
@@ -61,6 +62,9 @@ namespace ILCompiler
             }
 #else
             sb.AppendLine("// CoreDisTools not available in release builds");
+#endif
+#else
+            sb.AppendLine("// CoreDisTools not available outside Windows");
 #endif
             return sb.ToString();
         }

--- a/src/ILCompiler.Compiler/src/Compiler/Disassembler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/Disassembler.cs
@@ -1,0 +1,143 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using ILCompiler.DependencyAnalysis;
+using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Disassembler based on CoreDisTools. Only available in Debug builds.
+    /// </summary>
+    public class Disassembler
+    {
+        public static string Disassemble(TargetArchitecture arch, byte[] bytes, Relocation[] relocs)
+        {
+            var sb = new StringBuilder();
+
+            // The coredistools library is not available in release builds because
+            // we don't want to ship yet another huge LLVM-based DLL.
+#if DEBUG
+            SortedList<int, Relocation> sortedRelocs = new SortedList<int, Relocation>(relocs.Length);
+            foreach (Relocation reloc in relocs)
+                sortedRelocs.Add(reloc.Offset, reloc);
+
+            int relocIndex = 0;
+
+            using (var disasm = new CoreDisassembler(arch))
+            {
+                int offset = 0;
+                while (offset < bytes.Length)
+                {
+                    int size = disasm.Disassemble(bytes, offset, out string dis);
+                    if (size == 0)
+                        break;
+                    offset += size;
+
+                    // Drop the annoying `\n`
+                    dis = dis.Substring(0, dis.Length - 1);
+
+                    sb.Append(dis);
+
+                    if (relocIndex < sortedRelocs.Count)
+                    {
+                        Relocation currentReloc = sortedRelocs.Values[relocIndex];
+                        if (currentReloc.Offset < offset)
+                        {
+                            sb.Append(" // ");
+                            sb.Append(currentReloc.Target.ToString());
+                            relocIndex++;
+                        }
+                    }
+
+                    sb.AppendLine();
+                }
+            }
+#else
+            sb.AppendLine("// CoreDisTools not available in release builds");
+#endif
+            return sb.ToString();
+        }
+
+        private class CoreDisassembler : IDisposable
+        {
+            private IntPtr _handle;
+
+            private const string Library = "coredistools";
+
+            private enum TargetArch
+            {
+                Target_X86 = 1,
+                Target_X64,
+                Target_Thumb,
+                Target_Arm64
+            };
+
+            [DllImport(Library)]
+            private static extern IntPtr InitBufferedDisasm(TargetArch Target);
+
+            public CoreDisassembler(TargetArchitecture arch)
+            {
+                _handle = InitBufferedDisasm(arch switch
+                {
+                    TargetArchitecture.X86 => TargetArch.Target_X86,
+                    TargetArchitecture.X64 => TargetArch.Target_X64,
+                    TargetArchitecture.ARM => TargetArch.Target_Thumb,
+                    TargetArchitecture.ARM64 => TargetArch.Target_Arm64,
+                    _ => throw new NotSupportedException()
+                });
+
+                if (_handle == null)
+                    throw new OutOfMemoryException();
+            }
+
+            [DllImport(Library)]
+            private static extern int DumpInstruction(IntPtr handle, ulong address, IntPtr bytes, int size);
+
+            public unsafe int Disassemble(byte[] bytes, int offset, out string instruction)
+            {
+                int size;
+                fixed (byte* pByte = &bytes[offset])
+                {
+                    size = DumpInstruction(_handle, (ulong)offset, (IntPtr)pByte, bytes.Length - offset);
+                }
+
+                instruction = Marshal.PtrToStringAnsi(GetOutputBuffer());
+                ClearOutputBuffer();
+                return size;
+            }
+
+            [DllImport(Library)]
+            private static extern IntPtr GetOutputBuffer();
+
+            [DllImport(Library)]
+            private static extern void ClearOutputBuffer();
+
+            [DllImport(Library)]
+            private static extern void FinishDisasm(IntPtr handle);
+
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            private void Dispose(bool disposing)
+            {
+                FinishDisasm(_handle);
+                _handle = IntPtr.Zero;
+            }
+
+            ~CoreDisassembler()
+            {
+                Dispose(false);
+            }
+        }
+    }
+}

--- a/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
+++ b/src/ILCompiler.Compiler/src/ILCompiler.Compiler.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Compiler\DevirtualizationManager.cs" />
     <Compile Include="Compiler\DictionaryLayoutProvider.cs" />
     <Compile Include="Compiler\DirectPInvokePolicy.cs" />
+    <Compile Include="Compiler\Disassembler.cs" />
     <Compile Include="Compiler\DynamicInvokeThunkGenerationPolicy.cs" />
     <Compile Include="Compiler\EmptyInteropStubManager.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ISortableNode.cs" />

--- a/src/ILCompiler.RyuJit/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/ILCompiler.RyuJit/src/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -3,13 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-
+using System.Text;
 using Internal.Text;
 using Internal.TypeSystem;
-using Internal.TypeSystem.Interop;
 
 namespace ILCompiler.DependencyAnalysis
 {
+    [DebuggerTypeProxy(typeof(MethodCodeNodeDebugView))]
     public class MethodCodeNode : ObjectNode, IMethodBodyNode, INodeWithCodeInfo, INodeWithDebugInfo, ISymbolDefinitionNode, ISpecialUnboxThunkNode
     {
         private MethodDesc _method;
@@ -165,6 +165,47 @@ namespace ILCompiler.DependencyAnalysis
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
             return comparer.Compare(_method, ((MethodCodeNode)other)._method);
+        }
+
+        public override string ToString()
+        {
+            return _method.ToString();
+        }
+
+        internal class MethodCodeNodeDebugView
+        {
+            private readonly MethodCodeNode _node;
+
+            public MethodCodeNodeDebugView(MethodCodeNode node)
+            {
+                _node = node;
+            }
+
+            public MethodDesc Method => _node.Method;
+
+            public string Disassembly
+            {
+                get
+                {
+                    var sb = new StringBuilder();
+                    sb.Append("// ");
+                    sb.AppendLine(_node.Method.ToString());
+                    if (_node.StaticDependenciesAreComputed)
+                    {
+                        var d = Disassembler.Disassemble(
+                            _node.Method.Context.Target.Architecture,
+                            _node._methodCode.Data,
+                            _node._methodCode.Relocs);
+                        sb.Append(d);
+                    }
+                    else
+                    {
+                        sb.Append("// Not compiled yet.");
+                    }
+
+                    return sb.ToString();
+                }
+            }
         }
     }
 }

--- a/src/ILCompiler/CoreDisTools/CoreDisTools.depproj
+++ b/src/ILCompiler/CoreDisTools/CoreDisTools.depproj
@@ -1,0 +1,21 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <OutputPath>$(BaseOutputPath)$(OSPlatformConfig)/tools</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <NuGetTargetMoniker>.NETCoreApp,Version=v2.1</NuGetTargetMoniker>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeIdentifiers>$(NuPkgRid)</RuntimeIdentifiers>
+    <RidSpecificAssets>true</RidSpecificAssets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.CoreDisTools">
+      <Version>$(CoreDisToolsVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -14,7 +14,7 @@
 
     <Project Include="ILCompiler\RyuJIT\RyuJIT.depproj" />
     <Project Include="ILCompiler\ObjectWriter\ObjectWriter.depproj" Condition="'$(ObjWriterBuild)' != 'true'" />
-    <Project Include="ILCompiler\CoreDisTools\CoreDisTools.depproj" Condition="'$(Configuration)' == 'Debug'" />
+    <Project Include="ILCompiler\CoreDisTools\CoreDisTools.depproj" Condition="'$(Configuration)' == 'Debug' and '$(TargetsWindows)' == 'true'" />
     <Project Include="ILCompiler.WebAssembly\src\libLLVMdep.depproj" />
 
     <Project Include="*\src\*.csproj" Exclude="@(ExcludeProjects)" />

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -14,6 +14,7 @@
 
     <Project Include="ILCompiler\RyuJIT\RyuJIT.depproj" />
     <Project Include="ILCompiler\ObjectWriter\ObjectWriter.depproj" Condition="'$(ObjWriterBuild)' != 'true'" />
+    <Project Include="ILCompiler\CoreDisTools\CoreDisTools.depproj" Condition="'$(Configuration)' == 'Debug'" />
     <Project Include="ILCompiler.WebAssembly\src\libLLVMdep.depproj" />
 
     <Project Include="*\src\*.csproj" Exclude="@(ExcludeProjects)" />


### PR DESCRIPTION
This was useful when bringing up hardware intrinsics. The other option is `--codegenopt:NGenDisasm=foo`, but that only works with debug RyuJIT that I didn't use this time.