### PR TITLE
Add support for removing non-filestream support in System.Xml

### DIFF
--- a/src/ILCompiler/src/Program.cs
+++ b/src/ILCompiler/src/Program.cs
@@ -522,6 +522,8 @@ namespace ILCompiler
                     removedFeatures |= RemovedFeature.Comparers;
                 else if (feature == "SerializationGuard")
                     removedFeatures |= RemovedFeature.SerializationGuard;
+                else if (feature == "XmlNonFileStream")
+                    removedFeatures |= RemovedFeature.XmlDownloadNonFileStream;
             }
 
             ILProvider ilProvider = new CoreRTILProvider();

--- a/src/ILCompiler/src/RemovingILProvider.cs
+++ b/src/ILCompiler/src/RemovingILProvider.cs
@@ -218,6 +218,16 @@ namespace ILCompiler
                 }
             }
 
+            if ((_removedFeature & RemovedFeature.XmlDownloadNonFileStream) != 0)
+            {
+                if ((method.Name == "GetNonFileStream" || method.Name == "GetNonFileStreamAsync") &&
+                    owningType is Internal.TypeSystem.Ecma.EcmaType mdType &&
+                    mdType.Namespace == "System.Xml" && mdType.Name == "XmlDownloadManager")
+                {
+                    return RemoveAction.ConvertToThrow;
+                }
+            }
+
             return RemoveAction.Nothing;
         }
 
@@ -270,5 +280,6 @@ namespace ILCompiler
         Globalization = 0x4,
         Comparers = 0x8,
         SerializationGuard = 0x10,
+        XmlDownloadNonFileStream = 0x20,
     }
 }


### PR DESCRIPTION
I was playing with compiling the CoreRT compiler with itself. We use System.Xml to read RD.XML files. System.Xml brings the entire network stack into the app. Stubbing out this one method saves 3 MB for ilc.exe. With this ilc.exe is around 8 MB.

Similar to what I did in dotnet/corefx#31510. Hopefully we can switch to the "offical" solution for removable features soon and can stop hardcoding this in the compiler.