### PR TITLE
Wasm: Move generic context to local for catch and filter funclets

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -237,11 +237,19 @@ namespace Internal.IL
             LLVMBasicBlockRef prologBlock = _llvmFunction.AppendBasicBlock("Prolog");
             _builder.PositionAtEnd(prologBlock);
 
-
-            // Allocate a slot to store exceptions being dispatched
+            // Allocate slots to store exception being dispatched and generic context if present
             if(_exceptionRegions.Length > 0)
             {
                 _spilledExpressions.Add(new SpilledExpressionEntry(StackValueKind.ObjRef, "ExceptionSlot", GetWellKnownType(WellKnownType.Object), 0, this));
+                // and a slot for the generic context if present
+                if (FuncletsRequireHiddenContext())
+                {
+                    var genCtx = new SpilledExpressionEntry(StackValueKind.ObjRef, "GenericCtxSlot", GetWellKnownType(WellKnownType.IntPtr), 1, this);
+                    _spilledExpressions.Add(genCtx);
+                    // put the generic context in the slot for reference by funclets
+                    var addressValue = CastIfNecessary(_builder, LoadVarAddress(genCtx.LocalIndex, LocalVarKind.Temp, out TypeDesc unused, _builder), LLVMTypeRef.CreatePointer(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), 0));
+                    _builder.BuildStore(_llvmFunction.GetParam(GetHiddenContextParamNo()), addressValue);
+                }
             }
 
             // Copy arguments onto the stack to allow
@@ -446,19 +454,7 @@ namespace Internal.IL
                 {
                     returnType = LLVMTypeRef.Void;
                 }
-                // Funclets accept a shadow stack pointer and a generic ctx hidden param if the owning method has one
-                var baseArgCount = kind == ILExceptionRegionKind.Filter ? 2 : 1; // filter funclets take the exception, maybe catch should also?
-                var funcletArgs = new LLVMTypeRef[FuncletsRequireHiddenContext() ? baseArgCount + 1 : baseArgCount];
-                int argIx = 0;
-                funcletArgs[argIx++] = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
-                if (FuncletsRequireHiddenContext())
-                {
-                    funcletArgs[argIx++] = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
-                }
-                if (kind == ILExceptionRegionKind.Filter)
-                {
-                    funcletArgs[argIx++] = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
-                }
+                var funcletArgs = new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) }; 
                 LLVMTypeRef universalFuncletSignature = LLVMTypeRef.CreateFunction(returnType, funcletArgs, false);
                 funclet = Module.AddFunction(funcletName, universalFuncletSignature);
 
@@ -2823,49 +2819,21 @@ namespace Internal.IL
                                                                                                                                     LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0),
                                                                                                                                     LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0),
                                                                                                                                 }, false));
-                BuildCatchFunclet(Module, "LlvmCatchFuncletGeneric", 
+                BuildCatchFunclet(Module, 
                     new LLVMTypeRef[]
                     {
-                        LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0),
-                        LLVMTypeRef.CreatePointer(LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32, new LLVMTypeRef[]
-                        {
-                            LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), 
-                            LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)
-                        }, false), 0), // pHandlerIP - catch funcletAddress, generic context
-                        LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // shadow stack
-                        LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // generic context
-                    }, true /* add the generic context param */);
-                BuildCatchFunclet(Module, "LlvmCatchFunclet", 
-                    new LLVMTypeRef[]
-                    {
-                        LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0),
                         LLVMTypeRef.CreatePointer(LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32, new LLVMTypeRef[]
                         {
                             LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)
                         }, false), 0), // pHandlerIP - catch funcletAddress
                         LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // shadow stack
                     });
-                BuildFilterFunclet(Module, "LlvmFilterFuncletGeneric",
+                BuildFilterFunclet(Module, 
                     new LLVMTypeRef[]
                     {
-                        LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // exception object
-                        LLVMTypeRef.CreatePointer(LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32, new LLVMTypeRef[]
-                        {
-                            LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // shadow stack 
-                            LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // exception object
-                            LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) // generic context
-                        }, false), 0), // pHandlerIP - catch funcletAddress, generic context
-                        LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // shadow stack
-                        LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // generic context
-                    }, true /* add the generic context param */);
-                BuildFilterFunclet(Module, "LlvmFilterFunclet",
-                    new LLVMTypeRef[]
-                    {
-                        LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // exception object
                         LLVMTypeRef.CreatePointer(LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32, new LLVMTypeRef[]
                         {
                             LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // shadow stack
-                            LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) // exception object
                         }, false), 0), // pHandlerIP - catch funcletAddress
                         LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // shadow stack
                     });
@@ -2905,7 +2873,6 @@ namespace Internal.IL
                                                  new ExpressionEntry(StackValueKind.Int32, "idxStart", LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, 0xFFFFFFFFu, false)), 
                                                  new ExpressionEntry(StackValueKind.Int32, "idxTryLandingStart", LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, (ulong)tryRegion.ILRegion.TryOffset, false)),
                                                  new ExpressionEntry(StackValueKind.NativeInt, "shadowStack", _currentFunclet.GetParam(0)),
-                                                 new ExpressionEntry(StackValueKind.NativeInt, "exInfo", GetGenericContextParamForFunclet()),
                                                  new ExpressionEntry(StackValueKind.ByRef, "refFrameIter", ehInfoIterator),
                                                  new ExpressionEntry(StackValueKind.ByRef, "tryRegionIdx", tryRegionIdx),
                                                  new ExpressionEntry(StackValueKind.ByRef, "pHandler", handlerFuncPtr)
@@ -2926,10 +2893,10 @@ namespace Internal.IL
 
             LLVMValueRef[] callCatchArgs = new LLVMValueRef[]
                                   {
-                                      CastIfNecessary(landingPadBuilder, managedPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)),
+                                      LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)),
                                       CastIfNecessary(landingPadBuilder, handlerFunc, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)), /* catch funclet address */
                                       _currentFunclet.GetParam(0),
-                                      GetGenericContextParamForFunclet()
+                                      LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0))
                                   };
             LLVMValueRef leaveReturnValue = landingPadBuilder.BuildCall(RhpCallCatchFunclet, callCatchArgs, "");
 
@@ -4759,13 +4726,8 @@ namespace Internal.IL
                     // Work backwards through containing finally blocks to call them in the right order
                     BasicBlock finallyBlock = _basicBlocks[r.ILRegion.HandlerOffset];
                     MarkBasicBlock(finallyBlock);
-                    var funcletParams = new LLVMValueRef[FuncletsRequireHiddenContext() ? 2 : 1];
-                    funcletParams[0] = _currentFunclet.GetParam(0);
+                    var funcletParams = new LLVMValueRef[] {_currentFunclet.GetParam(0)};
 
-                    if (FuncletsRequireHiddenContext())
-                    {
-                        funcletParams[1] = _currentFunclet.GetParam(GetHiddenContextParamNo());
-                    }
                     // todo morganb: this should use invoke if the finally is inside of an outer try block
                     _builder.BuildCall(GetFuncletForBlock(finallyBlock), funcletParams, String.Empty);
                 }
@@ -4825,7 +4787,10 @@ namespace Internal.IL
 
                 return _builder.BuildLoad( thisPtr, "methodTablePtrRef");
             }
-            return CastIfNecessary(_builder, _currentFunclet.GetParam(GetHiddenContextParamNo() /* hidden param after shadow stack and return slot if present */), LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "HiddenArg");
+            // if the function has exception regions, the generic context is stored in a local, otherwise get it from the parameters
+            return _exceptionRegions.Length > 0
+                ? _builder.BuildLoad(CastIfNecessary(_builder, LoadVarAddress(1, LocalVarKind.Temp, out TypeDesc unused, _builder),  LLVMTypeRef.CreatePointer(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), 0), "ctx"))
+                : CastIfNecessary(_builder, _currentFunclet.GetParam(GetHiddenContextParamNo() /* hidden param after shadow stack and return slot if present */), LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "HiddenArg");
         }
 
         uint GetHiddenContextParamNo()

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -4800,7 +4800,7 @@ namespace Internal.IL
 
         bool FuncletsRequireHiddenContext()
         {
-            return _method.IsSharedByGenericInstantiations && !_method.AcquiresInstMethodTableFromThis();
+            return _method.RequiresInstArg();
         }
 
         LLVMValueRef GetGenericContextParamForFunclet()

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
@@ -159,41 +159,26 @@ namespace Internal.IL
             return null;
         }
 
-        static void BuildCatchFunclet(LLVMModuleRef module, string funcletName, LLVMTypeRef[] funcletArgTypes, bool passGenericContext = false)
+        static void BuildCatchFunclet(LLVMModuleRef module, LLVMTypeRef[] funcletArgTypes)
         {
-            LlvmCatchFunclet = module.AddFunction(funcletName, LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32, 
-                funcletArgTypes, false));
+            LlvmCatchFunclet = module.AddFunction("LlvmCatchFunclet", LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32, funcletArgTypes, false));
             var block = LlvmCatchFunclet.AppendBasicBlock("Catch");
             LLVMBuilderRef funcletBuilder = Context.CreateBuilder();
             funcletBuilder.PositionAtEnd( block);
 
-            List<LLVMValueRef> llvmArgs = new List<LLVMValueRef>();
-            llvmArgs.Add(LlvmCatchFunclet.GetParam(2));
-            if (passGenericContext)
-            {
-                llvmArgs.Add(LlvmCatchFunclet.GetParam(3));
-            }
-            LLVMValueRef leaveToILOffset = funcletBuilder.BuildCall(LlvmCatchFunclet.GetParam(1), llvmArgs.ToArray(), string.Empty);
+            LLVMValueRef leaveToILOffset = funcletBuilder.BuildCall(LlvmCatchFunclet.GetParam(0), new LLVMValueRef[] { LlvmCatchFunclet.GetParam(1) }, "callCatch");
             funcletBuilder.BuildRet(leaveToILOffset);
             funcletBuilder.Dispose();
         }
 
-        static void BuildFilterFunclet(LLVMModuleRef module, string funcletName, LLVMTypeRef[] funcletArgTypes, bool passGenericContext = false)
+        static void BuildFilterFunclet(LLVMModuleRef module, LLVMTypeRef[] funcletArgTypes)
         {
-            LlvmFilterFunclet = module.AddFunction(funcletName, LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32,
-                funcletArgTypes, false));
+            LlvmFilterFunclet = module.AddFunction("LlvmFilterFunclet", LLVMTypeRef.CreateFunction(LLVMTypeRef.Int32,  funcletArgTypes, false));
             var block = LlvmFilterFunclet.AppendBasicBlock("Filter");
             LLVMBuilderRef funcletBuilder = Context.CreateBuilder();
             funcletBuilder.PositionAtEnd(block);
 
-            List<LLVMValueRef> llvmArgs = new List<LLVMValueRef>();
-            llvmArgs.Add(LlvmFilterFunclet.GetParam(2)); //shadow stack
-            llvmArgs.Add(LlvmFilterFunclet.GetParam(0)); // exception object
-            if (passGenericContext)
-            {
-                llvmArgs.Add(LlvmFilterFunclet.GetParam(3));
-            }
-            LLVMValueRef filterResult = funcletBuilder.BuildCall(LlvmFilterFunclet.GetParam(1), llvmArgs.ToArray(), string.Empty);
+            LLVMValueRef filterResult = funcletBuilder.BuildCall(LlvmFilterFunclet.GetParam(0), new LLVMValueRef[] { LlvmFilterFunclet.GetParam(1) }, "callFilter");
             funcletBuilder.BuildRet(filterResult);
             funcletBuilder.Dispose();
         }
@@ -206,7 +191,7 @@ namespace Internal.IL
                     LLVMTypeRef.CreatePointer(LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)}, false), 0), // finallyHandler
                     LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), // shadow stack
                 }, false));
-            var block = LlvmFinallyFunclet.AppendBasicBlock("GenericFinally");
+            var block = LlvmFinallyFunclet.AppendBasicBlock("Finally");
             LLVMBuilderRef funcletBuilder = Context.CreateBuilder();
             funcletBuilder.PositionAtEnd(block);
 

--- a/src/Native/Bootstrap/main.cpp
+++ b/src/Native/Bootstrap/main.cpp
@@ -267,22 +267,16 @@ extern "C" void RhpThrowHwEx()
 
 #if defined(HOST_WASM)
 // returns the Leave target
-extern "C" uint32_t LlvmCatchFunclet(void * exceptionObj, void* pHandlerIP, void* pvRegDisplay); 
-extern "C" uint32_t LlvmCatchFuncletGeneric(void * exceptionObj, void* pHandlerIP, void* pvRegDisplay, void * genericContext); 
-extern "C" uint32_t RhpCallCatchFunclet(void * exceptionObj, void* pHandlerIP, void* pvRegDisplay, void *exInfo /* generic context, if any */)
+extern "C" uint32_t LlvmCatchFunclet(void* pHandlerIP, void* pvRegDisplay); 
+extern "C" uint32_t RhpCallCatchFunclet(void * exceptionObj, void* pHandlerIP, void* pvRegDisplay, void *exInfo)
 {
-    return exInfo 
-        ? LlvmCatchFuncletGeneric(exceptionObj, pHandlerIP, pvRegDisplay, exInfo)
-        : LlvmCatchFunclet(exceptionObj, pHandlerIP, pvRegDisplay);
+    return LlvmCatchFunclet(pHandlerIP, pvRegDisplay);
 }
 
-extern "C" uint32_t LlvmFilterFunclet(void* exceptionObj, unsigned int pHandlerIP, void* pvRegDisplay);
-extern "C" uint32_t LlvmFilterFuncletGeneric(void* exceptionObj, unsigned int pHandlerIP, void* pvRegDisplay, void* genericContext);
-extern "C" uint32_t RhpCallFilterFunclet(void* exceptionObj, unsigned int pHandlerIP, void* shadowStack)
+extern "C" uint32_t LlvmFilterFunclet(void* pHandlerIP, void* pvRegDisplay);
+extern "C" uint32_t RhpCallFilterFunclet(void* exceptionObj, void * pHandlerIP, void* shadowStack)
 {
-    return 0 /* how to tell we need the generic context ? */
-        ? LlvmFilterFuncletGeneric(exceptionObj, pHandlerIP, shadowStack, NULL /* generic context do we pass this? */)
-        : LlvmFilterFunclet(exceptionObj, pHandlerIP, shadowStack);
+    return LlvmFilterFunclet(pHandlerIP, shadowStack);
 }
 #else 
 extern "C" uint32_t RhpCallCatchFunclet(void *, void*, void*, void*)

--- a/src/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
+++ b/src/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
@@ -39,8 +39,7 @@ namespace System.Runtime
 
         // TODO: temporary to try things out, when working look to see how to refactor with FindFirstPassHandler
         private static bool FindFirstPassHandlerWasm(object exception, uint idxStart, uint idxTryLandingStart /* the start IL idx of the try region for the landing pad, will use in place of PC */, 
-            void* shadowStack, void* exInfo,
-            ref EHClauseIterator clauseIter, out uint tryRegionIdx, out byte* pHandler)
+            void* shadowStack, ref EHClauseIterator clauseIter, out uint tryRegionIdx, out byte* pHandler)
         {
             pHandler = (byte*)0;
             tryRegionIdx = MaxTryRegionIdx;


### PR DESCRIPTION
This enables access to the generic context in catch and filter funclets.  It follows https://github.com/dotnet/corert/pull/8125#issuecomment-622962485 and does the same for wasm - stores the generic context in a local (if exception blocks are present) instead of passing it around.