### PR TITLE
Wasm: 2 fixes for handling returned generic structs

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -428,6 +428,16 @@ namespace Internal.IL
 
         protected override LLVMValueRef ValueAsTypeInternal(LLVMTypeRef type, LLVMBuilderRef builder, bool signExtend)
         {
+            if (type.IsPackedStruct && type.Handle != RawLLVMValue.TypeOf.Handle)
+            {
+                var destStruct = type.Undef;
+                for (uint elemNo = 0; elemNo < RawLLVMValue.TypeOf.StructElementTypesCount; elemNo++)
+                {
+                    var elemValRef = builder.BuildExtractValue(RawLLVMValue, 0, "ex" + elemNo);
+                    destStruct = builder.BuildInsertValue(destStruct, elemValRef, elemNo, "st" + elemNo);
+                }
+                return destStruct;
+            }
             return ILImporter.CastIfNecessary(builder, RawLLVMValue, type, Name, !signExtend);
         }
     }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -4625,10 +4625,9 @@ namespace Internal.IL
             FieldDesc runtimeDeterminedField = (FieldDesc)_methodIL.GetObject(token);
             FieldDesc field = (FieldDesc)_canonMethodIL.GetObject(token);
             StackEntry valueEntry = _stack.Pop();
-            TypeDesc fieldType = _compilation.ConvertToCanonFormIfNecessary(field.FieldType, CanonicalFormKind.Specific);
 
             LLVMValueRef fieldAddress = GetFieldAddress(runtimeDeterminedField, field, isStatic);
-            CastingStore(fieldAddress, valueEntry, fieldType);
+            CastingStore(fieldAddress, valueEntry, field.FieldType);
         }
 
         // Loads symbol address. Address is represented as a i32*

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1173,6 +1173,7 @@ internal static class Program
         new GenClassUsingFieldOfInnerStruct<GenClassWithInnerStruct<string>.GenInterfaceOverGenStructStruct>(
             new GenClassWithInnerStruct<string>.GenInterfaceOverGenStructStruct(), null).Create();
 
+        // replicate compilation error with https://github.com/dotnet/runtime/blob/b57a099c1773eeb52d3c663211e275131b4b7938/src/libraries/System.Net.Primitives/src/System/Net/CredentialCache.cs#L328
         new GenClassWithInnerStruct<string>().SetField("");
 
         PassTest();

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1144,6 +1144,18 @@ internal static class Program
         }
     }
 
+    public struct GenStruct2<TKey, T2>
+    {
+        private TKey key;
+        T2 field2;
+
+        public GenStruct2(TKey key, T2 v)
+        {
+            this.key = key;
+            this.field2 = v;
+        }
+    }
+
     private static void TestGenericStructHandling()
     {
         StartTest("Casting of generic structs on return and in call params");
@@ -1154,15 +1166,37 @@ internal static class Program
         // test call param is cast
         GenStructCallParam(new GenStructWithImplicitOp<string>());
 
+        // replicate compilation error with https://github.com/dotnet/corert/blob/66fbcd492fbc08db4f472e7e8fa368cb523b38d4/src/System.Private.CoreLib/shared/System/Array.cs#L1482
+        GenStructCallParam(CreateGenStructWithImplicitOp<string>(new [] {""}));
+
         // replicate compilation error with https://github.com/dotnet/corefx/blob/e99ec129cfd594d53f4390bf97d1d736cff6f860/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs#L561
         new GenClassUsingFieldOfInnerStruct<GenClassWithInnerStruct<string>.GenInterfaceOverGenStructStruct>(
             new GenClassWithInnerStruct<string>.GenInterfaceOverGenStructStruct(), null).Create();
 
+        new GenClassWithInnerStruct<string>().SetField("");
+
         PassTest();
+    }
+
+    private static GenStructWithImplicitOp<T> CreateGenStructWithImplicitOp<T>(T[] v)
+    {
+        return new GenStructWithImplicitOp<T>(v);
+    }
+
+    private static GenStruct2<T, T2> CreateGenStruct2<T, T2>(T k, T2 v)
+    {
+        return new GenStruct2<T, T2>(k, v);
     }
 
     public class GenClassWithInnerStruct<TKey>
     {
+        private GenStruct2<TKey, string> structField;
+
+        public void SetField(TKey v)
+        {
+            structField = Program.CreateGenStruct2(v, "");
+        }
+
         internal readonly struct GenInterfaceOverGenStructStruct 
         {
             // 2 fields to avoid struct collapsing to an i32


### PR DESCRIPTION
This PR fixes the following 2 issues with generic structs

1. Where a generic struct is returned and passed immediately into another generic method, e.g. https://github.com/dotnet/corert/blob/66fbcd492fbc08db4f472e7e8fa368cb523b38d4/src/System.Private.CoreLib/shared/System/Array.cs#L1482  compilation is failing due to a type mismatch on the struct type.  The opposite of https://github.com/dotnet/corert/pull/7938.  Not hit previously as in many cases the struct is stored locally which does the casting when loading.

2. Where the generic struct `<T1,T2>` has `T2` defined, the storage in a local field fails due to the wrong type (`<_Canon, _Canon>` not `<_Canon, String>`) being used.  E.g. 
https://github.com/dotnet/runtime/blob/b57a099c1773eeb52d3c663211e275131b4b7938/src/libraries/System.Net.Primitives/src/System/Net/CredentialCache.cs#L328
