### PR TITLE
Wasm: Example for JS interop and target change to allow custom emcc parameters

### DIFF
--- a/src/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -314,7 +314,7 @@ See the LICENSE file in the project root for more information.
     
     <PropertyGroup>
       <EmccArgs>&quot;$(NativeObject)&quot; -o &quot;$(NativeBinary)&quot; -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s DISABLE_EXCEPTION_CATCHING=0 --emrun </EmccArgs>
-      <EmccArgs Condition="'$(Platform)'=='wasm'">$(EmccArgs) &quot;$(IlcPath)/sdk/libPortableRuntime.a&quot; &quot;$(IlcPath)/sdk/libbootstrappercpp.a&quot; &quot;$(IlcPath)/sdk/libSystem.Private.CoreLib.Native.a&quot; </EmccArgs>
+      <EmccArgs Condition="'$(Platform)'=='wasm'">$(EmccArgs) &quot;$(IlcPath)/sdk/libPortableRuntime.a&quot; &quot;$(IlcPath)/sdk/libbootstrappercpp.a&quot; &quot;$(IlcPath)/sdk/libSystem.Private.CoreLib.Native.a&quot; $(EmccExtraArgs)</EmccArgs>
       <EmccArgs Condition="'$(Configuration)'=='Release'">$(EmccArgs) -O2 -flto</EmccArgs>
       <EmccArgs Condition="'$(Configuration)'=='Debug'">$(EmccArgs) -g3</EmccArgs>
     </PropertyGroup>

--- a/tests/src/Simple/HelloWasm/HelloWasm.csproj
+++ b/tests/src/Simple/HelloWasm/HelloWasm.csproj
@@ -5,8 +5,8 @@
     <ProjectReference Include="CpObj.ilproj" Condition="'$(OS)' == 'Windows_NT'" />
     <IlcArg Include="-r:$(IntermediateOutputPath)\CpObj.dll" Condition="'$(OS)' == 'Windows_NT'" />
     <ProjectReference Include="CkFinite.ilproj" Condition="'$(OS)' == 'Windows_NT'" />
-    <IlcArg Include="-r:$(IntermediateOutputPath)\CkFinite.dll" Condition="'$(OS)' == 'Windows_NT'" />	
-	<ProjectReference Include="ILHelpers.ilproj" Condition="'$(OS)' == 'Windows_NT'" />
+    <IlcArg Include="-r:$(IntermediateOutputPath)\CkFinite.dll" Condition="'$(OS)' == 'Windows_NT'" />
+    <ProjectReference Include="ILHelpers.ilproj" Condition="'$(OS)' == 'Windows_NT'" />
     <IlcArg Include="-r:$(IntermediateOutputPath)\ILHelpers.dll" Condition="'$(OS)' == 'Windows_NT'" />
   </ItemGroup>
 
@@ -14,5 +14,8 @@
     <DefineConstants>TARGET_WINDOWS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <EmccExtraArgs>--js-library $(MSBuildProjectDirectory)\dotnet_support.js --pre-js $(MSBuildProjectDirectory)\Microsoft.JSInterop.js --post-js $(MSBuildProjectDirectory)\HelloWasm.js</EmccExtraArgs>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), SimpleTest.targets))\SimpleTest.targets" />
 </Project>

--- a/tests/src/Simple/HelloWasm/HelloWasm.js
+++ b/tests/src/Simple/HelloWasm/HelloWasm.js
@@ -1,0 +1,1 @@
+window.Answer = function () { return 42; }

--- a/tests/src/Simple/HelloWasm/Microsoft.JSInterop.js
+++ b/tests/src/Simple/HelloWasm/Microsoft.JSInterop.js
@@ -1,0 +1,240 @@
+
+if(typeof window === 'undefined') {
+    window = global;
+    window.location = {
+        search: ''
+    };
+} // create window for node and set to global
+
+// This is a single-file self-contained module to avoid the need for a Webpack build
+var DotNet;
+(function (DotNet) {
+    window.DotNet = DotNet; // Ensure reachable from anywhere
+    const jsonRevivers = [];
+    const pendingAsyncCalls = {};
+    const cachedJSFunctions = {};
+    let nextAsyncCallId = 1; // Start at 1 because zero signals "no response needed"
+    let dotNetDispatcher = null;
+    /**
+     * Sets the specified .NET call dispatcher as the current instance so that it will be used
+     * for future invocations.
+     *
+     * @param dispatcher An object that can dispatch calls from JavaScript to a .NET runtime.
+     */
+    function attachDispatcher(dispatcher) {
+        dotNetDispatcher = dispatcher;
+    }
+    DotNet.attachDispatcher = attachDispatcher;
+    /**
+     * Adds a JSON reviver callback that will be used when parsing arguments received from .NET.
+     * @param reviver The reviver to add.
+     */
+    function attachReviver(reviver) {
+        jsonRevivers.push(reviver);
+    }
+    DotNet.attachReviver = attachReviver;
+    /**
+     * Invokes the specified .NET public method synchronously. Not all hosting scenarios support
+     * synchronous invocation, so if possible use invokeMethodAsync instead.
+     *
+     * @param assemblyName The short name (without key/version or .dll extension) of the .NET assembly containing the method.
+     * @param methodIdentifier The identifier of the method to invoke. The method must have a [JSInvokable] attribute specifying this identifier.
+     * @param args Arguments to pass to the method, each of which must be JSON-serializable.
+     * @returns The result of the operation.
+     */
+    function invokeMethod(assemblyName, methodIdentifier, ...args) {
+        return invokePossibleInstanceMethod(assemblyName, methodIdentifier, null, args);
+    }
+    DotNet.invokeMethod = invokeMethod;
+    /**
+     * Invokes the specified .NET public method asynchronously.
+     *
+     * @param assemblyName The short name (without key/version or .dll extension) of the .NET assembly containing the method.
+     * @param methodIdentifier The identifier of the method to invoke. The method must have a [JSInvokable] attribute specifying this identifier.
+     * @param args Arguments to pass to the method, each of which must be JSON-serializable.
+     * @returns A promise representing the result of the operation.
+     */
+    function invokeMethodAsync(assemblyName, methodIdentifier, ...args) {
+        return invokePossibleInstanceMethodAsync(assemblyName, methodIdentifier, null, args);
+    }
+    DotNet.invokeMethodAsync = invokeMethodAsync;
+    function invokePossibleInstanceMethod(assemblyName, methodIdentifier, dotNetObjectId, args) {
+        const dispatcher = getRequiredDispatcher();
+        if (dispatcher.invokeDotNetFromJS) {
+            const argsJson = JSON.stringify(args, argReplacer);
+            const resultJson = dispatcher.invokeDotNetFromJS(assemblyName, methodIdentifier, dotNetObjectId, argsJson);
+            return resultJson ? parseJsonWithRevivers(resultJson) : null;
+        }
+        else {
+            throw new Error('The current dispatcher does not support synchronous calls from JS to .NET. Use invokeMethodAsync instead.');
+        }
+    }
+    function invokePossibleInstanceMethodAsync(assemblyName, methodIdentifier, dotNetObjectId, args) {
+        if (assemblyName && dotNetObjectId) {
+            throw new Error(`For instance method calls, assemblyName should be null. Received '${assemblyName}'.`);
+        }
+        const asyncCallId = nextAsyncCallId++;
+        const resultPromise = new Promise((resolve, reject) => {
+            pendingAsyncCalls[asyncCallId] = { resolve, reject };
+        });
+        try {
+            const argsJson = JSON.stringify(args, argReplacer);
+            getRequiredDispatcher().beginInvokeDotNetFromJS(asyncCallId, assemblyName, methodIdentifier, dotNetObjectId, argsJson);
+        }
+        catch (ex) {
+            // Synchronous failure
+            completePendingCall(asyncCallId, false, ex);
+        }
+        return resultPromise;
+    }
+    function getRequiredDispatcher() {
+        if (dotNetDispatcher !== null) {
+            return dotNetDispatcher;
+        }
+        throw new Error('No .NET call dispatcher has been set.');
+    }
+    function completePendingCall(asyncCallId, success, resultOrError) {
+        if (!pendingAsyncCalls.hasOwnProperty(asyncCallId)) {
+            throw new Error(`There is no pending async call with ID ${asyncCallId}.`);
+        }
+        const asyncCall = pendingAsyncCalls[asyncCallId];
+        delete pendingAsyncCalls[asyncCallId];
+        if (success) {
+            asyncCall.resolve(resultOrError);
+        }
+        else {
+            asyncCall.reject(resultOrError);
+        }
+    }
+    /**
+     * Receives incoming calls from .NET and dispatches them to JavaScript.
+     */
+    DotNet.jsCallDispatcher = {
+        /**
+         * Finds the JavaScript function matching the specified identifier.
+         *
+         * @param identifier Identifies the globally-reachable function to be returned.
+         * @returns A Function instance.
+         */
+        findJSFunction,
+        /**
+         * Invokes the specified synchronous JavaScript function.
+         *
+         * @param identifier Identifies the globally-reachable function to invoke.
+         * @param argsJson JSON representation of arguments to be passed to the function.
+         * @returns JSON representation of the invocation result.
+         */
+        invokeJSFromDotNet: (identifier, argsJson) => {
+            const result = findJSFunction(identifier).apply(null, parseJsonWithRevivers(argsJson));
+            return result === null || result === undefined
+                ? null
+                : JSON.stringify(result, argReplacer);
+        },
+        /**
+         * Invokes the specified synchronous or asynchronous JavaScript function.
+         *
+         * @param asyncHandle A value identifying the asynchronous operation. This value will be passed back in a later call to endInvokeJSFromDotNet.
+         * @param identifier Identifies the globally-reachable function to invoke.
+         * @param argsJson JSON representation of arguments to be passed to the function.
+         */
+        beginInvokeJSFromDotNet: (asyncHandle, identifier, argsJson) => {
+            // Coerce synchronous functions into async ones, plus treat
+            // synchronous exceptions the same as async ones
+            const promise = new Promise(resolve => {
+                const synchronousResultOrPromise = findJSFunction(identifier).apply(null, parseJsonWithRevivers(argsJson));
+                resolve(synchronousResultOrPromise);
+            });
+            // We only listen for a result if the caller wants to be notified about it
+            if (asyncHandle) {
+                // On completion, dispatch result back to .NET
+                // Not using "await" because it codegens a lot of boilerplate
+                promise.then(result => getRequiredDispatcher().endInvokeJSFromDotNet(asyncHandle, true, JSON.stringify([asyncHandle, true, result], argReplacer)), error => getRequiredDispatcher().endInvokeJSFromDotNet(asyncHandle, false, JSON.stringify([asyncHandle, false, formatError(error)])));
+            }
+        },
+        /**
+         * Receives notification that an async call from JS to .NET has completed.
+         * @param asyncCallId The identifier supplied in an earlier call to beginInvokeDotNetFromJS.
+         * @param success A flag to indicate whether the operation completed successfully.
+         * @param resultOrExceptionMessage Either the operation result or an error message.
+         */
+        endInvokeDotNetFromJS: (asyncCallId, success, resultOrExceptionMessage) => {
+            const resultOrError = success ? resultOrExceptionMessage : new Error(resultOrExceptionMessage);
+            completePendingCall(parseInt(asyncCallId), success, resultOrError);
+        }
+    };
+    function parseJsonWithRevivers(json) {
+        return json ? JSON.parse(json, (key, initialValue) => {
+            // Invoke each reviver in order, passing the output from the previous reviver,
+            // so that each one gets a chance to transform the value
+            return jsonRevivers.reduce((latestValue, reviver) => reviver(key, latestValue), initialValue);
+        }) : null;
+    }
+    function formatError(error) {
+        if (error instanceof Error) {
+            return `${error.message}\n${error.stack}`;
+        }
+        else {
+            return error ? error.toString() : 'null';
+        }
+    }
+    function findJSFunction(identifier) {
+        if (cachedJSFunctions.hasOwnProperty(identifier)) {
+            return cachedJSFunctions[identifier];
+        }
+        let result = window;
+        let resultIdentifier = 'window';
+        let lastSegmentValue;
+        identifier.split('.').forEach(segment => {
+            if (segment in result) {
+                lastSegmentValue = result;
+                result = result[segment];
+                resultIdentifier += '.' + segment;
+            }
+            else {
+                throw new Error(`Could not find '${segment}' in '${resultIdentifier}'.`);
+            }
+        });
+        if (result instanceof Function) {
+            result = result.bind(lastSegmentValue);
+            cachedJSFunctions[identifier] = result;
+            return result;
+        }
+        else {
+            throw new Error(`The value '${resultIdentifier}' is not a function.`);
+        }
+    }
+    class DotNetObject {
+        constructor(_id) {
+            this._id = _id;
+        }
+        invokeMethod(methodIdentifier, ...args) {
+            return invokePossibleInstanceMethod(null, methodIdentifier, this._id, args);
+        }
+        invokeMethodAsync(methodIdentifier, ...args) {
+            return invokePossibleInstanceMethodAsync(null, methodIdentifier, this._id, args);
+        }
+        dispose() {
+            const promise = invokePossibleInstanceMethodAsync(null, '__Dispose', this._id, null);
+            promise.catch(error => console.error(error));
+        }
+        serializeAsArg() {
+            return { __dotNetObject: this._id };
+        }
+    }
+    const dotNetObjectRefKey = '__dotNetObject';
+    attachReviver(function reviveDotNetObject(key, value) {
+        if (value && typeof value === 'object' && value.hasOwnProperty(dotNetObjectRefKey)) {
+            return new DotNetObject(value.__dotNetObject);
+        }
+        // Unrecognized - let another reviver handle it
+        return value;
+    });
+    function argReplacer(key, value) {
+        return value instanceof DotNetObject ? value.serializeAsArg() : value;
+    }
+})(DotNet || (DotNet = {}));
+//
+//# sourceMappingURL=Microsoft.JSInterop.js.map
+//
+//
+

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -353,6 +353,8 @@ internal static class Program
 
         TestIntOverflows();
 
+        TestJavascriptCall();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -2133,6 +2135,15 @@ internal static class Program
         PassTest();
     }
 
+    static void TestJavascriptCall()
+    {
+        StartTest("Test Javascript call");
+
+        IntPtr resultPtr = JSInterop.InternalCalls.InvokeJSUnmarshalled(out string exception, "Answer", IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+
+        EndTest(resultPtr.ToInt32() == 42);
+    }
+
     static ushort ReadUInt16()
     {
         // something with MSB set
@@ -2147,6 +2158,20 @@ internal static class Program
 
     [DllImport("*")]
     private static unsafe extern int printf(byte* str, byte* unused);
+}
+
+namespace JSInterop
+{
+    internal static class InternalCalls
+    {
+        [DllImport("*", EntryPoint = "corert_wasm_invoke_js_unmarshalled")]
+        private static extern IntPtr InvokeJSUnmarshalledInternal(string js, int length, IntPtr p1, IntPtr p2, IntPtr p3, out string exception);
+
+        public static IntPtr InvokeJSUnmarshalled(out string exception, string js, IntPtr p1, IntPtr p2, IntPtr p3)
+        {
+            return InvokeJSUnmarshalledInternal(js, js.Length, p1, p2, p3, out exception);
+        }
+    }
 }
 
 public class ClassForNre

--- a/tests/src/Simple/HelloWasm/dotnet_support.js
+++ b/tests/src/Simple/HelloWasm/dotnet_support.js
@@ -1,0 +1,41 @@
+
+var DotNetSupportLib = {
+	$DOTNET: {
+		_dotnet_get_global: function() {
+			function testGlobal(obj) {
+				obj['___dotnet_global___'] = obj;
+				var success = typeof ___dotnet_global___ === 'object' && obj['___dotnet_global___'] === obj;
+				if (!success) {
+					delete obj['___dotnet_global___'];
+				}
+				return success;
+			}
+			if (typeof ___dotnet_global___ === 'object') {
+				return ___dotnet_global___;
+			}
+			if (typeof global === 'object' && testGlobal(global)) {
+				___dotnet_global___ = global;
+			} else if (typeof window === 'object' && testGlobal(window)) {
+				___dotnet_global___ = window;
+			}
+			if (typeof ___dotnet_global___ === 'object') {
+				return ___dotnet_global___;
+			}
+			throw Error('unable to get DotNet global object.');
+		},
+	},
+    corert_wasm_invoke_js_unmarshalled: function (js, length, arg0, arg1, arg2, exception) {
+
+        var jsFuncName = UTF8ToString(js, length);
+        var dotNetExports = DOTNET._dotnet_get_global().DotNet;
+        if (!dotNetExports) {
+            throw new Error('The Microsoft.JSInterop.js library is not loaded.');
+        }
+        var funcInstance = dotNetExports.jsCallDispatcher.findJSFunction(jsFuncName);
+
+        return funcInstance.call(null, arg0, arg1, arg2);
+    },
+};
+
+autoAddDeps(DotNetSupportLib, '$DOTNET');
+mergeInto(LibraryManager.library, DotNetSupportLib);

--- a/tests/src/Simple/HelloWasm/dotnet_support.js
+++ b/tests/src/Simple/HelloWasm/dotnet_support.js
@@ -1,29 +1,29 @@
 
 var DotNetSupportLib = {
-	$DOTNET: {
-		_dotnet_get_global: function() {
-			function testGlobal(obj) {
-				obj['___dotnet_global___'] = obj;
-				var success = typeof ___dotnet_global___ === 'object' && obj['___dotnet_global___'] === obj;
-				if (!success) {
-					delete obj['___dotnet_global___'];
-				}
-				return success;
-			}
-			if (typeof ___dotnet_global___ === 'object') {
-				return ___dotnet_global___;
-			}
-			if (typeof global === 'object' && testGlobal(global)) {
-				___dotnet_global___ = global;
-			} else if (typeof window === 'object' && testGlobal(window)) {
-				___dotnet_global___ = window;
-			}
-			if (typeof ___dotnet_global___ === 'object') {
-				return ___dotnet_global___;
-			}
-			throw Error('unable to get DotNet global object.');
-		},
-	},
+    $DOTNET: {
+        _dotnet_get_global: function () {
+            function testGlobal(obj) {
+                obj['___dotnet_global___'] = obj;
+                var success = typeof ___dotnet_global___ === 'object' && obj['___dotnet_global___'] === obj;
+                if (!success) {
+                    delete obj['___dotnet_global___'];
+                }
+                return success;
+            }
+            if (typeof ___dotnet_global___ === 'object') {
+                return ___dotnet_global___;
+            }
+            if (typeof global === 'object' && testGlobal(global)) {
+                ___dotnet_global___ = global;
+            } else if (typeof window === 'object' && testGlobal(window)) {
+                ___dotnet_global___ = window;
+            }
+            if (typeof ___dotnet_global___ === 'object') {
+                return ___dotnet_global___;
+            }
+            throw Error('unable to get DotNet global object.');
+        },
+    },
     corert_wasm_invoke_js_unmarshalled: function (js, length, arg0, arg1, arg2, exception) {
 
         var jsFuncName = UTF8ToString(js, length);


### PR DESCRIPTION
This PR adds an example for how to do JS interop.  The only change to the main project is the build target change to allow additional parameters.  The other changes are in the test HelloWasm project at the moment.  I don't know if they are best left here as an example, or whether it would be good to make some of the code and JS part of the the core project.  I sort of lean to thinking its fine as is and if there was documentation changes this PR could go in?  If it would be better to include any of the JS or classes somewhere else so they are always available let me know.  There are 3 JS files, 

- `dotnet_support.js` - a copy of https://github.com/mono/mono/blob/master/sdks/wasm/src/dotnet_support.js with `mono` changed to `corert` and unused functions removed.
- `Microsoft.JSInterop.js` - this is from https://github.com/dotnet/jsinterop/blob/master/src/Microsoft.JSInterop.JS/src/Microsoft.JSInterop.ts with a small change to allow it to work in node.js
- `HelloWasm.js` - contains the test function