### PR TITLE
Wasm: add overflow checks to sub_ovf and sub_ovf_un

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -3928,7 +3928,7 @@ namespace Internal.IL
                 if (signed)
                 {
                     builder.PositionAtEnd(elseBlock);
-                    // a - b overflows when b is -ve if  a > max + b
+                    // a - b overflows when b is negative if  a > max + b
                     BuildOverflowCheck(builder, rightOp, LLVMIntPredicate.LLVMIntSGT, maxValue, leftOp, ovfBlock, noOvfBlock, LLVMOpcode.LLVMAdd);
                 }
                 builder.PositionAtEnd(opBlock);

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
@@ -120,10 +120,14 @@ namespace Internal.IL
         static LLVMValueRef NullRefFunction = default(LLVMValueRef);
         static LLVMValueRef CkFinite32Function = default(LLVMValueRef);
         static LLVMValueRef CkFinite64Function = default(LLVMValueRef);
-        static LLVMValueRef Ovf32Function = default(LLVMValueRef);
-        static LLVMValueRef OvfUn32Function = default(LLVMValueRef);
-        static LLVMValueRef Ovf64Function = default(LLVMValueRef);
-        static LLVMValueRef OvfUn64Function = default(LLVMValueRef);
+        static LLVMValueRef AddOvf32Function = default(LLVMValueRef);
+        static LLVMValueRef AddOvfUn32Function = default(LLVMValueRef);
+        static LLVMValueRef AddOvf64Function = default(LLVMValueRef);
+        static LLVMValueRef AddOvfUn64Function = default(LLVMValueRef);
+        static LLVMValueRef SubOvf32Function = default(LLVMValueRef);
+        static LLVMValueRef SubOvfUn32Function = default(LLVMValueRef);
+        static LLVMValueRef SubOvf64Function = default(LLVMValueRef);
+        static LLVMValueRef SubOvfUn64Function = default(LLVMValueRef);
         public static LLVMValueRef GxxPersonality = default(LLVMValueRef);
         public static LLVMTypeRef GxxPersonalityType = default(LLVMTypeRef);
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1985,6 +1985,15 @@ internal static class Program
         TestUnsignedIntAddOvf();
 
         TestUnsignedLongAddOvf();
+
+        TestSignedIntSubOvf();
+
+        TestSignedLongSubOvf();
+
+        TestUnsignedIntSubOvf();
+
+        TestUnsignedLongSubOvf();
+
     }
 
     private static void TestSignedLongAddOvf()
@@ -2120,6 +2129,152 @@ internal static class Program
         try
         {
             ulong res = checked(op64l + op64r);
+        }
+        catch (OverflowException)
+        {
+            thrown = true;
+        }
+        if (!thrown)
+        {
+            FailTest("exception not thrown for unsigned i64 addition of +ve number");
+            return;
+        }
+        PassTest();
+    }
+
+    private static void TestSignedLongSubOvf()
+    {
+        StartTest("Test long sub overflows");
+        bool thrown;
+        long op64l = -2;
+        long op64r = long.MaxValue;
+        thrown = false;
+        try
+        {
+            long res = checked(op64l - op64r);
+        }
+        catch (OverflowException)
+        {
+            thrown = true;
+        }
+        if (!thrown)
+        {
+            FailTest("exception not thrown for signed i64 substraction of +ve number");
+            return;
+        }
+        thrown = false;
+        op64l = long.MaxValue; // subtract negative to overflow above the MaxValue
+        op64r = -1;
+        try
+        {
+            long res = checked(op64l - op64r);
+        }
+        catch (OverflowException)
+        {
+            thrown = true;
+        }
+        if (!thrown)
+        {
+            FailTest("exception not thrown for signed i64 addition of -ve number");
+            return;
+        }
+        EndTest(true);
+    }
+
+    private static void TestSignedIntSubOvf()
+    {
+        StartTest("Test int sub overflows");
+        bool thrown;
+        int op32l = 5;
+        int op32r = 2;
+        if (checked(op32l - op32r) != 3)
+        {
+            FailTest("No overflow failed"); // check not always throwing an exception
+            return;
+        }
+        op32l = -2;
+        op32r = int.MaxValue;
+        thrown = false;
+        try
+        {
+            int res = checked(op32l - op32r);
+        }
+        catch (OverflowException)
+        {
+            thrown = true;
+        }
+        if (!thrown)
+        {
+            FailTest("exception not thrown for signed i32 subtraction of +ve number");
+            return;
+        }
+
+        thrown = false;
+        op32l = int.MaxValue; // subtract negative to overflow above the MaxValue
+        op32r = -1;
+        try
+        {
+            int res = checked(op32l - op32r);
+        }
+        catch (OverflowException)
+        {
+            thrown = true;
+        }
+        if (!thrown)
+        {
+            FailTest("exception not thrown for signed i32 subtraction of -ve number");
+            return;
+        }
+        PassTest();
+    }
+
+    private static void TestUnsignedIntSubOvf()
+    {
+        StartTest("Test uint sub overflows");
+        bool thrown;
+        uint op32l = 5;
+        uint op32r = 2;
+        if (checked(op32l - op32r) != 3)
+        {
+            FailTest("No overflow failed"); // check not always throwing an exception
+            return;
+        }
+        op32l = 0;
+        op32r = 1;
+        thrown = false;
+        try
+        {
+            uint res = checked(op32l - op32r);
+        }
+        catch (OverflowException)
+        {
+            thrown = true;
+        }
+        if (!thrown)
+        {
+            FailTest("exception not thrown for unsigned i32 subtraction of +ve number");
+            return;
+        }
+        PassTest();
+    }
+
+    private static void TestUnsignedLongSubOvf()
+    {
+        StartTest("Test ulong sub overflows");
+        bool thrown;
+        ulong op64l = 5;
+        ulong op64r = 2;
+        if (checked(op64l - op64r) != 3)
+        {
+            FailTest("No overflow failed"); // check not always throwing an exception
+            return;
+        }
+        op64l = 0;
+        op64r = 1;
+        thrown = false;
+        try
+        {
+            ulong res = checked(op64l - op64r);
         }
         catch (OverflowException)
         {

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -2013,7 +2013,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for signed i64 addition of +ve number");
+            FailTest("exception not thrown for signed i64 addition of positive number");
             return;
         }
         thrown = false;
@@ -2029,7 +2029,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for signed i64 addition of -ve number");
+            FailTest("exception not thrown for signed i64 addition of negative number");
             return;
         }
         EndTest(true);
@@ -2059,7 +2059,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for signed i32 addition of +ve number");
+            FailTest("exception not thrown for signed i32 addition of positive number");
             return;
         }
 
@@ -2076,7 +2076,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for signed i32 addition of -ve number");
+            FailTest("exception not thrown for signed i32 addition of negative number");
             return;
         }
         PassTest();
@@ -2106,7 +2106,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for unsigned i32 addition of +ve number");
+            FailTest("exception not thrown for unsigned i32 addition of positive number");
             return;
         }
         PassTest();
@@ -2136,7 +2136,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for unsigned i64 addition of +ve number");
+            FailTest("exception not thrown for unsigned i64 addition of positive number");
             return;
         }
         PassTest();
@@ -2159,7 +2159,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for signed i64 substraction of +ve number");
+            FailTest("exception not thrown for signed i64 substraction of positive number");
             return;
         }
         thrown = false;
@@ -2175,7 +2175,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for signed i64 addition of -ve number");
+            FailTest("exception not thrown for signed i64 addition of negative number");
             return;
         }
         EndTest(true);
@@ -2205,7 +2205,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for signed i32 subtraction of +ve number");
+            FailTest("exception not thrown for signed i32 subtraction of positive number");
             return;
         }
 
@@ -2222,7 +2222,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for signed i32 subtraction of -ve number");
+            FailTest("exception not thrown for signed i32 subtraction of negative number");
             return;
         }
         PassTest();
@@ -2252,7 +2252,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for unsigned i32 subtraction of +ve number");
+            FailTest("exception not thrown for unsigned i32 subtraction of positive number");
             return;
         }
         PassTest();
@@ -2282,7 +2282,7 @@ internal static class Program
         }
         if (!thrown)
         {
-            FailTest("exception not thrown for unsigned i64 addition of +ve number");
+            FailTest("exception not thrown for unsigned i64 addition of positive number");
             return;
         }
         PassTest();


### PR DESCRIPTION
This PR refactors and extends the integer add overflow checks to allow them to be used for the sub opcodes.

Still missing, but not part of this PR, mul_ovf(_un) and float equivalents for add/sub/mul, and conv_ovf*