### PR TITLE
Wasm: fix isinst for some generics test

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -1704,28 +1705,24 @@ namespace Internal.IL
             else
                 function = throwing ? "CheckCastClass" : "IsInstanceOfClass";
 
-            StackEntry[] arguments;
+            LLVMValueRef typeRef;
             if (type.IsRuntimeDeterminedSubtype)
             {
-                //TODO refactor argument creation with else below
-                arguments = new StackEntry[]
-                            {
-                                new ExpressionEntry(StackValueKind.ValueType, "eeType", CallGenericHelper(ReadyToRunHelperId.TypeHandle, type),
-                                    GetEETypePtrTypeDesc()),
-                                _stack.Pop()
-                            };
+                typeRef = CallGenericHelper(ReadyToRunHelperId.TypeHandleForCasting, type);
             }
             else
             {
-                arguments = new StackEntry[]
-                                {
-                                    new LoadExpressionEntry(StackValueKind.ValueType, "eeType", GetEETypePointerForTypeDesc(type, true),
-                                        GetEETypePtrTypeDesc()),
-                                    _stack.Pop()
-                                };
+                ISymbolNode lookup = _compilation.ComputeConstantLookup(ReadyToRunHelperId.TypeHandleForCasting, type);
+                _dependencies.Add(lookup);
+                typeRef = LoadAddressOfSymbolNode(lookup);
             }
 
-            _stack.Push(CallRuntime(_compilation.TypeSystemContext, TypeCast, function, arguments, GetWellKnownType(WellKnownType.Object)));
+            _stack.Push(CallRuntime(_compilation.TypeSystemContext, TypeCast, function,
+                new StackEntry[]
+                {
+                    new ExpressionEntry(StackValueKind.ValueType, "eeType", typeRef, GetEETypePtrTypeDesc()),
+                    _stack.Pop()
+                }, GetWellKnownType(WellKnownType.Object)));
         }
 
         LLVMValueRef CallGenericHelper(ReadyToRunHelperId helperId, object helperArg)
@@ -4563,6 +4560,8 @@ namespace Internal.IL
         ISymbolNode GetGenericLookupHelperAndAddReference(ReadyToRunHelperId helperId, object helperArg, out LLVMValueRef helper, IEnumerable<LLVMTypeRef> additionalArgs = null)
         {
             ISymbolNode node;
+            GenericDictionaryLookup lookup = _compilation.ComputeGenericLookup(_method, helperId, helperArg);
+
             var retType = helperId == ReadyToRunHelperId.DelegateCtor
                 ? LLVMTypeRef.Void
                 : LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
@@ -4574,14 +4573,14 @@ namespace Internal.IL
             if (additionalArgs != null) helperArgs.AddRange(additionalArgs);
             if (_method.RequiresInstMethodDescArg())
             {
-                node = _compilation.NodeFactory.ReadyToRunHelperFromDictionaryLookup(helperId, helperArg, _method);
+                node = _compilation.NodeFactory.ReadyToRunHelperFromDictionaryLookup(lookup.HelperId, lookup.HelperObject, _method);
                 helper = GetOrCreateLLVMFunction(node.GetMangledName(_compilation.NameMangler),
                     LLVMTypeRef.CreateFunction(retType, helperArgs.ToArray(), false));
             }
             else
             {
                 Debug.Assert(_method.RequiresInstMethodTableArg() || _method.AcquiresInstMethodTableFromThis());
-                node = _compilation.NodeFactory.ReadyToRunHelperFromTypeLookup(helperId, helperArg, _method.OwningType);
+                node = _compilation.NodeFactory.ReadyToRunHelperFromTypeLookup(lookup.HelperId, lookup.HelperObject, _method.OwningType);
                 helper = GetOrCreateLLVMFunction(node.GetMangledName(_compilation.NameMangler),
                     LLVMTypeRef.CreateFunction(retType, helperArgs.ToArray(), false));
             }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;

--- a/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
@@ -1004,6 +1004,7 @@ namespace ILCompiler.DependencyAnalysis
             
                 // These are all simple: just get the thing from the dictionary and we're done
                 case ReadyToRunHelperId.TypeHandle:
+                case ReadyToRunHelperId.TypeHandleForCasting:
                 case ReadyToRunHelperId.MethodHandle:
                 case ReadyToRunHelperId.FieldHandle:
                 case ReadyToRunHelperId.MethodDictionary:

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -38,9 +38,9 @@ class Program
         TestDevirtualization.Run();
         TestGenericInlining.Run();
 #if !CODEGEN_CPP 
-#if !CODEGEN_WASM
         TestNullableCasting.Run();
         TestVariantCasting.Run();
+#if !CODEGEN_WASM
         TestMDArrayAddressMethod.Run();
         TestNativeLayoutGeneration.Run();
 #endif


### PR DESCRIPTION
Fixes #7934 
This PR follows up on the comment https://github.com/dotnet/corert/pull/7897/files#r362161168 which was correct, there were just a few other things missing.  I admit to having gaps in my understanding of the type handling, but what I've done is compare from 
https://github.com/dotnet/corert/blob/cb72789a97214cd75579e158530a5e91189c40c4/src/ILCompiler.Compiler/src/IL/ILImporter.Scanner.cs#L234-L246
and put in the missing bits to the Wasm backend.  Allows another 2 tests from the simple Generics test.

`TestMDArrayAddressMethod` still fails, but will create another issue for that.