### PR TITLE
Wasm: Support for generic md array tests

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -292,6 +292,7 @@ namespace Internal.IL
                 if (CanStoreTypeOnStack(_signature[i]))
                 {
                     LLVMValueRef storageAddr;
+                    Debug.Assert(signatureIndex < _llvmFunction.ParamsCount);
                     LLVMValueRef argValue = _llvmFunction.GetParam((uint)signatureIndex);
 
                     // The caller will always pass the argument on the stack. If this function doesn't have 
@@ -1991,7 +1992,9 @@ namespace Internal.IL
             {
                 if (!_compilation.NodeFactory.TypeSystemContext.IsSpecialUnboxingThunkTargetMethod(canonMethod))
                 {
-                    hasHiddenParam = canonMethod.RequiresInstArg();
+                    hasHiddenParam = canonMethod.RequiresInstArg() || (canonMethod.IsArrayAddressMethod() &&
+                                                                       (callee.IsSharedByGenericInstantiations ||
+                                                                        canonMethod.IsSharedByGenericInstantiations));
                 }
                 AddMethodReference(canonMethod);
                 return GetOrCreateLLVMFunction(canonMethodName, canonMethod.Signature, hasHiddenParam);

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1992,9 +1992,7 @@ namespace Internal.IL
             {
                 if (!_compilation.NodeFactory.TypeSystemContext.IsSpecialUnboxingThunkTargetMethod(canonMethod))
                 {
-                    hasHiddenParam = canonMethod.RequiresInstArg() || (canonMethod.IsArrayAddressMethod() &&
-                                                                       (callee.IsSharedByGenericInstantiations ||
-                                                                        canonMethod.IsSharedByGenericInstantiations));
+                    hasHiddenParam = canonMethod.RequiresInstArg() || canonMethod.IsArrayAddressMethod();
                 }
                 AddMethodReference(canonMethod);
                 return GetOrCreateLLVMFunction(canonMethodName, canonMethod.Signature, hasHiddenParam);

--- a/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyCodegenNodeFactory.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/DependencyAnalysis/WebAssemblyCodegenNodeFactory.cs
@@ -40,6 +40,10 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     return MethodEntrypoint(TypeSystemContext.GetRealSpecialUnboxingThunkTargetMethod(method));
                 }
+                if (method.IsArrayAddressMethod())
+                {
+                    return new WebAssemblyMethodBodyNode(((ArrayType)method.OwningType).GetArrayMethod(ArrayMethodKind.AddressWithHiddenArg));
+                }
             }
             if (CompilationModuleGroup.ContainsMethodBody(method, false))
             {

--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -40,8 +40,8 @@ class Program
 #if !CODEGEN_CPP 
         TestNullableCasting.Run();
         TestVariantCasting.Run();
-#if !CODEGEN_WASM
         TestMDArrayAddressMethod.Run();
+#if !CODEGEN_WASM
         TestNativeLayoutGeneration.Run();
 #endif
         TestByRefLikeVTables.Run();


### PR DESCRIPTION
This enables the `TestMDArrayAddressMethod` test for Wasm by adding support for the `AddressWithHiddenArg` array method.  It would have been simpler but the signature for this method takes an EETypePtr (a struct of size 4) but the generic context elsewhere is a byte * (`i8*` in LLVM) so I had to special case the LLVM type for EETypePtr which got a bit complicated as its needed where the `TypeSystemContext` is not available - in the `StackExpression`s.  So I created a static which I wasn't that happy about but couldn't see a way round without adding parameters to a lot of methods.

Still to do is the `TestNativeLayoutGeneration` test which is still failing

Closes #8167