### PR TITLE
Wasm: change generic context type

### DIFF
--- a/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
+++ b/src/Common/src/TypeSystem/IL/Stubs/ArrayMethodILEmitter.cs
@@ -103,11 +103,11 @@ namespace Internal.IL.Stubs
                 else if (_method.Kind == ArrayMethodKind.AddressWithHiddenArg)
                 {
                     TypeDesc objectType = context.GetWellKnownType(WellKnownType.Object);
-                    TypeDesc eetypePtrType = context.SystemModule.GetKnownType("System", "EETypePtr");
+                    TypeDesc ptrEetypeType = context.GetPointerType(context.SystemModule.GetKnownType("Internal.Runtime", "EEType"));
 
                     typeMismatchExceptionLabel = _emitter.NewCodeLabel();
 
-                    ILLocalVariable thisEEType = _emitter.NewLocal(eetypePtrType);
+                    ILLocalVariable thisEEType = _emitter.NewLocal(ptrEetypeType);
 
                     ILCodeLabel typeCheckPassedLabel = _emitter.NewCodeLabel();
 
@@ -117,7 +117,7 @@ namespace Internal.IL.Stubs
                     //     goto TypeCheckPassed;
                     codeStream.EmitLdArga(1);
                     codeStream.Emit(ILOpcode.call,
-                        _emitter.NewToken(eetypePtrType.GetKnownMethod("get_IsNull", null)));
+                        _emitter.NewToken(ptrEetypeType.GetKnownMethod("get_IsNull", null)));
                     codeStream.Emit(ILOpcode.brtrue, typeCheckPassedLabel);
 
                     // EETypePtr actualElementType = this.EETypePtr.ArrayElementType;
@@ -126,16 +126,16 @@ namespace Internal.IL.Stubs
                     codeStream.EmitStLoc(thisEEType);
                     codeStream.EmitLdLoca(thisEEType);
                     codeStream.Emit(ILOpcode.call,
-                        _emitter.NewToken(eetypePtrType.GetKnownMethod("get_ArrayElementType", null)));
+                        _emitter.NewToken(ptrEetypeType.GetKnownMethod("get_ArrayElementType", null)));
 
                     // EETypePtr expectedElementType = hiddenArg.ArrayElementType;
                     codeStream.EmitLdArga(1);
                     codeStream.Emit(ILOpcode.call,
-                        _emitter.NewToken(eetypePtrType.GetKnownMethod("get_ArrayElementType", null)));
+                        _emitter.NewToken(ptrEetypeType.GetKnownMethod("get_ArrayElementType", null)));
 
                     // if (expectedElementType != actualElementType)
                     //     ThrowHelpers.ThrowArrayTypeMismatchException();
-                    codeStream.Emit(ILOpcode.call, _emitter.NewToken(eetypePtrType.GetKnownMethod("op_Equality", null)));
+                    codeStream.Emit(ILOpcode.call, _emitter.NewToken(ptrEetypeType.GetKnownMethod("op_Equality", null)));
                     codeStream.Emit(ILOpcode.brfalse, typeMismatchExceptionLabel);
 
                     codeStream.EmitLabel(typeCheckPassedLabel);

--- a/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -439,6 +439,10 @@ namespace ILCompiler
                 // by the (canonical) instance method, but normally not part of the signature in IL).
                 codeStream.EmitLdArg(0);
                 codeStream.Emit(ILOpcode.ldfld, emit.NewToken(eeTypeField));
+                codeStream.Emit(ILOpcode.call, emit.NewToken(Context.SystemModule.GetKnownType("System", "IntPtr").GetMethod(
+                    "op_Explicit", 
+                    new MethodSignature(MethodSignatureFlags.Static, 0, Context.GetPointerType(Context.GetWellKnownType(WellKnownType.Void)),
+                        new TypeDesc[] {Context.GetWellKnownType(WellKnownType.IntPtr) }))));
 
                 // Load rest of the arguments
                 for (int i = 0; i < _targetMethod.Signature.Length; i++)
@@ -586,7 +590,7 @@ namespace ILCompiler
 
                         // Shared instance methods on generic valuetypes have a hidden parameter with the generic context.
                         // We add it to the signature so that we can refer to it from IL.
-                        parameters[0] = Context.GetWellKnownType(WellKnownType.Object).GetKnownField("m_pEEType").FieldType;
+                        parameters[0] = Context.GetPointerType(Context.SystemModule.GetKnownType("Internal.Runtime", "EEType"));
                         for (int i = 0; i < _methodRepresented.Signature.Length; i++)
                             parameters[i + 1] = _methodRepresented.Signature[i];
 


### PR DESCRIPTION
Following from https://github.com/dotnet/corert/pull/8168 , this PR changes the type of the generic context parameter from i8* to EEType*.  You'll notice that I've changed the special unboxing stub and the AddressWithHiddenArg IL to match.  Hopefully I've understood correctly.