### PR TITLE
Wasm: call RhpAssignRef for stfld and stelem

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/LLVMSharpInterop.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/LLVMSharpInterop.cs
@@ -1,0 +1,15 @@
+﻿using LLVMSharp.Interop;
+
+namespace Internal.IL
+{
+    /// <summary>
+    /// Workaround while waiting for https://github.com/microsoft/LLVMSharp/pull/141
+    /// </summary>
+    internal class LLVMSharpInterop
+    {
+        internal static unsafe uint ElementAtOffset(LLVMTargetDataRef targetDataRef, LLVMTypeRef structTypeRef, ulong offset)
+        {
+            return LLVM.ElementAtOffset(targetDataRef, structTypeRef, offset);
+        }
+    }
+}

--- a/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
+++ b/src/ILCompiler.WebAssembly/src/Compiler/WebAssemblyCodegenCompilation.cs
@@ -17,6 +17,7 @@ namespace ILCompiler
     {
         internal WebAssemblyCodegenConfigProvider Options { get; }
         internal LLVMModuleRef Module { get; }
+        internal LLVMTargetDataRef TargetData { get; }
         public new WebAssemblyCodegenNodeFactory NodeFactory { get; }
         internal LLVMDIBuilderRef DIBuilder { get; }
         internal Dictionary<string, DebugMetadata> DebugMetadataMap { get; }
@@ -32,7 +33,7 @@ namespace ILCompiler
         {
             NodeFactory = nodeFactory;
             LLVMModuleRef m = LLVMModuleRef.CreateWithName("netscripten");
-            m.Target = "wasm32-unknown-unknown-wasm";
+            m.Target = "wasm32-unknown-emscripten";
             // https://llvm.org/docs/LangRef.html#langref-datalayout
             // e litte endian, mangled names
             // m:e ELF mangling 
@@ -41,8 +42,8 @@ namespace ILCompiler
             // n:32:64 native widths
             // S128 natural alignment of stack
             m.DataLayout = "e-m:e-p:32:32-i64:64-n32:64-S128";
-            Module = m; 
-
+            Module = m;
+            TargetData = m.CreateExecutionEngine().TargetData;
             Options = options;
             DIBuilder = Module.CreateDIBuilder();
             DebugMetadataMap = new Dictionary<string, DebugMetadata>();

--- a/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
+++ b/src/ILCompiler.WebAssembly/src/ILCompiler.WebAssembly.csproj
@@ -40,6 +40,7 @@
     </Compile>
     <Compile Include="CodeGen\DebugMetadata.cs" />
     <Compile Include="CodeGen\ILToWebAssemblyImporter_Statics.cs" />
+    <Compile Include="CodeGen\LLVMSharpInterop.cs" />
     <Compile Include="CodeGen\WebAssemblyObjectWriter.cs" />
     <Compile Include="Compiler\DependencyAnalysis\EHInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\RawMainMethodRootProvider.cs" />

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -21,6 +21,11 @@ internal static class Program
     internal static bool Success;
     private static unsafe int Main(string[] args)
     {
+        var x = new StructWithObjRefs
+        {
+            C1 = null,
+            C2 = null,
+        };
         Success = true;
         PrintLine("Starting " + 1);
 
@@ -393,15 +398,235 @@ internal static class Program
             PrintString("GC Collection Count " + i.ToString() + " ");
             PrintLine(GC.CollectionCount(i).ToString());
         }
-        if(!TestObjectRefInUncoveredShadowStackSlot())
+        
+        if (!TestObjectRefInUncoveredShadowStackSlot())
         {
             FailTest("struct Child1 alive unexpectedly");
-
         }
-        EndTest(true);
+            
+        if (!TestRhpAssignRefWithClassInStructGC())
+        {
+            FailTest();
+            return;
+        }
+
+        EndTest(TestGeneration2Rooting());
     }
 
+    private static Parent aParent;
+    private static ParentOfStructWithObjRefs aParentOfStructWithObjRefs;
     private static WeakReference childRef;
+
+    private static unsafe bool TestRhpAssignRefWithClassInStructGC()
+    {
+        bool result = true;
+
+        var parentRef = CreateParentWithStruct();
+        result &= BumpToGen(parentRef, 1);
+        result &= BumpToGen(parentRef, 2);
+
+        StoreChildInC1();
+        GC.Collect(1);
+        PrintLine("GC finished");
+
+        if (!childRef.IsAlive)
+        {
+            PrintLine("Child died unexpectedly");
+            result = false;
+        }
+
+        KillParentWithStruct();
+        GC.Collect();
+        if (childRef.IsAlive)
+        {
+            PrintLine("Child alive unexpectedly");
+            result = false;
+        }
+        if (parentRef.IsAlive)
+        {
+            PrintLine("Parent of struct Child1 alive unexpectedly");
+            result = false;
+        }
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool BumpToGen(WeakReference reference, int expectedGeneration)
+    {
+        GC.Collect();
+        var target = reference.Target;
+        if (target == null)
+        {
+            PrintLine("WeakReference died unexpectedly");
+            return false;
+        }
+        if (GC.GetGeneration(target) is { } actualGeneration && actualGeneration != expectedGeneration)
+        {
+            PrintLine("WeakReference is in gen " + actualGeneration + " instead of " + expectedGeneration);
+            return false;
+        }
+        return true;
+    }
+
+    private static bool TestGeneration2Rooting()
+    {
+        var parent = CreateParent();
+        GC.Collect(); // parent moves to gen1
+        GC.Collect(); // parent moves to gen2
+        if (!CheckParentGeneration()) return false;
+
+        // store our children in the gen2 object
+        var child1 = StoreProperty();
+        var child2 = StoreField();
+
+        KillParent(); // even though we kill the parent, it should survive as we do not collect gen2
+        GC.Collect(1);
+
+        // the parent should have kept the children alive
+        bool parentAlive = parent.IsAlive;
+        bool child1Alive = child1.IsAlive;
+        bool child2Alive = child2.IsAlive;
+        if (!parentAlive)
+        {
+            PrintLine("Parent died unexpectedly");
+            return false;
+        }
+
+        if (!child1Alive)
+        {
+            PrintLine("Child1 died unexpectedly");
+            return false;
+        }
+
+        if (!child2Alive)
+        {
+            PrintLine("Child2 died unexpectedly");
+            return false;
+        }
+
+        // Test struct assignment keeps fields alive
+        var parentRef = CreateParentWithStruct();
+        GC.Collect(); // move parent to gen1
+        GC.Collect(); // move parent to gen2
+        StoreChildInC1(); // store ephemeral object in gen 2 object via struct assignment
+        KillParentWithStruct();
+        GC.Collect(1);
+
+        if (childRef.IsAlive)
+        {
+            PrintLine("Child1 gen:" + GC.GetGeneration(childRef.Target));
+        }
+
+        if (!childRef.IsAlive)
+        {
+            PrintLine("struct Child1 died unexpectedly");
+            return false;
+        }
+        if (!parentRef.IsAlive)
+        {
+            PrintLine("parent of struct Child1 died unexpectedly");
+            return false;
+        }
+
+        return true;
+    }
+
+    class ParentOfStructWithObjRefs
+    {
+        internal StructWithObjRefs StructWithObjRefs;
+    }
+
+    struct StructWithObjRefs
+    {
+        internal Child C1;
+        internal Child C2;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static WeakReference CreateParent()
+    {
+        var parent = new Parent();
+        aParent = parent;
+        return new WeakReference(parent);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static WeakReference CreateStruct()
+    {
+        var parent = new Parent();
+        aParent = parent;
+        return new WeakReference(parent);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void KillParent()
+    {
+        aParent = null;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool CheckParentGeneration()
+    {
+        int actualGen = GC.GetGeneration(aParent);
+        if (actualGen != 2)
+        {
+            PrintLine("Parent Object is not in expected generation 2 but in " + actualGen);
+            return false;
+        }
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static WeakReference StoreProperty()
+    {
+        var child = new Child();
+        aParent.Child1 = child;
+        return new WeakReference(child);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static WeakReference StoreField()
+    {
+        var child = new Child();
+        aParent.Child2 = child;
+        return new WeakReference(child);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    unsafe static WeakReference CreateParentWithStruct()
+    {
+        var parent = new ParentOfStructWithObjRefs();
+        aParentOfStructWithObjRefs = parent;
+        return new WeakReference(parent);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void KillParentWithStruct()
+    {
+        aParentOfStructWithObjRefs = null;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static unsafe void StoreChildInC1()
+    {
+        var child = new Child();
+        aParentOfStructWithObjRefs.StructWithObjRefs = new StructWithObjRefs
+        {
+            C1 = child,
+        };
+        childRef = new WeakReference(child);
+    }
+
+    public class Parent
+    {
+        public Child Child1 { get; set; }
+        public Child Child2;
+    }
+
+    public class Child
+    {
+    }
+
     // This test is to catch where slots are allocated on the shadow stack uncovering object references that were there previously.
     // If this happens in the call to GC.Collect, which at the time of writing allocate 12 bytes in the call, 3 slots, then any objects that were in those 
     // 3 slots will not be collected as they will now be (back) in the range of bottom of stack -> top of stack.
@@ -419,10 +644,6 @@ internal static class Program
         Child c1, c2, c3;  // 3 more locals to cover give a bit more resiliency to the test, in case of slots being added or removed in the RhCollect calls
         c1 = c2 = c3 = child;
         childRef = new WeakReference(child);
-    }
-
-    public class Child
-    {
     }
 
     private static unsafe void TestBoxUnboxDifferentSizes()


### PR DESCRIPTION
This PR changes the implementation of stfld and stelem when the target type `IsGCPointer` and adds a test for objects rooted through a Gen 2 parent.  Are there other opcodes where `RhpAssignRef` should be used?

Thanks @Suchiman 