### PR TITLE
Wasm: Move the NRE check higher for method calls, to catch non-virtual case

### DIFF
--- a/tests/src/Simple/Generics/Generics.cs
+++ b/tests/src/Simple/Generics/Generics.cs
@@ -41,9 +41,7 @@ class Program
         TestNullableCasting.Run();
         TestVariantCasting.Run();
         TestMDArrayAddressMethod.Run();
-#if !CODEGEN_WASM
         TestNativeLayoutGeneration.Run();
-#endif
         TestByRefLikeVTables.Run();
 #endif
         return 100;

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1924,8 +1924,22 @@ internal static class Program
         }
         try
         {
-            var f = c.ToString(); //method access
-            PrintLine("NRE method access failed");
+            var f = c.ToString(); //virtual method access
+            PrintLine("NRE virtual method access failed");
+            success = false;
+        }
+        catch (NullReferenceException)
+        {
+        }
+        catch (Exception)
+        {
+            success = false;
+        }
+
+        try
+        {
+            c.NonVirtual(); //method access
+            PrintLine("NRE non virtual method access failed");
             success = false;
         }
         catch (NullReferenceException)
@@ -2307,6 +2321,7 @@ internal static class Program
 public class ClassForNre
 {
     public int F;
+    public void NonVirtual() { }
 }
 
 


### PR DESCRIPTION
This PR fixes a missing ThrowIfNull call for non-virtual method calls by moving the check higher up the stack.  Adds a test, enables the remaining Generics test, and removes 2 dead methods.