### PR TITLE
Fix for build error when using libunwind.

### DIFF
--- a/src/Native/libunwind/src/UnwindCursor.hpp
+++ b/src/Native/libunwind/src/UnwindCursor.hpp
@@ -1459,7 +1459,7 @@ bool UnwindCursor<A, R>::getInfoFromEHABISection(
   _info.unwind_info = exceptionTableAddr;
   _info.lsda = lsda;
   // flags is pr_cache.additional. See EHABI #7.2 for definition of bit 0.
-  _info.flags = isSingleWordEHT ? 1 : 0 | scope32 ? 0x2 : 0;  // Use enum?
+  _info.flags = (isSingleWordEHT ? 1 : 0) | (scope32 ? 0x2 : 0);  // Use enum?
 
   return true;
 }


### PR DESCRIPTION
Cross-building on x64 linux for arm caused a build error in libunwind UnwindCursor.hpp

This was fixed in llvm-project with the commit https://github.com/llvm/llvm-project/commit/221c5af4e4f4a504a4d1f352dd7b76d305e56a62