### PR TITLE
Prevent out/ref marshalling of COM interfaces

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/Marshaller.Aot.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/Marshaller.Aot.cs
@@ -879,5 +879,15 @@ namespace Internal.TypeSystem.Interop
 
             StoreNativeValue(codeStream);
         }
+
+        protected override void TransformNativeToManaged(ILCodeStream codeStream)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void TransformManagedToNative(ILCodeStream codeStream)
+        {
+            throw new NotSupportedException();
+        }
     }
 }


### PR DESCRIPTION
AllocAndTransform is not called for out/ref marshalling, so this was ending up blitting the raw pointer across.