### PR TITLE
Allow preinitializing delegates and reading initonly statics

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenObjectNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/FrozenObjectNode.cs
@@ -49,7 +49,7 @@ namespace ILCompiler.DependencyAnalysis
             dataBuilder.EmitZeroPointer();
 
             // byte contents
-            _data.WriteContent(ref dataBuilder, factory);
+            _data.WriteContent(ref dataBuilder, this, factory);
         }
 
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);

--- a/src/ILCompiler.Compiler/src/Compiler/PreinitializationManager.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/PreinitializationManager.cs
@@ -94,20 +94,9 @@ namespace ILCompiler
             if (type.IsModuleType)
                 return false;
 
-            if (type.HasInstantiation)
-            {
-                // Generic definitions cannot be preinitialized
-                if (type.IsGenericDefinition)
-                    return false;
-
-                // If the type has a canonical form the runtime type loader could create
-                // a new type sharing code with this one. They need to agree on how
-                // initialization happens. We can't preinitialize runtime-created
-                // generic types at compile time.
-                if (type.ConvertToCanonForm(CanonicalFormKind.Specific)
-                    .IsCanonicalSubtype(CanonicalFormKind.Any))
-                    return false;
-            }
+            // Generic definitions cannot be preinitialized
+            if (type.IsGenericDefinition)
+                return false;
 
             return GetPreinitializationInfo(type).IsPreinitialized;
         }

--- a/src/ILCompiler.Compiler/src/Compiler/TypePreinit.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypePreinit.cs
@@ -274,9 +274,19 @@ namespace ILCompiler
                             }
 
                             if (_fieldValues[field] is IAssignableValue assignableField)
-                                assignableField.Assign(stack.PopIntoLocation(field.FieldType));
+                            {
+                                if (!assignableField.TryAssign(stack.PopIntoLocation(field.FieldType)))
+                                {
+                                    return Status.Fail(methodIL.OwningMethod, opcode, "Unsupported store");
+                                }
+                            }
                             else
-                                _fieldValues[field] = stack.PopIntoLocation(field.FieldType);
+                            {
+                                Value value = stack.PopIntoLocation(field.FieldType);
+                                if (value is IInternalModelingOnlyValue)
+                                    return Status.Fail(methodIL.OwningMethod, opcode, "Value with no external representation");
+                                _fieldValues[field] = value;
+                            }
                         }
                         break;
 
@@ -288,17 +298,40 @@ namespace ILCompiler
                                 ThrowHelper.ThrowInvalidProgramException();
                             }
 
-                            if (field.OwningType != _type)
-                            {
-                                return Status.Fail(methodIL.OwningMethod, opcode, "Load from other static" + (field.IsInitOnly ? " initonly " : ""));
-                            }
-
                             if (field.IsThreadStatic || field.HasRva)
                             {
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Unsupported static");
                             }
 
-                            stack.PushFromLocation(field.FieldType, _fieldValues[field]);
+                            if (field.OwningType == _type)
+                            {
+                                stack.PushFromLocation(field.FieldType, _fieldValues[field]);
+                            }
+                            else if (field.IsInitOnly
+                                && field.OwningType.HasStaticConstructor
+                                && !field.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific).IsCanonicalSubtype(CanonicalFormKind.Any))
+                            {
+                                TypePreinit nestedPreinit = new TypePreinit((MetadataType)field.OwningType, _compilationGroup, _ilProvider);
+                                recursionProtect ??= new Stack<MethodDesc>();
+                                recursionProtect.Push(methodIL.OwningMethod);
+                                Status status = nestedPreinit.TryScanMethod(field.OwningType.GetStaticConstructor(), null, recursionProtect, out Value _);
+                                if (!status.IsSuccessful)
+                                {
+                                    return Status.Fail(methodIL.OwningMethod, opcode, "Nested cctor failed to preinit");
+                                }
+                                recursionProtect.Pop();
+                                Value value = nestedPreinit._fieldValues[field];
+                                if (value is ValueTypeValue)
+                                    stack.PushFromLocation(field.FieldType, value);
+                                else if (value is ReferenceTypeValue referenceType)
+                                    stack.PushFromLocation(field.FieldType, new ForeignTypeInstance(referenceType.Type, field, referenceType));
+                                else
+                                    return Status.Fail(methodIL.OwningMethod, opcode);
+                            }
+                            else
+                            {
+                                return Status.Fail(methodIL.OwningMethod, opcode, "Load from other non-initonly static");
+                            }   
                         }
                         break;
 
@@ -320,12 +353,13 @@ namespace ILCompiler
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Unsupported static");
                             }
 
-                            if (!(_fieldValues[field] is ValueTypeValue vtfield))
+                            Value fieldValue = _fieldValues[field];
+                            if (fieldValue == null || !fieldValue.TryCreateByRef(out Value byRefValue))
                             {
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Unsupported byref");
                             }
 
-                            stack.Push(vtfield.CreateByRef());
+                            stack.Push(StackValueKind.ByRef, byRefValue);
                         }
                         break;
 
@@ -404,42 +438,78 @@ namespace ILCompiler
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Finalizable class");
                             }
 
-                            if (((DefType)owningType).ContainsGCPointers)
-                            {
-                                // We don't want to end up with GC pointers in the frozen region
-                                // because write barriers can't handle that.
-                                return Status.Fail(methodIL.OwningMethod, opcode, "GC pointers");
-                            }
-
-                            Value instance;
-                            Value ctorArg0;
-                            if (owningType.IsValueType)
-                            {
-                                instance = new ValueTypeValue(owningType);
-                                ctorArg0 = ((ValueTypeValue)instance).CreateByRef();
-                            }
-                            else
-                            {
-                                instance = new ObjectInstance((DefType)owningType);
-                                ctorArg0 = instance;
-                            }
-
                             Value[] ctorParameters = new Value[ctorSig.Length + 1];
-                            ctorParameters[0] = ctorArg0;
                             for (int i = ctorSig.Length - 1; i >= 0; i--)
                             {
                                 ctorParameters[i + 1] = stack.PopIntoLocation(GetArgType(ctor, i + 1));
                             }
-                            recursionProtect ??= new Stack<MethodDesc>();
-                            recursionProtect.Push(methodIL.OwningMethod);
-                            Status ctorCallResult = TryScanMethod(ctor, ctorParameters, recursionProtect, out _);
-                            if (!ctorCallResult.IsSuccessful)
+
+                            Value instance;
+                            if (owningType.IsDelegate)
                             {
-                                recursionProtect.Pop();
-                                return ctorCallResult;
+                                if (!(ctorParameters[2] is MethodPointerValue methodPointer))
+                                {
+                                    return Status.Fail(methodIL.OwningMethod, opcode, "Unverifiable delegate creation");
+                                }
+
+                                ForeignTypeInstance firstParameter = null;
+                                if (ctorParameters[1] != null)
+                                {
+                                    // We only have a way to refer to an allocated object if it's referenced from a static
+                                    // field of a different type. This conveniently matches delegates that the C# compiler creates
+                                    // for lambdas: this is more common than it sounds.
+                                    firstParameter = ctorParameters[1] as ForeignTypeInstance;
+                                    if (firstParameter == null)
+                                    {
+                                        return Status.Fail(methodIL.OwningMethod, opcode, "Delegate with an unsupported first parameter");
+                                    }
+                                }
+
+                                MethodDesc pointedMethod = methodPointer.PointedToMethod;
+                                if ((firstParameter == null) != pointedMethod.Signature.IsStatic)
+                                {
+                                    return Status.Fail(methodIL.OwningMethod, opcode, "Open/closed static/instance delegate mismatch");
+                                }
+
+                                if (firstParameter != null && pointedMethod.HasInstantiation)
+                                {
+                                    return Status.Fail(methodIL.OwningMethod, opcode, "Delegate with fat pointer");
+                                }
+
+                                instance = new DelegateInstance(owningType, pointedMethod, firstParameter);
                             }
-                                    
-                            recursionProtect.Pop();
+                            else
+                            {
+                                if (owningType.IsValueType)
+                                {
+                                    instance = new ValueTypeValue(owningType);
+                                    bool byrefCreated = instance.TryCreateByRef(out ctorParameters[0]);
+                                    Debug.Assert(byrefCreated);
+                                }
+                                else
+                                {
+                                    instance = new ObjectInstance((DefType)owningType);
+                                    ctorParameters[0] = instance;
+                                }
+
+                                if (((DefType)owningType).ContainsGCPointers)
+                                {
+                                    // We don't want to end up with GC pointers in the frozen region
+                                    // because write barriers can't handle that.
+                                    return Status.Fail(methodIL.OwningMethod, opcode, "GC pointers");
+                                }
+
+                                recursionProtect ??= new Stack<MethodDesc>();
+                                recursionProtect.Push(methodIL.OwningMethod);
+                                Status ctorCallResult = TryScanMethod(ctor, ctorParameters, recursionProtect, out _);
+                                if (!ctorCallResult.IsSuccessful)
+                                {
+                                    recursionProtect.Pop();
+                                    return ctorCallResult;
+                                }
+
+                                recursionProtect.Pop();
+                            }
 
                             stack.PushFromLocation(owningType, instance);
                         }
@@ -509,7 +579,7 @@ namespace ILCompiler
                                 return Status.Fail(methodIL.OwningMethod, opcode);
                             }
 
-                            stack.Push(loadableInstance.GetFieldAddress(field));
+                            stack.Push(StackValueKind.ByRef, loadableInstance.GetFieldAddress(field));
                         }
                         break;
 
@@ -616,7 +686,12 @@ namespace ILCompiler
                             int index = opcode == ILOpcode.starg ? reader.ReadILUInt16() : reader.ReadILByte();
                             TypeDesc argType = GetArgType(methodIL.OwningMethod, index);
                             if (parameters[index] is IAssignableValue assignableParam)
-                                assignableParam.Assign(stack.PopIntoLocation(argType));
+                            {
+                                if (!assignableParam.TryAssign(stack.PopIntoLocation(argType)))
+                                {
+                                    return Status.Fail(methodIL.OwningMethod, opcode, "Unsuported store");
+                                }
+                            }
                             else
                                 parameters[index] = stack.PopIntoLocation(argType);
                         }
@@ -629,8 +704,17 @@ namespace ILCompiler
                             {
                                 return Status.Fail(methodIL.OwningMethod, opcode);
                             }
+                            stack.Push(new StackEntry(StackValueKind.ValueType, new RuntimeFieldHandleValue(field)));                                
+                        }
+                        break;
 
-                            stack.Push(new StackEntry(StackValueKind.ValueType, new RuntimeFieldHandleValue(field)));
+                    case ILOpcode.ldftn:
+                        {
+                            var method = methodIL.GetObject(reader.ReadILToken()) as MethodDesc;
+                            if (method != null)
+                                stack.Push(StackValueKind.NativeInt, new MethodPointerValue(method));
+                            else
+                                ThrowHelper.ThrowInvalidProgramException();
                         }
                         break;
 
@@ -678,7 +762,12 @@ namespace ILCompiler
 
                             TypeDesc localType = localTypes[index].Type;
                             if (locals[index] is IAssignableValue assignableLocal)
-                                assignableLocal.Assign(stack.PopIntoLocation(localType));
+                            {
+                                if (!assignableLocal.TryAssign(stack.PopIntoLocation(localType)))
+                                {
+                                    return Status.Fail(methodIL.OwningMethod, opcode, "Unsupported store");
+                                }
+                            }
                             else
                                 locals[index] = stack.PopIntoLocation(localType);
                                 
@@ -700,13 +789,14 @@ namespace ILCompiler
                                 ThrowHelper.ThrowInvalidProgramException();
                             }
 
-                            if (locals[index] is ValueTypeValue vtvalue)
+                            Value localValue = locals[index];
+                            if (localValue == null || !localValue.TryCreateByRef(out Value byrefValue))
                             {
-                                stack.Push(vtvalue.CreateByRef());
+                                return Status.Fail(methodIL.OwningMethod, opcode);
                             }
                             else
                             {
-                                return Status.Fail(methodIL.OwningMethod, opcode);
+                                stack.Push(StackValueKind.ByRef, byrefValue);
                             }
                         }
                         break;
@@ -1150,7 +1240,13 @@ namespace ILCompiler
                                     return Status.Fail(methodIL.OwningMethod, opcode);
 
                                 Value value = stack.PopIntoLocation(type);
-                                stack.Push(StackValueKind.ObjRef, ObjectInstance.Box((DefType)type, ((ValueTypeValue)value).InstanceBytes));
+                                if (!ObjectInstance.TryBox((DefType)type, value, out ObjectInstance boxedResult))
+                                {
+                                    return Status.Fail(methodIL.OwningMethod, opcode);
+                                }
+
+
+                                stack.Push(boxedResult);
                             }
                         }
                         break;
@@ -1297,11 +1393,6 @@ namespace ILCompiler
             public void Push(ReferenceTypeValue value)
             {
                 Push(StackValueKind.ObjRef, value);
-            }
-
-            public void Push(ByRefValue value)
-            {
-                Push(StackValueKind.ByRef, value);
             }
 
             public void PushFromLocation(TypeDesc locationType, Value value)
@@ -1483,7 +1574,8 @@ namespace ILCompiler
         /// </summary>
         public interface ISerializableReference : ISerializableValue
         {
-            void WriteContent(ref ObjectDataBuilder builder, NodeFactory factory);
+            TypeDesc Type { get; }
+            void WriteContent(ref ObjectDataBuilder builder, ISymbolNode thisNode, NodeFactory factory);
         }
 
         /// <summary>
@@ -1498,11 +1590,19 @@ namespace ILCompiler
         }
 
         /// <summary>
+        /// Represents a special value that is used internally to model known constructs, but cannot
+        /// be represented externally and that's why we don't allow field stores with it.
+        /// </summary>
+        private interface IInternalModelingOnlyValue
+        {
+        }
+
+        /// <summary>
         /// Represents a value that can be assigned into.
         /// </summary>
         private interface IAssignableValue
         {
-            void Assign(Value value);
+            bool TryAssign(Value value);
         }
 
         private abstract class Value : ISerializableValue
@@ -1520,6 +1620,12 @@ namespace ILCompiler
                     return false;
                 }
                 return value1.Equals(value2);
+            }
+
+            public virtual bool TryCreateByRef(out Value value)
+            {
+                value = null;
+                return false;
             }
 
             public abstract void WriteFieldData(ref ObjectDataBuilder builder, FieldDesc field, NodeFactory factory);
@@ -1561,21 +1667,27 @@ namespace ILCompiler
                 InstanceBytes = bytes;
             }
 
-            public ByRefValue CreateByRef()
+            public override bool TryCreateByRef(out Value value)
             {
-
-                return new ByRefValue(InstanceBytes, 0);
+                value = new ByRefValue(InstanceBytes, 0);
+                return true;
             }
 
-            void IAssignableValue.Assign(Value value)
+            bool IAssignableValue.TryAssign(Value value)
             {
-                if (!(value is ValueTypeValue other)
+                if (!(value is BaseValueTypeValue other)
                     || other.Size != Size)
                 {
                     ThrowHelper.ThrowInvalidProgramException();
                 }
 
-                Array.Copy(((ValueTypeValue)value).InstanceBytes, InstanceBytes, InstanceBytes.Length);
+                if (!(value is ValueTypeValue vtvalue))
+                {
+                    return false;
+                }
+
+                Array.Copy(vtvalue.InstanceBytes, InstanceBytes, InstanceBytes.Length);
+                return true;
             }
 
             public override bool Equals(Value value)
@@ -1624,7 +1736,7 @@ namespace ILCompiler
             public static ValueTypeValue FromDouble(double value) => new ValueTypeValue(BitConverter.GetBytes(value));
         }
 
-        private class RuntimeFieldHandleValue : BaseValueTypeValue
+        private class RuntimeFieldHandleValue : BaseValueTypeValue, IInternalModelingOnlyValue
         {
             public FieldDesc Field { get; private set; }
 
@@ -1647,8 +1759,34 @@ namespace ILCompiler
 
             public override void WriteFieldData(ref ObjectDataBuilder builder, FieldDesc field, NodeFactory factory)
             {
-                Debug.Assert(field.FieldType.IsWellKnownType(WellKnownType.RuntimeFieldHandle));
-                builder.EmitPointerReloc(factory.RuntimeFieldHandle(Field));
+                throw new NotSupportedException();
+            }
+        }
+
+        private class MethodPointerValue : BaseValueTypeValue, IInternalModelingOnlyValue
+        {
+            public MethodDesc PointedToMethod { get; }
+
+            public MethodPointerValue(MethodDesc pointedToMethod)
+            {
+                PointedToMethod = pointedToMethod;
+            }
+
+            public override int Size => PointedToMethod.Context.Target.PointerSize;
+
+            public override bool Equals(Value value)
+            {
+                if (!(value is MethodPointerValue))
+                {
+                    ThrowHelper.ThrowInvalidProgramException();
+                }
+
+                return PointedToMethod == ((MethodPointerValue)value).PointedToMethod;
+            }
+
+            public override void WriteFieldData(ref ObjectDataBuilder builder, FieldDesc field, NodeFactory factory)
+            {
+                throw new NotSupportedException();
             }
         }
 
@@ -1698,21 +1836,86 @@ namespace ILCompiler
             }
         }
 
-        private abstract class ReferenceTypeValue : Value, ISerializableReference
+        private abstract class ReferenceTypeValue : Value
         {
-            protected readonly TypeDesc _type;
+            public TypeDesc Type { get; }
 
-            protected ReferenceTypeValue(TypeDesc type) { _type = type; }
+            protected ReferenceTypeValue(TypeDesc type) { Type = type; }
 
             public override bool Equals(Value value)
             {
                 return this == value;
             }
-
-            public abstract void WriteContent(ref ObjectDataBuilder builder, NodeFactory factory);
         }
 
-        private class ArrayInstance : ReferenceTypeValue
+        private class DelegateInstance : ReferenceTypeValue, ISerializableReference
+        {
+            private readonly MethodDesc _methodPointed;
+            private readonly ForeignTypeInstance _firstParameter;
+
+            public DelegateInstance(TypeDesc delegateType, MethodDesc methodPointed, ForeignTypeInstance firstParameter)
+                : base(delegateType)
+            {
+                _methodPointed = methodPointed;
+                _firstParameter = firstParameter;
+            }
+
+            public virtual void WriteContent(ref ObjectDataBuilder builder, ISymbolNode thisNode, NodeFactory factory)
+            {
+                Debug.Assert(_methodPointed.Signature.IsStatic == (_firstParameter == null));
+                Debug.Assert(!_methodPointed.IsUnmanagedCallersOnly);
+
+                var creationInfo = DelegateCreationInfo.Create(Type.ConvertToCanonForm(CanonicalFormKind.Specific), _methodPointed, factory, followVirtualDispatch: false);
+
+                Debug.Assert(!creationInfo.TargetNeedsVTableLookup);
+
+                // EEType
+                var node = factory.ConstructedTypeSymbol(Type);
+                Debug.Assert(!node.RepresentsIndirectionCell);  // Shouldn't have allowed this
+                builder.EmitPointerReloc(node);
+
+                if (_methodPointed.Signature.IsStatic)
+                {
+                    Debug.Assert(creationInfo.Constructor.Method.Name == "InitializeOpenStaticThunk");
+
+                    // m_firstParameter
+                    builder.EmitPointerReloc(thisNode);
+
+                    // m_helperObject
+                    builder.EmitZeroPointer();
+
+                    // m_extraFunctionPointerOrData
+                    builder.EmitPointerReloc(creationInfo.GetTargetNode(factory));
+
+                    // m_functionPointer
+                    Debug.Assert(creationInfo.Thunk != null);
+                    builder.EmitPointerReloc(creationInfo.Thunk);
+                }
+                else
+                {
+                    Debug.Assert(creationInfo.Constructor.Method.Name == "InitializeClosedInstance");
+
+                    // m_firstParameter
+                    _firstParameter.WriteFieldData(ref builder, _firstParameter.ForeignField, factory);
+
+                    // m_helperObject
+                    builder.EmitZeroPointer();
+
+                    // m_extraFunctionPointerOrData
+                    builder.EmitZeroPointer();
+
+                    // m_functionPointer
+                    builder.EmitPointerReloc(factory.CanonicalEntrypoint(_methodPointed));
+                }
+            }
+
+            public override void WriteFieldData(ref ObjectDataBuilder builder, FieldDesc field, NodeFactory factory)
+            {
+                builder.EmitPointerReloc(factory.SerializedFrozenObject(field, this));
+            }
+        }
+
+        private class ArrayInstance : ReferenceTypeValue, ISerializableReference
         {
             private readonly int _elementCount;
             private readonly int _elementSize;
@@ -1745,12 +1948,12 @@ namespace ILCompiler
 
             public bool TryStoreElement(int index, Value value)
             {
-                Debug.Assert(value is ValueTypeValue);
+                if (!(value is ValueTypeValue valueToStore))
+                    return false;
 
                 if ((uint)index > (uint)Length)
                     return false;
 
-                var valueToStore = value as ValueTypeValue;
                 Debug.Assert(valueToStore.InstanceBytes.Length == _elementSize);
                 Array.Copy(valueToStore.InstanceBytes, 0, _data, index * _elementSize, valueToStore.InstanceBytes.Length);
                 return true;
@@ -1761,17 +1964,17 @@ namespace ILCompiler
                 builder.EmitPointerReloc(factory.SerializedFrozenObject(field, this));
             }
 
-            public override void WriteContent(ref ObjectDataBuilder builder, NodeFactory factory)
+            public virtual void WriteContent(ref ObjectDataBuilder builder, ISymbolNode thisNode, NodeFactory factory)
             {
                 // EEType
-                var node = factory.ConstructedTypeSymbol(_type);
+                var node = factory.ConstructedTypeSymbol(Type);
                 Debug.Assert(!node.RepresentsIndirectionCell);  // Arrays are always local
                 builder.EmitPointerReloc(node);
 
                 // numComponents
                 builder.EmitInt(_elementCount);
 
-                int pointerSize = _type.Context.Target.PointerSize;
+                int pointerSize = Type.Context.Target.PointerSize;
                 Debug.Assert(pointerSize == 8 || pointerSize == 4);
 
                 if (pointerSize == 8)
@@ -1781,6 +1984,31 @@ namespace ILCompiler
                 }
 
                 builder.EmitBytes(_data);
+            }
+        }
+
+        private class ForeignTypeInstance : ReferenceTypeValue
+        {
+            public FieldDesc ForeignField { get; }
+            public ReferenceTypeValue Data { get; }
+
+            public ForeignTypeInstance(TypeDesc type, FieldDesc foreignField, ReferenceTypeValue data)
+                : base(type)
+            {
+                ForeignField = foreignField;
+                Data = data;
+            }
+
+            public override void WriteFieldData(ref ObjectDataBuilder builder, FieldDesc field, NodeFactory factory)
+            {
+                if (Data is ISerializableReference serializableReference)
+                {
+                    builder.EmitPointerReloc(factory.SerializedFrozenObject(ForeignField, serializableReference));
+                }
+                else
+                {
+                    Data.WriteFieldData(ref builder, field, factory);
+                }
             }
         }
 
@@ -1798,15 +2026,9 @@ namespace ILCompiler
             {
                 builder.EmitPointerReloc(factory.SerializedStringObject(_value));
             }
-
-            public override void WriteContent(ref ObjectDataBuilder builder, NodeFactory factory)
-            {
-                // Not actually used by SerializedStringObject.
-                throw new NotImplementedException();
-            }
         }
 
-        private class ObjectInstance : ReferenceTypeValue, IHasInstanceFields
+        private class ObjectInstance : ReferenceTypeValue, IHasInstanceFields, ISerializableReference
         {
             private readonly byte[] _data;
 
@@ -1819,11 +2041,20 @@ namespace ILCompiler
                 _data = new byte[size];
             }
 
-            public static ObjectInstance Box(DefType type, byte[] data)
+            public static bool TryBox(DefType type, Value value, out ObjectInstance result)
             {
-                var inst = new ObjectInstance(type);
-                Array.Copy(data, 0, inst._data, type.Context.Target.PointerSize, data.Length);
-                return inst;
+                if (!(value is BaseValueTypeValue))
+                    ThrowHelper.ThrowInvalidProgramException();
+
+                if (!(value is ValueTypeValue valuetype))
+                {
+                    result = null;
+                    return false;
+                }
+
+                result = new ObjectInstance(type);
+                Array.Copy(valuetype.InstanceBytes, 0, result._data, type.Context.Target.PointerSize, valuetype.InstanceBytes.Length);
+                return true;
             }
 
             public bool TryUnboxAny(TypeDesc type, out Value value)
@@ -1833,7 +2064,7 @@ namespace ILCompiler
                 if (!type.IsValueType || type.IsNullable)
                     return false;
 
-                if (_type.UnderlyingType != type.UnderlyingType)
+                if (Type.UnderlyingType != type.UnderlyingType)
                     return false;
 
                 var result = new ValueTypeValue(type);
@@ -1851,10 +2082,10 @@ namespace ILCompiler
                 builder.EmitPointerReloc(factory.SerializedFrozenObject(field, this));
             }
 
-            public override void WriteContent(ref ObjectDataBuilder builder, NodeFactory factory)
+            public virtual void WriteContent(ref ObjectDataBuilder builder, ISymbolNode thisNode, NodeFactory factory)
             {
                 // EEType
-                var node = factory.ConstructedTypeSymbol(_type);
+                var node = factory.ConstructedTypeSymbol(Type);
                 Debug.Assert(!node.RepresentsIndirectionCell);  // Shouldn't have allowed preinitializing this
                 builder.EmitPointerReloc(node);
 
@@ -1873,7 +2104,7 @@ namespace ILCompiler
             public FieldAccessor(byte[] bytes, int offset = 0)
             {
                 _instanceBytes = bytes;
-                _offset = 0;
+                _offset = offset;
             }
 
             public Value GetField(FieldDesc field)

--- a/tests/src/Simple/Preinitialization/Preinitialization.cs
+++ b/tests/src/Simple/Preinitialization/Preinitialization.cs
@@ -31,6 +31,10 @@ internal class Program
         TestTryCatch.Run();
         TestBadClass.Run();
         TestRefs.Run();
+        TestDelegate.Run();
+        TestInitFromOtherClass.Run();
+        TestInitFromOtherClassDouble.Run();
+        TestDelegateToOtherClass.Run();
 #else
         Console.WriteLine("Preinitialization is disabled in multimodule builds for now. Skipping test.");
 #endif
@@ -516,6 +520,125 @@ class TestRefs
         Assert.AreEqual(42, s_value1.Value);
         Assert.AreEqual(100, s_value2.Value);
         Assert.AreEqual(3.14, s_doubleValue.Value);
+    }
+}
+
+class TestDelegate
+{
+    static Func<int> s_delegate = GetVal;
+
+    static int GetVal() => 42;
+
+    static Func<int> s_lambda = () => 2020;
+
+    public static void Run()
+    {
+        Assert.IsPreinitialized(typeof(TestDelegate));
+        Assert.AreEqual(42, s_delegate());
+        Assert.AreEqual(2020, s_lambda());
+    }
+}
+
+class TestInitFromOtherClass
+{
+    class OtherClass
+    {
+        public static readonly int IntValue = 456;
+        public static readonly string StringValue = "Hello";
+        public static readonly object ObjectValue = new object();
+    }
+
+    static int s_intValue = OtherClass.IntValue;
+    static string s_stringValue = OtherClass.StringValue;
+    static object s_objectValue = OtherClass.ObjectValue;
+
+    public static void Run()
+    {
+        Assert.IsPreinitialized(typeof(TestInitFromOtherClass));
+        Assert.AreEqual(OtherClass.IntValue, s_intValue);
+        Assert.AreSame(OtherClass.StringValue, s_stringValue);
+        Assert.AreSame(OtherClass.ObjectValue, s_objectValue);
+    }
+}
+
+class TestInitFromOtherClassDouble
+{
+    class OtherClass
+    {
+        public static readonly int IntValue = 456;
+        public static readonly string StringValue = "Hello";
+        public static readonly object ObjectValue = new object();
+    }
+
+    class OtherClassDouble
+    {
+        public static readonly int IntValue = OtherClass.IntValue;
+        public static readonly string StringValue = OtherClass.StringValue;
+        public static readonly object ObjectValue = OtherClass.ObjectValue;
+    }
+
+    static int s_intValue = OtherClassDouble.IntValue;
+    static string s_stringValue = OtherClassDouble.StringValue;
+    static object s_objectValue = OtherClassDouble.ObjectValue;
+
+    public static void Run()
+    {
+        Assert.IsPreinitialized(typeof(TestInitFromOtherClassDouble));
+        Assert.AreEqual(OtherClass.IntValue, s_intValue);
+        Assert.AreSame(OtherClass.StringValue, s_stringValue);
+        Assert.AreSame(OtherClass.ObjectValue, s_objectValue);
+    }
+}
+
+
+class TestDelegateToOtherClass
+{
+    static Func<int> s_getCookie = OtherClass.s_otherclass.GetCookie;
+    static Func<Type> s_getStringType = OtherClass.s_otherString.GetType;
+    static Func<int> s_getCookieDoubleIndirect = OtherClass.s_getCookie;
+    static Func<Type> s_getStringTypeDoubleIndirect = OtherClass.s_getStringType;
+    static Func<int> s_getCookieIndirected = OtherClass.s_otherclassFromYetAnother.GetCookie;
+    static Func<Type> s_getStringTypeIndirected = OtherClass.s_otherStringFromYetAnother.GetType;
+
+    class OtherClass
+    {
+        int _cookie;
+        public static readonly OtherClass s_otherclass = new OtherClass(4040);
+        public static readonly string s_otherString = "1";
+        public static readonly Func<int> s_getCookie = YetAnotherClass.s_otherclass.GetCookie;
+        public static readonly Func<Type> s_getStringType = YetAnotherClass.s_otherString.GetType;
+        public static readonly OtherClass s_otherclassFromYetAnother = YetAnotherClass.s_otherclass;
+        public static readonly string s_otherStringFromYetAnother = YetAnotherClass.s_otherString;
+        public OtherClass(int cookie) { _cookie = cookie; }
+        public int GetCookie() => _cookie;
+    }
+
+    class YetAnotherClass
+    {
+        public static readonly OtherClass s_otherclass = new OtherClass(1010);
+        public static readonly string s_otherString = "1";
+    }
+
+    public static void Run()
+    {
+        Assert.IsPreinitialized(typeof(TestDelegateToOtherClass));
+
+        Assert.AreEqual(4040, s_getCookie());
+        Assert.AreSame(OtherClass.s_otherclass, s_getCookie.Target);
+        Assert.AreSame(typeof(string), s_getStringType());
+        Assert.AreSame(OtherClass.s_otherString, s_getStringType.Target);
+
+        Assert.AreEqual(1010, s_getCookieDoubleIndirect());
+        Assert.AreSame(YetAnotherClass.s_otherclass, s_getCookieDoubleIndirect.Target);
+        Assert.AreSame(typeof(string), s_getStringTypeDoubleIndirect());
+        Assert.AreSame(YetAnotherClass.s_otherString, s_getStringTypeDoubleIndirect.Target);
+        Assert.AreSame(OtherClass.s_getCookie, s_getCookieDoubleIndirect);
+        Assert.AreSame(OtherClass.s_getStringType, s_getStringTypeDoubleIndirect);
+
+        Assert.AreEqual(1010, s_getCookieIndirected());
+        Assert.AreSame(YetAnotherClass.s_otherclass, s_getCookieIndirected.Target);
+        Assert.AreSame(typeof(string), s_getStringTypeIndirected());
+        Assert.AreSame(YetAnotherClass.s_otherString, s_getStringTypeIndirected.Target);
     }
 }
 


### PR DESCRIPTION
This extends the static constructor interpreter with support for preinitializing delegates and support for reading readonly static fields declared by other types.

The readonly static fields can be accessed after interpreting the static constructor of the containing type. This opens us up to recursive dependencies - the interpreter will bail if recursive dependency is hit (we already have a test).

This significantly improves the interpreter's ability to run static constructors at compile time:

|          | Eligible types | Preinitialized before | Preinitialized after |
| -------- | -------------- | --------------------- | -------------------- |
| WinForms | 1520           | 702                   | 967                  |
| WebApi   | 2005           | 746                   | 1278                 |

About 60% of types now have their static constructor executed at compile time.