### PR TITLE
Wasm: Add support for throw in catch block

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -153,7 +153,9 @@ namespace Internal.IL
                 _ehInfoNode = new EHInfoNode(_mangledName);
             }
             int curRegion = 0;
-            foreach (ILExceptionRegion region in ilExceptionRegions.OrderBy(region => region.TryOffset))
+            foreach (ILExceptionRegion region in ilExceptionRegions.OrderBy(region => region.TryOffset)
+                .ThenByDescending(region => region.TryLength)  // outer regions with the same try offset as inner region first - they will have longer lengths, // WASMTODO, except maybe an inner of try {} catch {} which could still be a problem
+                .ThenBy(region => region.HandlerOffset))
             {
                 _exceptionRegions[curRegion++] = new ExceptionRegion
                                                  {
@@ -596,11 +598,16 @@ namespace Internal.IL
         /// </summary>
         private ExceptionRegion GetCurrentTryRegion()
         {
+            return GetTryRegion(_currentOffset);
+        }
+
+        private ExceptionRegion GetTryRegion(int offset)
+        {
             // Iterate backwards to find the most nested region
             for (int i = _exceptionRegions.Length - 1; i >= 0; i--)
             {
                 ILExceptionRegion region = _exceptionRegions[i].ILRegion;
-                if (IsOffsetContained(_currentOffset - 1, region.TryOffset, region.TryLength))
+                if (IsOffsetContained(offset - 1, region.TryOffset, region.TryLength))
                 {
                     return _exceptionRegions[i];
                 }
@@ -2863,7 +2870,7 @@ namespace Internal.IL
 
             var arguments = new StackEntry[] { new ExpressionEntry(StackValueKind.ObjRef, "managedPtr", managedPtr),
                                                  new ExpressionEntry(StackValueKind.Int32, "idxStart", LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, 0xFFFFFFFFu, false)), 
-                                                 new ExpressionEntry(StackValueKind.Int32, "idxTryLandingStart", LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, (ulong)tryRegion.ILRegion.TryOffset, false)),
+                                                 new ExpressionEntry(StackValueKind.Int32, "idxCurrentBlockStart", LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, (ulong)_currentBasicBlock.StartOffset, false)),
                                                  new ExpressionEntry(StackValueKind.NativeInt, "shadowStack", _currentFunclet.GetParam(0)),
                                                  new ExpressionEntry(StackValueKind.ByRef, "refFrameIter", ehInfoIterator),
                                                  new ExpressionEntry(StackValueKind.ByRef, "tryRegionIdx", tryRegionIdx),
@@ -2917,6 +2924,7 @@ namespace Internal.IL
 
             if (_leaveTargets != null)
             {
+                LLVMBasicBlockRef switchReturnBlock = default;
                 foreach (var leaveTarget in _leaveTargets)
                 {
                     var targetBlock = _basicBlocks[leaveTarget];
@@ -2925,6 +2933,27 @@ namespace Internal.IL
                     {
                         @switch.AddCase(BuildConstInt32(targetBlock.StartOffset), GetLLVMBasicBlockForBlock(targetBlock));
                     }
+                    else
+                    {
+
+                        // leave destination is in a different funclet, this happens when an exception is thrown/rethrown from inside a catch handler and the throw is not directly in a try handler
+                        // In this case we need to return out of this funclet to get back to the containing funclet.  Logic checks we are actually in a catch funclet as opposed to a finally or the main function funclet
+                        ExceptionRegion currentRegion = GetTryRegion(_currentBasicBlock.StartOffset);
+                        if (currentRegion != null && _currentBasicBlock.StartOffset >= currentRegion.ILRegion.HandlerOffset && _currentBasicBlock.StartOffset < currentRegion.ILRegion.HandlerOffset + currentRegion.ILRegion.HandlerLength
+                            && currentRegion.ILRegion.Kind == ILExceptionRegionKind.Catch)
+                        {
+                            if (switchReturnBlock == default)
+                            {
+                                switchReturnBlock = _currentFunclet.AppendBasicBlock("SwitchReturn");
+                            }
+                            @switch.AddCase(BuildConstInt32(targetBlock.StartOffset), switchReturnBlock);
+                        }
+                    }
+                }
+                if (switchReturnBlock != default)
+                {
+                    landingPadBuilder.PositionAtEnd(switchReturnBlock);
+                    landingPadBuilder.BuildRet(landingPadBuilder.BuildLoad(leaveDestination, "loadLeaveDest"));
                 }
             }
 
@@ -5219,10 +5248,11 @@ namespace Internal.IL
             while (i >= 0)
             {
                 int tryStart = _exceptionRegions[i].ILRegion.TryOffset;
+                int tryLength = _exceptionRegions[i].ILRegion.TryLength;
                 for (var j = 0; j < _exceptionRegions.Length; j++)
                 {
                     ExceptionRegion exceptionRegion = _exceptionRegions[j];
-                    if (exceptionRegion.ILRegion.TryOffset != tryStart) continue;
+                    if (exceptionRegion.ILRegion.TryOffset != tryStart || exceptionRegion.ILRegion.TryLength != tryLength) continue;
                     //                if (i > 0)
                     //                {
                     //                    ExceptionRegion previousClause = _exceptionRegions[i - 1];
@@ -5259,8 +5289,7 @@ namespace Internal.IL
 
                     builder.EmitCompressedUInt((uint)exceptionRegion.ILRegion.TryOffset);
 
-                    uint tryLength = (uint)exceptionRegion.ILRegion.TryLength;
-                    builder.EmitCompressedUInt((tryLength << 2) | (uint)clauseKind);
+                    builder.EmitCompressedUInt(((uint)tryLength << 2) | (uint)clauseKind);
 
                     RelocType rel = (_compilation.NodeFactory.Target.IsWindows)
                         ? RelocType.IMAGE_REL_BASED_ABSOLUTE

--- a/src/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
+++ b/src/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
@@ -38,7 +38,7 @@ namespace System.Runtime
         }
 
         // TODO: temporary to try things out, when working look to see how to refactor with FindFirstPassHandler
-        private static bool FindFirstPassHandlerWasm(object exception, uint idxStart, uint idxTryLandingStart /* the start IL idx of the try region for the landing pad, will use in place of PC */, 
+        private static bool FindFirstPassHandlerWasm(object exception, uint idxStart, uint idxCurrentBlockStart /* the start IL idx of the current block for the landing pad, will use in place of PC */, 
             void* shadowStack, ref EHClauseIterator clauseIter, out uint tryRegionIdx, out byte* pHandler)
         {
             pHandler = (byte*)0;
@@ -75,7 +75,7 @@ namespace System.Runtime
                 EHClauseIterator.RhEHClauseKindWasm clauseKind = ehClause._clauseKind;
                 if (((clauseKind != EHClauseIterator.RhEHClauseKindWasm.RH_EH_CLAUSE_TYPED) &&
                      (clauseKind != EHClauseIterator.RhEHClauseKindWasm.RH_EH_CLAUSE_FILTER))
-                    || !ehClause.ContainsCodeOffset(idxTryLandingStart))
+                    || !ehClause.ContainsCodeOffset(idxCurrentBlockStart))
                 {
                     continue;
                 }

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1381,6 +1381,8 @@ internal static class Program
         TestFilter();
 
         TestFilterNested();
+
+        TestCatchAndThrow();
     }
 
     private static void TestTryCatchNoException()
@@ -1591,6 +1593,32 @@ internal static class Program
         }
         PrintLine(exceptionFlowSequence);
         EndTest(exceptionFlowSequence == @"In middle catchRunning outer filterIn outer catchRunning inner filterIn inner catch");
+    }
+
+    private static void TestCatchAndThrow()
+    {
+        StartTest("Test catch and throw different exception");
+        int caught = 0;
+        try
+        {
+            try
+            {
+                throw new Exception("first");
+            }
+            catch
+            {
+                caught += 1;
+                throw new Exception("second");
+            }
+        }
+        catch(Exception e)
+        {
+            if(e.Message == "second")
+            {
+                caught += 10;
+            }
+        }
+        EndTest(caught == 11);
     }
 
     static bool Print(string s)


### PR DESCRIPTION
Exception support currently breaks with 

```
       try
        {
            try
            {
                throw new Exception();
            }
            catch
            {
                throw new Exception();
            }
        }
        catch
        {
        }
```
because the leave target for the second throw is in a different LLVM funclet and so can't be done with just an LLVM switch/branch as is currently implemented.  The leave target needs to be returned out of the LLVM funclet.  This PR adds support and a test for this.  Also fixes the problem in release mode where the inner try has the same offset as the outer, as here.

Thanks @jkotas 