### PR TITLE
Preinit, fix ldlen to push 32 bit value when pointer size is 4

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/TypePreinit.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/TypePreinit.cs
@@ -1080,7 +1080,7 @@ namespace ILCompiler
                             StackEntry popped = stack.Pop();
                             if (popped.Value is ArrayInstance arrayInstance)
                             {
-                                stack.Push(StackValueKind.NativeInt, ValueTypeValue.FromInt64(arrayInstance.Length));
+                                stack.Push(StackValueKind.NativeInt, context.Target.PointerSize == 8 ? ValueTypeValue.FromInt64(arrayInstance.Length) : ValueTypeValue.FromInt32(arrayInstance.Length));
                             }
                             else if (popped.Value == null)
                             {


### PR DESCRIPTION
Fixes #8208
This PR changes the pushed value type from Int64 to Int32 for 32bit architectures.