### PR TITLE
Add Rd.xml documentation

### DIFF
--- a/Documentation/using-corert/rd-xml-format.md
+++ b/Documentation/using-corert/rd-xml-format.md
@@ -1,7 +1,7 @@
 Rd.xml File Format
 ==================
 
-ILCompiler discovers types to compile by starting from the application's entry point. This may miss types if an application uses reflection.
+The CoreRT ahead of time compiler discovers methods to compile and types to generate by compiling the application entry point and its transitive dependencies. The compiler may miss types if an application uses reflection. For more information about the problem see [Reflection in AOT mode](reflection-in-aot-mode.md).
 An rd.xml file can be supplemented to help ILCompiler find types that should be analyzed. This file is similar but more limited than the rd.xml file used by .NET Native.
 
 Minimal Rd.xml configuration

--- a/Documentation/using-corert/rd-xml-format.md
+++ b/Documentation/using-corert/rd-xml-format.md
@@ -117,4 +117,4 @@ or if you want instantiate generic method you can pass `<GenericArgument>`.
 </Directives>
 ```
 
-Take not that methods distinguished by method name and parameters. Type of return value does not used in the method signature.
+Take note that methods are distinguished by their method name and parameters. The return value's type is not used in the method signature.

--- a/Documentation/using-corert/rd-xml-format.md
+++ b/Documentation/using-corert/rd-xml-format.md
@@ -33,7 +33,7 @@ Module metadata only just need simple `<Assembly>` tag with short name of the as
 </Directives>
 ```
 
-All types in the assembly require adding `Dynamic` attribute with value `Required All`. *NOTE*: This is only available options for this attribute.
+All types in the assembly require adding `Dynamic` attribute with value `Required All`. *NOTE*: This is the only available value for this attribute.
 ```
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Application>

--- a/Documentation/using-corert/rd-xml-format.md
+++ b/Documentation/using-corert/rd-xml-format.md
@@ -15,7 +15,7 @@ Minimal Rd.xml configuration
 ```
 
 ILCompiler supports 2 top level directives `Application` or `Library`. Right now both of them can be used interchangeably and just define area where actual assembly configuration happens.
-Developer can put multiple `<Assembly>` tags inside the `<Application>` directive  to configure each assembly individually.
+You can put multiple `<Assembly>` tags inside the `<Application>` directive to configure each assembly individually.
 
 ## Assembly directive
 

--- a/Documentation/using-corert/rd-xml-format.md
+++ b/Documentation/using-corert/rd-xml-format.md
@@ -56,7 +56,7 @@ Module metadata and selected types option based on module metadata only mode wit
 ```
 
 ## Types directives.
-Types directive provide a way to specify which parts of code related to classes are needed. Developer can have two options here: 
+Type directive provides a way to specify what types are needed. Developer has two options here: 
 - Take all type methods;
 - Select which methods should be rooted.
 

--- a/Documentation/using-corert/rd-xml-format.md
+++ b/Documentation/using-corert/rd-xml-format.md
@@ -94,6 +94,19 @@ To select which methods should be rooted add nested `<Method>` tags.
   <Application>
     <Assembly Name="System.Private.CoreLib">
       <Type Name="System.Collections.Generic.Dictionary`2[[System.Int32,System.Private.CoreLib],[System.String,System.Private.CoreLib]]">
+        <Method Name="EnsureCapacity" />
+      </Type>
+    </Assembly>
+  </Application>
+</Directives>
+```
+
+Alternatively you can specify optional `<Parameter>` tag, if you want only specific overload. For example:
+```
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Application>
+    <Assembly Name="System.Private.CoreLib">
+      <Type Name="System.Collections.Generic.Dictionary`2[[System.Int32,System.Private.CoreLib],[System.String,System.Private.CoreLib]]">
         <Method Name="EnsureCapacity">
           <Parameter Name="System.Int32, System.Private.CoreLib" />
         </Method>
@@ -102,6 +115,7 @@ To select which methods should be rooted add nested `<Method>` tags.
   </Application>
 </Directives>
 ```
+
 or if you want instantiate generic method you can pass `<GenericArgument>`.
 ```
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">

--- a/Documentation/using-corert/rd-xml-format.md
+++ b/Documentation/using-corert/rd-xml-format.md
@@ -1,8 +1,8 @@
 Rd.xml File Format
 ==================
 
-ILCompiler by default lookup for types to be compiled starting from the entry point of the application. If application using reflection, that's not enough to make application running.
-To help ILCompiler found types which should be analyzed rd.xml file can be supplemented. This is similar format as format used by .NET Native, but much more limiting.
+ILCompiler discovers types to compile by starting from the application's entry point. This may miss types if an application uses reflection.
+An rd.xml file can be supplemented to help ILCompiler find types that should be analyzed. This file is similar but more limited than the rd.xml file used by .NET Native.
 
 Minimal Rd.xml configuration
 

--- a/Documentation/using-corert/rd-xml-format.md
+++ b/Documentation/using-corert/rd-xml-format.md
@@ -1,0 +1,120 @@
+Rd.xml File Format
+==================
+
+ILCompiler by default lookup for types to be compiled starting from the entry point of the application. If application using reflection, that's not enough to make application running.
+To help ILCompiler found types which should be analyzed rd.xml file can be supplemented. This is similar format as format used by .NET Native, but much more limiting.
+
+Minimal Rd.xml configuration
+
+```
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Application>
+    <Assembly Name="mscorlib" />
+  </Application>
+</Directives>
+```
+
+ILCompiler supports 2 top level directives `Application` or `Library`. Right now both of them can be used interchangeably and just define area where actual assembly configuration happens.
+Developer can put multiple `<Assembly>` tags inside the `<Application>` directive  to configure each assembly individually.
+
+## Assembly directive
+
+There 3 forms how assembly can be configured
+- Module metadata only;
+- All types;
+- Module metadata and selected types.
+
+Module metadata only just need simple `<Assembly>` tag with short name of the assembly.
+```
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Application>
+    <Assembly Name="mscorlib" />
+  </Application>
+</Directives>
+```
+
+All types in the assembly require adding `Dynamic` attribute with value `Required All`. *NOTE*: This is only available options for this attribute.
+```
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Application>
+    <Assembly Name="mscorlib" Dynamic="Required All" />
+  </Application>
+</Directives>
+```
+Note that if you have generic types in the assembly, then specific instantiation would not be present in generated code, and if you need one to be included,
+then you should include these instantiation using nested `<Type>` tag.
+
+Module metadata and selected types option based on module metadata only mode with added `<Type>` tags inside `<Assembly>`.
+```
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Application>
+    <Assembly Name="MonoGame.Framework">
+      <Type Name="Microsoft.Xna.Framework.Content.ListReader`1[[System.Char,mscorlib]]" Dynamic="Required All" />
+    </Assembly>
+  </Application>
+</Directives>
+```
+
+## Types directives.
+Types directive provide a way to specify which parts of code related to classes are needed. Developer can have two options here: 
+- Take all type methods;
+- Select which methods should be rooted.
+
+Take all type methods:
+```
+<Type Name="Microsoft.Xna.Framework.Content.ListReader`1[[System.Char,mscorlib]]" Dynamic="Required All" />
+```
+
+Example how specify typenames
+```
+// just int
+System.Int32
+// string[]
+System.String[]
+// string[][]
+System.String[][]
+// string[,]
+System.String[,]
+// List<int>
+System.Collections.Generic.List`1[[System.Int32,System.Private.CoreLib]]
+// Dictionary<int, string>.KeyCollection
+System.Collections.Generic.Dictionary`2[[System.Int32,System.Private.CoreLib],[System.String,System.Private.CoreLib]]+KeyCollection
+```
+
+Note that it likely does not make sense to have generic type to be placed here, since code generated over specific instantiation of the generic type.
+Example of invalid scenario:
+```
+// List<T>
+System.Collections.Generic.List`1
+```
+
+To select which methods should be rooted add nested `<Method>` tags.
+```
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Application>
+    <Assembly Name="System.Private.CoreLib">
+      <Type Name="System.Collections.Generic.Dictionary`2[[System.Int32,System.Private.CoreLib],[System.String,System.Private.CoreLib]]">
+        <Method Name="EnsureCapacity">
+          <Parameter Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+      </Type>
+    </Assembly>
+  </Application>
+</Directives>
+```
+or if you want instantiate generic method you can pass `<GenericArgument>`.
+```
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Application>
+    <Assembly Name="System.Private.CoreLib">
+      <Type Name="System.Array">
+        <Method Name="Empty">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+      </Type>
+    </Assembly>
+  </Application>
+</Directives>
+```
+
+Take not that methods distinguished by method name and parameters. Type of return value does not used in the method signature.

--- a/Documentation/using-corert/reflection-in-aot-mode.md
+++ b/Documentation/using-corert/reflection-in-aot-mode.md
@@ -64,3 +64,15 @@ The compiler can build insights into how reflection is used by analyzing the use
 ### Assume nothing is accessed dynamically ###
 
 In CoreRT, reflection metadata (names of types, list of their methods, fields, signatures, etc.) is _optional_. The CoreRT runtime has its own minimal version of the metadata that represents the minimum required to execute managed code (think: base type and list of interfaces, offsets to GC pointers within an instance of the type, pointer to the finalizer, etc.). The metadata used by the reflection subsystem within the base class libraries is only used by the reflection stack and is not necessary to execute non-reflection code. For a .NET app that doesn't use reflection, the compiler can skip generating the reflection metadata completely. People who would like to totally minimize the size of their applications or obfuscate their code could be interested in this option, although not much existing real world code would be expected to work with this (including a lot of the framework code).
+
+## Providing hints to the compiler externally ##
+
+If compiler cannot detect types used by the aplication, an rd.xml file can be supplemented to help ILCompiler find types that should be analyzed.
+For that, file `rd.xml` should be created and following lines added to project file
+```
+<ItemGroup>
+  <RdXmlFile Include="rd.xml" />
+</ItemGroup>
+```
+
+Format of the file described [here](rd-xml-format.md)


### PR DESCRIPTION
This documentation provide examples of how rd.xml can be presented.
The only reason for this PR is https://github.com/dotnet/corert/pull/8194#issuecomment-641123667

> Yes, I usually copy the RD.XML from the MonoGame sample and tweak it because I don't remember it either. A volunteer who would document it would have my eternal gratitude. At least we have docs for the SerString format we can link to: [dotnet/runtime#4416](https://github.com/dotnet/runtime/issues/4416)

Hopefully @MichalStrehovsky would keep his word 😉 