### PR TITLE
Place non-GC static data in the BSS section

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -32,7 +32,23 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
-        public override ObjectNodeSection Section => ObjectNodeSection.DataSection;
+        public override ObjectNodeSection Section
+        {
+            get
+            {
+                if (_preinitializationManager.HasLazyStaticConstructor(_type)
+                    || _preinitializationManager.IsPreinitialized(_type))
+                {
+                    // We have data to be emitted so this needs to be in an initialized data section
+                    return ObjectNodeSection.DataSection;
+                }
+                else
+                {
+                    // This is all zeros; place this to the BSS section
+                    return ObjectNodeSection.BssSection;
+                }
+            }
+        }
 
         public static string GetMangledName(TypeDesc type, NameMangler nameMangler)
         {


### PR DESCRIPTION
If the data is all zeros, we can place it in the uninitialized data region. No point storing zeros in the executable.