### PR TITLE
Update compiler from dotnet/runtime

### DIFF
--- a/src/Common/src/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/Common/src/Internal/Runtime/ReadyToRunConstants.cs
@@ -118,6 +118,9 @@ namespace Internal.ReadyToRunConstants
 
         Check_InstructionSetSupport = 0x30, // Define the set of instruction sets that must be supported/unsupported to use the fixup 
 
+        Verify_FieldOffset = 0x31,  // Generate a runtime check to ensure that the field offset matches between compile and runtime. Unlike CheckFieldOffset, this will generate a runtime exception on failure instead of silently dropping the method
+        Verify_TypeLayout = 0x32,  // Generate a runtime check to ensure that the type layout (size, alignment, HFA, reference map) matches between compile and runtime. Unlike Check_TypeLayout, this will generate a runtime failure instead of silently dropping the method
+
         ModuleOverride = 0x80,
         // followed by sig-encoded UInt with assemblyref index into either the assemblyref
         // table of the MSIL metadata of the master context module for the signature or

--- a/src/Common/src/TypeSystem/Common/InstantiatedType.cs
+++ b/src/Common/src/TypeSystem/Common/InstantiatedType.cs
@@ -146,9 +146,9 @@ namespace Internal.TypeSystem
         }
 
         // TODO: Substitutions, generics, modopts, ...
-        public override MethodDesc GetMethod(string name, MethodSignature signature)
+        public override MethodDesc GetMethod(string name, MethodSignature signature, Instantiation substitution)
         {
-            MethodDesc typicalMethodDef = _typeDef.GetMethod(name, signature);
+            MethodDesc typicalMethodDef = _typeDef.GetMethod(name, signature, substitution);
             if (typicalMethodDef == null)
                 return null;
             return _typeDef.Context.GetMethodForInstantiatedType(typicalMethodDef, this);

--- a/src/Common/src/TypeSystem/Common/MethodDesc.cs
+++ b/src/Common/src/TypeSystem/Common/MethodDesc.cs
@@ -20,6 +20,7 @@ namespace Internal.TypeSystem
         UnmanagedCallingConventionStdCall    = 0x0002,
         UnmanagedCallingConventionThisCall   = 0x0003,
         CallingConventionVarargs             = 0x0005,
+        UnmanagedCallingConvention           = 0x0009,
 
         Static = 0x0010,
     }
@@ -42,6 +43,44 @@ namespace Internal.TypeSystem
             _parameters = parameters;
 
             Debug.Assert(parameters != null, "Parameters must not be null");
+        }
+
+        public MethodSignature ApplySubstitution(Instantiation substitution)
+        {
+            if (substitution.IsNull)
+                return this;
+
+            bool needsNewMethodSignature = false;
+            TypeDesc[] newParameters = _parameters; // Re-use existing array until conflict appears
+            TypeDesc returnTypeNew = _returnType.InstantiateSignature(substitution, default(Instantiation));
+            if (returnTypeNew != _returnType)
+            {
+                needsNewMethodSignature = true;
+                newParameters = (TypeDesc[])_parameters.Clone();
+            }
+
+            for (int i = 0; i < newParameters.Length; i++)
+            {
+                TypeDesc newParameter = newParameters[i].InstantiateSignature(substitution, default(Instantiation));
+                if (newParameter != newParameters[i])
+                {
+                    if (!needsNewMethodSignature)
+                    {
+                        needsNewMethodSignature = true;
+                        newParameters = (TypeDesc[])_parameters.Clone();
+                    }
+                    newParameters[i] = newParameter;
+                }
+            }
+
+            if (needsNewMethodSignature)
+            {
+                return new MethodSignature(_flags, _genericParameterCount, returnTypeNew, newParameters);
+            }
+            else
+            {
+                return this;
+            }
         }
 
         public MethodSignatureFlags Flags

--- a/src/Common/src/TypeSystem/Common/TypeDesc.cs
+++ b/src/Common/src/TypeSystem/Common/TypeDesc.cs
@@ -513,14 +513,25 @@ namespace Internal.TypeSystem
         /// If signature is not specified and there are multiple matches, the first one
         /// is returned. Returns null if method not found.
         /// </summary>
-        // TODO: Substitutions, generics, modopts, ...
-        public virtual MethodDesc GetMethod(string name, MethodSignature signature)
+        public MethodDesc GetMethod(string name, MethodSignature signature)
+        {
+            return GetMethod(name, signature, default(Instantiation));
+        }
+
+        /// <summary>
+        /// Gets a named method on the type. This method only looks at methods defined
+        /// in type's metadata. The <paramref name="signature"/> parameter can be null.
+        /// If signature is not specified and there are multiple matches, the first one
+        /// is returned. If substitution is not null, then substitution will be applied to
+        /// possible target methods before signature comparison. Returns null if method not found.
+        /// </summary>
+        public virtual MethodDesc GetMethod(string name, MethodSignature signature, Instantiation substitution)
         {
             foreach (var method in GetMethods())
             {
                 if (method.Name == name)
                 {
-                    if (signature == null || signature.Equals(method.Signature))
+                    if (signature == null || signature.Equals(method.Signature.ApplySubstitution(substitution)))
                         return method;
                 }
             }

--- a/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaModule.cs
@@ -419,12 +419,12 @@ namespace Internal.TypeSystem.Ecma
                 {
                     MethodSignature sig = parser.ParseMethodSignature();
                     TypeDesc typeDescToInspect = parentTypeDesc;
+                    Instantiation substitution = default(Instantiation);
 
                     // Try to resolve the name and signature in the current type, or any of the base types.
                     do
                     {
-                        // TODO: handle substitutions
-                        MethodDesc method = typeDescToInspect.GetMethod(name, sig);
+                        MethodDesc method = typeDescToInspect.GetMethod(name, sig, substitution);
                         if (method != null)
                         {
                             // If this resolved to one of the base types, make sure it's not a constructor.
@@ -434,7 +434,31 @@ namespace Internal.TypeSystem.Ecma
 
                             return method;
                         }
-                        typeDescToInspect = typeDescToInspect.BaseType;
+                        var baseType = typeDescToInspect.BaseType;
+                        if (baseType != null)
+                        {
+                            if (!baseType.HasInstantiation)
+                            {
+                                substitution = default(Instantiation);
+                            }
+                            else
+                            {
+                                // If the base type is generic, any signature match for methods on the base type with the generic details from
+                                // the deriving type
+                                Instantiation newSubstitution = typeDescToInspect.GetTypeDefinition().BaseType.Instantiation;
+                                if (!substitution.IsNull)
+                                {
+                                    TypeDesc[] newSubstitutionTypes = new TypeDesc[newSubstitution.Length];
+                                    for (int i = 0; i < newSubstitution.Length; i++)
+                                    {
+                                        newSubstitutionTypes[i] = newSubstitution[i].InstantiateSignature(substitution, default(Instantiation));
+                                    }
+                                    newSubstitution = new Instantiation(newSubstitutionTypes);
+                                }
+                                substitution = newSubstitution;
+                            }
+                        }
+                        typeDescToInspect = baseType;
                     } while (typeDescToInspect != null);
 
                     ThrowHelper.ThrowMissingMethodException(parentTypeDesc, name, sig);

--- a/src/Common/src/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -170,6 +170,8 @@ namespace Internal.TypeSystem.Ecma
                 Debug.Assert((int)MethodSignatureFlags.UnmanagedCallingConventionStdCall == (int)SignatureCallingConvention.StdCall);
                 Debug.Assert((int)MethodSignatureFlags.UnmanagedCallingConventionThisCall == (int)SignatureCallingConvention.ThisCall);
                 Debug.Assert((int)MethodSignatureFlags.CallingConventionVarargs == (int)SignatureCallingConvention.VarArgs);
+                // [TODO] Debug.Assert((int)MethodSignatureFlags.UnmanagedCallingConvention == (int)SignatureCallingConvention.Unmanaged);
+                Debug.Assert((int)MethodSignatureFlags.UnmanagedCallingConvention == 9);
 
                 flags = (MethodSignatureFlags)signatureCallConv;
             }

--- a/src/Common/src/TypeSystem/Ecma/EcmaType.cs
+++ b/src/Common/src/TypeSystem/Ecma/EcmaType.cs
@@ -311,7 +311,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override MethodDesc GetMethod(string name, MethodSignature signature)
+        public override MethodDesc GetMethod(string name, MethodSignature signature, Instantiation substitution)
         {
             var metadataReader = this.MetadataReader;
             var stringComparer = metadataReader.StringComparer;
@@ -321,7 +321,7 @@ namespace Internal.TypeSystem.Ecma
                 if (stringComparer.Equals(metadataReader.GetMethodDefinition(handle).Name, name))
                 {
                     MethodDesc method = (MethodDesc)_module.GetObject(handle);
-                    if (signature == null || signature.Equals(method.Signature))
+                    if (signature == null || signature.Equals(method.Signature.ApplySubstitution(substitution)))
                         return method;
                 }
             }

--- a/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
+++ b/src/Common/src/TypeSystem/NativeFormat/NativeFormatType.cs
@@ -378,7 +378,7 @@ namespace Internal.TypeSystem.NativeFormat
             }
         }
 
-        public override MethodDesc GetMethod(string name, MethodSignature signature)
+        public override MethodDesc GetMethod(string name, MethodSignature signature, Instantiation substitution)
         {
             var metadataReader = this.MetadataReader;
 
@@ -387,7 +387,7 @@ namespace Internal.TypeSystem.NativeFormat
                 if (metadataReader.GetMethod(handle).Name.StringEquals(name, metadataReader))
                 {
                     MethodDesc method = (MethodDesc)_metadataUnit.GetMethod(handle, this);
-                    if (signature == null || signature.Equals(method.Signature))
+                    if (signature == null || signature.Equals(method.Signature.ApplySubstitution(substitution)))
                         return method;
                 }
             }

--- a/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
+++ b/src/Common/src/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
@@ -115,9 +115,9 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override MethodDesc GetMethod(string name, MethodSignature signature)
+        public override MethodDesc GetMethod(string name, MethodSignature signature, Instantiation substitution)
         {
-            MethodDesc method = _rawCanonType.GetMethod(name, signature);
+            MethodDesc method = _rawCanonType.GetMethod(name, signature, substitution);
             if (method == null)
                 return null;
             return Context.GetMethodForRuntimeDeterminedType(method.GetTypicalMethodDefinition(), this);

--- a/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/InstanceFieldLayout.cs
+++ b/src/ILCompiler.TypeSystem/tests/CoreTestAssembly/InstanceFieldLayout.cs
@@ -79,7 +79,7 @@ namespace Explicit
     }
 
     [StructLayout(LayoutKind.Explicit, Size = 40)]
-    class ExplicitSize : Class1
+    class ExplicitSize
     {
         [FieldOffset(0)]
         int Lol;
@@ -89,6 +89,11 @@ namespace Explicit
 
     [StructLayout(LayoutKind.Explicit)]
     public class ExplicitEmptyClass
+    {
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0)]
+    public class ExplicitEmptyClassSize0
     {
     }
 

--- a/src/ILCompiler.TypeSystem/tests/GCPointerMapTests.Statics.cs
+++ b/src/ILCompiler.TypeSystem/tests/GCPointerMapTests.Statics.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.TypeSystem;
+
+using Xunit;
+
+namespace TypeSystemTests
+{
+    public partial class GCPointerMapTests
+    {
+        [Fact]
+        public void TestStaticMap()
+        {
+            MetadataType mixedStaticClass = _testModule.GetType("GCPointerMap", "MixedStaticClass");
+            var map = GCPointerMap.FromStaticLayout(mixedStaticClass);
+            Assert.Equal(12, map.Size);
+            Assert.Equal("010100101001", map.ToString());
+        }
+
+        [Fact]
+        public void TestThreadStaticMap()
+        {
+            MetadataType mixedThreadStaticClass = _testModule.GetType("GCPointerMap", "MixedThreadStaticClass");
+            var map = GCPointerMap.FromThreadStaticLayout(mixedThreadStaticClass);
+            Assert.Equal(14, map.Size);
+            Assert.Equal("00010010100110", map.ToString());
+        }
+    }
+}

--- a/src/ILCompiler.TypeSystem/tests/GCPointerMapTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/GCPointerMapTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace TypeSystemTests
 {
-    public class GCPointerMapTests
+    public partial class GCPointerMapTests
     {
         TestTypeSystemContext _context;
         ModuleDesc _testModule;
@@ -75,24 +75,6 @@ namespace TypeSystemTests
                 Assert.Equal(32, map.Size);
                 Assert.Equal("11111111111111111111111111111111", map.ToString());
             }
-        }
-
-        [Fact]
-        public void TestStaticMap()
-        {
-            MetadataType mixedStaticClass = _testModule.GetType("GCPointerMap", "MixedStaticClass");
-            var map = GCPointerMap.FromStaticLayout(mixedStaticClass);
-            Assert.Equal(12, map.Size);
-            Assert.Equal("010100101001", map.ToString());
-        }
-
-        [Fact]
-        public void TestThreadStaticMap()
-        {
-            MetadataType mixedThreadStaticClass = _testModule.GetType("GCPointerMap", "MixedThreadStaticClass");
-            var map = GCPointerMap.FromThreadStaticLayout(mixedThreadStaticClass);
-            Assert.Equal(14, map.Size);
-            Assert.Equal("00010010100110", map.ToString());
         }
     }
 }

--- a/src/ILCompiler.TypeSystem/tests/GenericTypeAndMethodTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/GenericTypeAndMethodTests.cs
@@ -110,12 +110,11 @@ namespace TypeSystemTests
         /// Testing lookup up of a method in an instantiated type.
         /// </summary>
         [Fact]
-        [ActiveIssue(-1)]
         public void TestMethodLookup()
         {
             MetadataType t = _testModule.GetType("GenericTypes", "GenericClass`1").MakeInstantiatedType(_context.GetWellKnownType(WellKnownType.Int32));
 
-            MethodSignature sig = new MethodSignature(MethodSignatureFlags.None, 0, t.Instantiation[0], new TypeDesc[0] { });
+            MethodSignature sig = new MethodSignature(MethodSignatureFlags.None, 0, _context.GetSignatureVariable(0, false), new TypeDesc[0] { });
             MethodDesc fooMethod = t.GetMethod("Foo", sig);
             Assert.NotNull(fooMethod);
         }

--- a/src/ILCompiler.TypeSystem/tests/ILTestAssembly/ILTestAssembly.ilproj
+++ b/src/ILCompiler.TypeSystem/tests/ILTestAssembly/ILTestAssembly.ilproj
@@ -15,6 +15,7 @@
     <Compile Include="InstanceFieldLayout.il" />
     <Compile Include="StaticFieldLayout.il" />
     <Compile Include="VirtualFunctionOverride.il" />
+    <Compile Include="MethodImplOverride1.il" />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/ILCompiler.TypeSystem/tests/ILTestAssembly/MethodImplOverride1.il
+++ b/src/ILCompiler.TypeSystem/tests/ILTestAssembly/MethodImplOverride1.il
@@ -1,0 +1,467 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.class private abstract auto ansi beforefieldinit MethodImplOverride1.Base`2<T,U>
+       extends [CoreTestAssembly]System.Object
+{
+  .method public hidebysig newslot virtual 
+          instance string  Method([out] class [CoreTestAssembly]GenericTypes.GenericClass`1<!U>& y,
+                                class [CoreTestAssembly]GenericTypes.GenericClass`1<!T>& x) cil managed
+  {
+    // Code size       16 (0x10)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.1
+    IL_0002:  ldnull
+    IL_0003:  stind.ref
+    IL_0004:  ldstr      "Base<T, U>.Method(out List<U> y, ref List<T> x)"
+    IL_000f:  ret
+  } // end of method MethodImplOverride1.Base`2::Method
+
+  .method public hidebysig newslot virtual 
+          instance string  Method(class [CoreTestAssembly]GenericTypes.GenericClass`1<!T>& x,
+                                [out] class [CoreTestAssembly]GenericTypes.GenericClass`1<!U>& y) cil managed
+  {
+    // Code size       16 (0x10)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.2
+    IL_0002:  ldnull
+    IL_0003:  stind.ref
+    IL_0004:  ldstr      "Base<T, U>.Method(ref List<T> x, out List<U> y)"
+    IL_000f:  ret
+  } // end of method MethodImplOverride1.Base`2::Method
+
+  .method public hidebysig newslot virtual 
+          instance string  Method(class [CoreTestAssembly]GenericTypes.GenericClass`1<!U>& x) cil managed
+  {
+    // Code size       13 (0xd)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldstr      "Base<T, U>.Method(ref List<U> x)"
+    IL_000c:  ret
+  } // end of method MethodImplOverride1.Base`2::Method
+
+  .method family hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [CoreTestAssembly]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method MethodImplOverride1.Base`2::.ctor
+
+} // end of class MethodImplOverride1.Base`2
+
+.class private auto ansi beforefieldinit MethodImplOverride1.Base2`2<A,B>
+       extends class MethodImplOverride1.Base`2<!A,!B>
+{
+  .method public hidebysig newslot virtual 
+          instance string  Method([out] class [CoreTestAssembly]GenericTypes.GenericClass`1<!A>& x) cil managed
+  {
+    // Code size       16 (0x10)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.1
+    IL_0002:  ldnull
+    IL_0003:  stind.ref
+    IL_0004:  ldstr      "Base2<A, B>.Method(out List<A> x)"
+    IL_000f:  ret
+  } // end of method MethodImplOverride1.Base2`2::Method
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void class MethodImplOverride1.Base`2<!A,!B>::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method MethodImplOverride1.Base2`2::.ctor
+
+} // end of class MethodImplOverride1.Base2`2
+
+.class private auto ansi beforefieldinit MethodImplOverride1.Derived
+       extends class MethodImplOverride1.Base2`2<int32,int32>
+{
+  .method public hidebysig newslot virtual 
+          instance string  Method(class [CoreTestAssembly]GenericTypes.GenericClass`1<int32>& a,
+                                [out] class [CoreTestAssembly]GenericTypes.GenericClass`1<int32>& b) cil managed
+  {
+    .override  method instance string class MethodImplOverride1.Base`2<int32,int32>::Method(class [CoreTestAssembly]GenericTypes.GenericClass`1<!0>&,
+                                                                      class [CoreTestAssembly]GenericTypes.GenericClass`1<!1>&)
+    // Code size       16 (0x10)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldarg.2
+    IL_0002:  ldnull
+    IL_0003:  stind.ref
+    IL_0004:  ldstr      "Derived.Method(ref List<int> a, out List<int> b)"
+    IL_000f:  ret
+  } // end of method MethodImplOverride1.Derived::Method
+
+  .method public hidebysig newslot virtual 
+          instance string  Method(class [CoreTestAssembly]GenericTypes.GenericClass`1<int32>& a) cil managed
+  {
+    .override  method instance string class MethodImplOverride1.Base`2<int32,int32>::Method(class [CoreTestAssembly]GenericTypes.GenericClass`1<!1>&)
+    // Code size       13 (0xd)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldstr      "Derived.Method(ref List<int> a)"
+    IL_000c:  ret
+  } // end of method MethodImplOverride1.Derived::Method
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void class MethodImplOverride1.Base2`2<int32,int32>::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method MethodImplOverride1.Derived::.ctor
+
+} // end of class MethodImplOverride1.Derived
+
+
+// TEST2 classes
+.class private auto ansi beforefieldinit MethodImplOverride1.BaseTestGenericsShape`4<A,B,C,D>
+      extends [CoreTestAssembly]System.Object
+{
+  .method public hidebysig newslot virtual 
+          instance string  Method(!A a,
+                                  !B b) cil managed
+  {
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "BaseTestGenericsShape.Method(A a, B b)"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method MethodImplOverride1.BaseTestGenericsShape`4::Method
+
+  .method public hidebysig newslot virtual 
+          instance string  Method(!C modopt([CoreTestAssembly]System.Void) c,
+                                  !D modopt([CoreTestAssembly]System.Object) d) cil managed
+  {
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "BaseTestGenericsShape.Method(C c, D d)"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method MethodImplOverride1.BaseTestGenericsShape`4::Method
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [CoreTestAssembly]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method MethodImplOverride1.BaseTestGenericsShape`4::.ctor
+
+} // end of class MethodImplOverride1.BaseTestGenericsShape`4
+
+.class private auto ansi beforefieldinit MethodImplOverride1.IntermediateGenericsShape`2<E,F>
+      extends class MethodImplOverride1.BaseTestGenericsShape`4<object,string,class [CoreTestAssembly]GenericTypes.GenericClass`1<!E>,!F[]>
+{
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void class MethodImplOverride1.BaseTestGenericsShape`4<object,string,!E,!F>::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method MethodImplOverride1.IntermediateGenericsShape`2::.ctor
+
+} // end of class MethodImplOverride1.IntermediateGenericsShape`2
+
+.class private auto ansi beforefieldinit MethodImplOverride1.DerivedGenericsShape`1<G>
+      extends class MethodImplOverride1.IntermediateGenericsShape`2<int32,!G>
+{
+  .method public hidebysig virtual instance string 
+          MethodOnDerived(class [CoreTestAssembly]GenericTypes.GenericClass`1<int32> modopt([CoreTestAssembly]System.Void) e,
+               !G[] modopt([CoreTestAssembly]System.Object) f) cil managed
+  {
+    .override  method instance string class MethodImplOverride1.IntermediateGenericsShape`2<int32,!G>::Method(class [CoreTestAssembly]GenericTypes.GenericClass`1<!0> modopt([CoreTestAssembly]System.Void), !1[]modopt([CoreTestAssembly]System.Object))
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "DerivedGenericsShape<G>.Method(int e, G f)"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method MethodImplOverride1.DerivedGenericsShape`1::Method
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void class MethodImplOverride1.IntermediateGenericsShape`2<int32,!G>::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method MethodImplOverride1.DerivedGenericsShape`1::.ctor
+
+} // end of class MethodImplOverride1.DerivedGenericsShape`1
+
+.class private auto ansi beforefieldinit MethodImplOverride1.DerivedGenericsShapeInvalidSubstitutedOverride
+      extends class MethodImplOverride1.IntermediateGenericsShape`2<int32,int32>
+{
+  .method public hidebysig virtual instance string 
+          MethodOnDerived(int32 e,
+                int32 f) cil managed
+  {
+    .override  method instance string class  MethodImplOverride1.BaseTestGenericsShape`4<object,string, int32, int32>::Method(int32, int32)
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "DerivedGenericsShapeInvalidSubstitutedOverride.Method(int e, int f)"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method MethodImplOverride1.DerivedGenericsShapeInvalidSubstitutedOverride::Method
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void class MethodImplOverride1.IntermediateGenericsShape`2<int32,int32>::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method MethodImplOverride1.DerivedGenericsShapeInvalidSubstitutedOverride::.ctor
+
+} // end of class MethodImplOverride1.DerivedGenericsShapeInvalidSubstitutedOverride
+
+
+// Types for Test4
+.class interface private abstract auto ansi MethodImplOverride1.IMultiGeneric`2<T,U>
+{
+  .method public hidebysig newslot abstract virtual 
+          instance string  Func(!T t1,
+                                !U u2) cil managed
+  {
+  } // end of method MethodImplOverride1.IMultiGeneric`2::Func
+
+  .method public hidebysig newslot abstract virtual 
+          instance string  Func(!U u1,
+                                !T t2) cil managed
+  {
+  } // end of method MethodImplOverride1.IMultiGeneric`2::Func
+
+} // end of class MethodImplOverride1.IMultiGeneric`2
+
+.class private auto ansi beforefieldinit MethodImplOverride1.Implementor`2<A,B>
+       extends [CoreTestAssembly]System.Object
+       implements class MethodImplOverride1.IMultiGeneric`2<!A,!B>
+{
+  .method private hidebysig newslot virtual final 
+          instance string  'IMultiGeneric<A,B>.Func'(!A t1,
+                                                     !B u2) cil managed
+  {
+    .override  method instance string class MethodImplOverride1.IMultiGeneric`2<!A,!B>::Func(!0,
+                                                                         !1)
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "Implementor<A,B>.IMultiGeneric<A, B>.Func(A t1, B "
+    + "u2)"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method MethodImplOverride1.Implementor`2::'IMultiGeneric<A,B>.Func'
+
+  .method private hidebysig newslot virtual final 
+          instance string  'IMultiGeneric<A,B>.Func'(!B u1,
+                                                     !A t2) cil managed
+  {
+    .override  method instance string class MethodImplOverride1.IMultiGeneric`2<!A,!B>::Func(!1,
+                                                                         !0)
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "Implementor<A,B>.IMultiGeneric<A, B>.Func(B u1, A "
+    + "t2)"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method MethodImplOverride1.Implementor`2::'IMultiGeneric<A,B>.Func'
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [CoreTestAssembly]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method MethodImplOverride1.Implementor`2::.ctor
+
+} // end of class MethodImplOverride1.Implementor`2
+
+.class private auto ansi beforefieldinit MethodImplOverride1.PartialIntImplementor`1<C>
+       extends [CoreTestAssembly]System.Object
+       implements class MethodImplOverride1.IMultiGeneric`2<!C,int32>
+{
+  .method private hidebysig newslot virtual final 
+          instance string  'IMultiGeneric<C,System.Int32>.Func'(!C t1,
+                                                                int32 u2) cil managed
+  {
+    .override  method instance string class MethodImplOverride1.IMultiGeneric`2<!C,int32>::Func(!0,
+                                                                            !1)
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "PartialIntImplementor<C>.IMultiGeneric<C, int>.Fun"
+    + "c(C t1, int u2)"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method MethodImplOverride1.PartialIntImplementor`1::'IMultiGeneric<C,System.Int32>.Func'
+
+  .method private hidebysig newslot virtual final 
+          instance string  'IMultiGeneric<C,System.Int32>.Func'(int32 u1,
+                                                                !C t2) cil managed
+  {
+    .override  method instance string class MethodImplOverride1.IMultiGeneric`2<!C,int32>::Func(!1,
+                                                                            !0)
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "PartialIntImplementor<C>.IMultiGeneric<C, int>.Fun"
+    + "c(int u1, C t2)"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method MethodImplOverride1.PartialIntImplementor`1::'IMultiGeneric<C,System.Int32>.Func'
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [CoreTestAssembly]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method MethodImplOverride1.PartialIntImplementor`1::.ctor
+
+} // end of class MethodImplOverride1.PartialIntImplementor`1
+
+.class private auto ansi beforefieldinit MethodImplOverride1.IntImplementor
+       extends [CoreTestAssembly]System.Object
+       implements class MethodImplOverride1.IMultiGeneric`2<int32,int32>
+{
+  .method public hidebysig newslot virtual final 
+          instance string  Func(int32 x,
+                                int32 y) cil managed
+  {
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "IntImplementor.Func(int x, int y)"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method MethodImplOverride1.IntImplementor::Func
+
+  .method private hidebysig newslot virtual final 
+          instance string  'IMultiGeneric<System.Int32,System.Int32>.Func(!0,!1)'(int32 u1,
+                                                                           int32 t2) cil managed
+  {
+    .override  method instance string class MethodImplOverride1.IMultiGeneric`2<int32,int32>::Func(!0,
+                                                                               !1)
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "IntImplementor.IMultiGeneric<int, int>.Func(!0, !1)"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method MethodImplOverride1.IntImplementor::'IMultiGeneric<System.Int32,System.Int32>.Func(!0,!1)'
+
+  .method private hidebysig newslot virtual final 
+          instance string  'IMultiGeneric<System.Int32,System.Int32>.Func(!1,!0)'(int32 u1,
+                                                                           int32 t2) cil managed
+  {
+    .override  method instance string class MethodImplOverride1.IMultiGeneric`2<int32,int32>::Func(!1,
+                                                                               !0)
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "IntImplementor.IMultiGeneric<int, int>.Func(!1, !0)"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method MethodImplOverride1.IntImplementor::'IMultiGeneric<System.Int32,System.Int32>.Func(!1,!0)'
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [CoreTestAssembly]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method MethodImplOverride1.IntImplementor::.ctor
+
+} // end of class MethodImplOverride1.IntImplementor
+
+// Types for Test5
+.class interface private abstract auto ansi MethodImplOverride1.ISingleGeneric`1<T>
+{
+  .method public hidebysig newslot abstract virtual 
+          instance string  Method(!T t) cil managed
+  {
+  } // end of method MethodImplOverride1.ISingleGeneric`1::Method
+
+} // end of class MethodImplOverride1.ISingleGeneric`1

--- a/src/ILCompiler.TypeSystem/tests/SyntheticVirtualOverrideTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/SyntheticVirtualOverrideTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace TypeSystemTests
 {
-    public class SyntheticVirtualOverrideTests
+    public partial class SyntheticVirtualOverrideTests
     {
         TestTypeSystemContext _context;
         ModuleDesc _testModule;
@@ -156,7 +156,7 @@ namespace TypeSystemTests
             }
         }
 
-        private class SyntheticMethod : MethodDesc
+        private partial class SyntheticMethod : MethodDesc
         {
             private TypeDesc _owningType;
             private MethodSignature _signature;

--- a/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
+++ b/src/ILCompiler.TypeSystem/tests/TestTypeSystemContext.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 
 using Internal.TypeSystem;
+using System.Reflection;
 using System.Reflection.PortableExecutable;
 using System.IO;
 
@@ -45,7 +46,9 @@ namespace TypeSystemTests
 
         public ModuleDesc CreateModuleForSimpleName(string simpleName)
         {
-            ModuleDesc module = Internal.TypeSystem.Ecma.EcmaModule.Create(this, new PEReader(File.OpenRead(simpleName + ".dll")), containingAssembly: null);
+            string bindingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string filePath = Path.Combine(bindingDirectory, simpleName + ".dll");
+            ModuleDesc module = Internal.TypeSystem.Ecma.EcmaModule.Create(this, new PEReader(File.OpenRead(filePath)), containingAssembly: null);
             _modules.Add(simpleName, module);
             return module;
         }

--- a/src/ILCompiler.TypeSystem/tests/TypeSystem.Tests.csproj
+++ b/src/ILCompiler.TypeSystem/tests/TypeSystem.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="CanonicalizationTests.cs" />
     <Compile Include="ConstraintsValidationTest.cs" />
     <Compile Include="GCPointerMapTests.cs" />
+    <Compile Include="GCPointerMapTests.Statics.cs" />
     <Compile Include="GenericTypeAndMethodTests.cs" />
     <Compile Include="CastingTests.cs" />
     <Compile Include="HashcodeTests.cs" />

--- a/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
+++ b/src/ILCompiler.TypeSystem/tests/VirtualFunctionOverrideTests.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-
+using System.Linq;
 using Internal.TypeSystem;
 
 using Xunit;
@@ -143,6 +143,133 @@ namespace TypeSystemTests
             MethodDesc virtualMethod = algo.FindVirtualFunctionTargetMethodOnObjectType(method, myDerived2Type);
             Assert.NotNull(virtualMethod);
             Assert.Equal(method, virtualMethod);
+        }
+
+        [Fact]
+        public void TestGenericsOverrideOfSpecificMethodWhereSubstitutionsAreNecessaryToComputeTheRightTargetToOverride()
+        {
+            var algo = new MetadataVirtualMethodAlgorithm();
+            var ilModule = _context.GetModuleForSimpleName("ILTestAssembly");
+            MetadataType myDerivedType = ilModule.GetType("MethodImplOverride1", "Derived");
+            MetadataType baseType = ilModule.GetType("MethodImplOverride1", "Base`2").MakeInstantiatedType(_context.GetWellKnownType(WellKnownType.Int32), _context.GetWellKnownType(WellKnownType.Int32));
+            var csModule = _context.GetModuleForSimpleName("CoreTestAssembly");
+            var myGenericType = csModule.GetType("GenericTypes", "GenericClass`1");
+            var myGenericTypeInstantiatedOverBang0 = myGenericType.MakeInstantiatedType(_context.GetSignatureVariable(0, false));
+            var myGenericTypeInstantiatedOverBang0ByRef = myGenericTypeInstantiatedOverBang0.MakeByRefType();
+            var myGenericTypeInstantiatedOverBang1 = myGenericType.MakeInstantiatedType(_context.GetSignatureVariable(1, false));
+            var myGenericTypeInstantiatedOverBang1ByRef = myGenericTypeInstantiatedOverBang1.MakeByRefType();
+            var stringType = _context.GetWellKnownType(WellKnownType.String);
+
+            MethodSignature sigBang0Bang1 = new MethodSignature(0, 0, stringType, new TypeDesc[] { myGenericTypeInstantiatedOverBang0ByRef, myGenericTypeInstantiatedOverBang1ByRef });
+            MethodDesc baseMethod0_1 = baseType.GetMethod("Method", sigBang0Bang1);
+
+            MethodDesc virtualMethodBang0Bang1 = algo.FindVirtualFunctionTargetMethodOnObjectType(baseMethod0_1, myDerivedType);
+            Assert.Equal(virtualMethodBang0Bang1.OwningType, myDerivedType);
+
+            MethodSignature sigBang1Bang0 = new MethodSignature(0, 0, stringType, new TypeDesc[] { myGenericTypeInstantiatedOverBang1ByRef, myGenericTypeInstantiatedOverBang0ByRef });
+            MethodDesc baseMethod1_0 = baseType.GetMethod("Method", sigBang1Bang0);
+
+            MethodDesc virtualMethodBang1Bang0 = algo.FindVirtualFunctionTargetMethodOnObjectType(baseMethod1_0, myDerivedType);
+            Assert.Equal(virtualMethodBang1Bang0.OwningType, baseType);
+        }
+
+        [Fact]
+        public void TestGenericsClassOverrideOfMethodWhereMethodHasBeenMovedFromTheTypeWhichPreviouslyDeclaredTheTypeToItsBaseType()
+        {
+            var algo = new MetadataVirtualMethodAlgorithm();
+            var csModule = _context.GetModuleForSimpleName("CoreTestAssembly");
+            var ilModule = _context.GetModuleForSimpleName("ILTestAssembly");
+            var doubleType = _context.GetWellKnownType(WellKnownType.Double);
+            var objectType = _context.GetWellKnownType(WellKnownType.Object);
+            var stringType = _context.GetWellKnownType(WellKnownType.String);
+            var intType = _context.GetWellKnownType(WellKnownType.Int32);
+            var myGenericType = csModule.GetType("GenericTypes", "GenericClass`1");
+            var genericTypeOfInt = myGenericType.MakeInstantiatedType(intType);
+            var doubleArrayType = doubleType.MakeArrayType();
+
+            MetadataType myDerivedType = ilModule.GetType("MethodImplOverride1", "DerivedGenericsShape`1").MakeInstantiatedType(doubleType);
+            MetadataType baseType = ilModule.GetType("MethodImplOverride1", "BaseTestGenericsShape`4").MakeInstantiatedType(objectType, stringType, genericTypeOfInt, doubleArrayType);
+
+            var bang0Type = _context.GetSignatureVariable(0, false);
+            var bang1Type = _context.GetSignatureVariable(1, false);
+            var bang2Type = _context.GetSignatureVariable(2, false);
+            var bang3Type = _context.GetSignatureVariable(3, false);
+
+            MethodSignature sigBang0Bang1 = new MethodSignature(0, 0, stringType, new TypeDesc[] { bang0Type, bang1Type });
+            MethodDesc baseMethod0_1 = baseType.GetMethod("Method", sigBang0Bang1);
+
+            MethodDesc virtualMethodBang0Bang1 = algo.FindVirtualFunctionTargetMethodOnObjectType(baseMethod0_1, myDerivedType);
+            Assert.Equal(virtualMethodBang0Bang1.OwningType, baseType);
+
+            MethodSignature sigBang2Bang3 = new MethodSignature(0, 0, stringType, new TypeDesc[] { bang2Type, bang3Type });
+            MethodDesc baseMethod2_3 = null;
+            // BaseMethod(!2,!3) has custom modifiers in its signature, and thus the sig is difficult to write up by hand. Just search for
+            // it in an ad hoc manner
+            foreach (MethodDesc method in baseType.GetMethods())
+            {
+                if (method.Name != "Method")
+                    continue;
+
+                if (method.GetTypicalMethodDefinition().Signature[0] == bang2Type)
+                {
+                    baseMethod2_3 = method;
+                    break;
+                }
+            }
+
+            MethodDesc virtualMethodBang1Bang0 = algo.FindVirtualFunctionTargetMethodOnObjectType(baseMethod2_3, myDerivedType);
+            Assert.Equal(virtualMethodBang1Bang0.OwningType, myDerivedType);
+        }
+
+        private void ResolveInterfaceDispatch_ForMultiGenericTest(MetadataType type, out MethodDesc md1, out MethodDesc md2)
+        {
+            var algo = new MetadataVirtualMethodAlgorithm();
+            var stringType = _context.GetWellKnownType(WellKnownType.String);
+
+            var bang0Type = _context.GetSignatureVariable(0, false);
+            var bang1Type = _context.GetSignatureVariable(1, false);
+            MethodSignature sigBang0Bang1 = new MethodSignature(0, 0, stringType, new TypeDesc[] { bang0Type, bang1Type });
+            MethodSignature sigBang1Bang0 = new MethodSignature(0, 0, stringType, new TypeDesc[] { bang1Type, bang0Type });
+
+            var iMultiGeneric = type.ExplicitlyImplementedInterfaces.First();
+            var method0_1 = iMultiGeneric.GetMethod("Func", sigBang0Bang1);
+            Assert.NotNull(method0_1);
+            var method1_0 = iMultiGeneric.GetMethod("Func", sigBang1Bang0);
+            Assert.NotNull(method1_0);
+
+            md1 = algo.ResolveInterfaceMethodToVirtualMethodOnType(method0_1, type);
+            md2 = algo.ResolveInterfaceMethodToVirtualMethodOnType(method1_0, type);
+            Assert.NotNull(md1);
+            Assert.NotNull(md2);
+        }
+
+        [Fact]
+        public void TestExactMethodImplGenericDeclResolutionOnInterfaces()
+        {
+            var ilModule = _context.GetModuleForSimpleName("ILTestAssembly");
+            var intType = _context.GetWellKnownType(WellKnownType.Int32);
+            var bang0Type = _context.GetSignatureVariable(0, false);
+            var bang1Type = _context.GetSignatureVariable(1, false);
+
+            var implementorType = ilModule.GetType("MethodImplOverride1", "Implementor`2").MakeInstantiatedType(intType, intType);
+            var partialIntImplementorType = ilModule.GetType("MethodImplOverride1", "PartialIntImplementor`1").MakeInstantiatedType(intType);
+            var intImplementorType = ilModule.GetType("MethodImplOverride1", "IntImplementor");
+
+            ResolveInterfaceDispatch_ForMultiGenericTest(implementorType, out var md1, out var md2);
+            Assert.Equal(bang0Type, md1.GetTypicalMethodDefinition().Signature[0]);
+            Assert.Equal(bang1Type, md1.GetTypicalMethodDefinition().Signature[1]);
+            Assert.Equal(bang1Type, md2.GetTypicalMethodDefinition().Signature[0]);
+            Assert.Equal(bang0Type, md2.GetTypicalMethodDefinition().Signature[1]);
+
+            ResolveInterfaceDispatch_ForMultiGenericTest(partialIntImplementorType, out md1, out md2);
+            Assert.Equal(bang0Type, md1.GetTypicalMethodDefinition().Signature[0]);
+            Assert.Equal(intType, md1.GetTypicalMethodDefinition().Signature[1]);
+            Assert.Equal(intType, md2.GetTypicalMethodDefinition().Signature[0]);
+            Assert.Equal(bang0Type, md2.GetTypicalMethodDefinition().Signature[1]);
+
+            ResolveInterfaceDispatch_ForMultiGenericTest(intImplementorType, out md1, out md2);
+            Assert.Contains("!0,!1", md1.Name);
+            Assert.Contains("!1,!0", md2.Name);
         }
     }
 }

--- a/src/JitInterface/src/CorInfoImpl.cs
+++ b/src/JitInterface/src/CorInfoImpl.cs
@@ -1010,7 +1010,14 @@ namespace Internal.JitInterface
                 else
                 {
                     var methodContext = (MethodDesc)typeOrMethodContext;
-                    Debug.Assert((!methodContext.HasInstantiation && !owningMethod.HasInstantiation) ||
+                    // Allow cases where the method's do not have instantiations themselves, if
+                    // 1. The method defining the context is generic, but the target method is not
+                    // 2. Both methods are not generic
+                    // 3. The methods are the same generic
+                    // AND
+                    // The methods are on the same type
+                    Debug.Assert((methodContext.HasInstantiation && !owningMethod.HasInstantiation) ||
+                        (!methodContext.HasInstantiation && !owningMethod.HasInstantiation) ||
                         methodContext.GetTypicalMethodDefinition() == owningMethod.GetTypicalMethodDefinition() ||
                         (owningMethod.Name == "CreateDefaultInstance" && methodContext.Name == "CreateInstance"));
                     Debug.Assert(methodContext.OwningType.HasSameTypeDefinition(owningMethod.OwningType));
@@ -1186,6 +1193,11 @@ namespace Internal.JitInterface
             var methodIL = (MethodIL)HandleToObject((IntPtr)module);
             var methodSig = (MethodSignature)methodIL.GetObject((int)sigTOK);
             Get_CORINFO_SIG_INFO(methodSig, sig);
+
+            if (sig->callConv == CorInfoCallConv.CORINFO_CALLCONV_UNMANAGED)
+            {
+                throw new NotImplementedException();
+            }
 
 #if !READYTORUN
             // Check whether we need to report this as a fat pointer call

--- a/src/JitInterface/src/CorInfoTypes.cs
+++ b/src/JitInterface/src/CorInfoTypes.cs
@@ -351,6 +351,7 @@ namespace Internal.JitInterface
         CORINFO_CALLCONV_FIELD = 0x6,
         CORINFO_CALLCONV_LOCAL_SIG = 0x7,
         CORINFO_CALLCONV_PROPERTY = 0x8,
+        CORINFO_CALLCONV_UNMANAGED = 0x9,
         CORINFO_CALLCONV_NATIVEVARARG = 0xb,    // used ONLY for IL stub PInvoke vararg calls
 
         CORINFO_CALLCONV_MASK = 0x0f,     // Calling convention is bottom 4 bits


### PR DESCRIPTION
Also, we haven't changed the copyright headers in a couple years and it seems like it was time for that again. I factored that change out to avoid noise. The copyright headers only changed in the synced files for now.

I'll need to get the scripts that @stephentoub ran on the runtime repo because the one in the pull request that did the renaming is probably not the one that was eventually run.