### PR TITLE
Wasm: fix commit version for emsdk

### DIFF
--- a/eng/install-emscripten.cmd
+++ b/eng/install-emscripten.cmd
@@ -4,6 +4,8 @@ cd "%1"
 git clone https://github.com/emscripten-core/emsdk.git
 
 cd emsdk
+rem checkout a known good version to avoid a random break when emscripten changes the top of tree.
+git checkout 92d512f 
 
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0update-machine-certs.ps1""" %*"
 


### PR DESCRIPTION
This PR fixes the commit version of Emscripten, the build environment, not the actual compiler.  Currently the head is pulled and if Emscripten commit a breaking change, the Wasm CI fails, as happened recently.  They've actually fixed that particular problem, but going forwards it's probably a good idea.