### PR TITLE
Don't mark object files incremental linker compatible

### DIFF
--- a/src/Native/ObjWriter/objwriter.cpp
+++ b/src/Native/ObjWriter/objwriter.cpp
@@ -142,7 +142,7 @@ bool ObjectWriter::Init(llvm::StringRef ObjectFilePath, const char* tripleName) 
   Streamer = (MCObjectStreamer *)TheTarget->createMCObjectStreamer(
       TheTriple, *OutContext, *AsmBackend, *OS, CodeEmitter, *SubtargetInfo,
       RelaxAll,
-      /*IncrementalLinkerCompatible*/ true,
+      /*IncrementalLinkerCompatible*/ false,
       /*DWARFMustBeAtTheEnd*/ false);
   if (!Streamer)
     return error("no object streamer for target " + TripleName);


### PR DESCRIPTION
From a quick search in the LLVM codebase, the only thing this controls is whether to generate a timestamp into the object file in PE/COFF outputs. This breaks output determinism.

We disable incremental linking anyway:

https://github.com/dotnet/corert/blob/692e443e3427e43f54b0e43567d7df761a47c961/src/BuildIntegration/Microsoft.NETCore.Native.Windows.props#L72-L73