### PR TITLE
Wasm: Upgrade emscripten for thread destructor support on thread termination

### DIFF
--- a/Documentation/how-to-build-WebAssembly.md
+++ b/Documentation/how-to-build-WebAssembly.md
@@ -3,7 +3,7 @@
 ## Build WebAssembly on Windows ##
 
 1. Install Emscripten by following the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html). 
-2. Follow the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#updating-the-sdk) to update Emscripten to 1.39.8 ```./emsdk install 1.39.8``` followed by ```./emsdk activate 1.39.8```
+2. Follow the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#updating-the-sdk) to update Emscripten to 1.39.19 ```./emsdk install 1.39.19``` followed by ```./emsdk activate 1.39.19```
 3. Install [Firefox](https://www.getfirefox.com) (for testing).
 3. Get CoreRT set up by following the [Visual Studio instructions](how-to-build-and-run-ilcompiler-in-visual-studio.md).
 4. Build the WebAssembly runtime by running ```build.cmd wasm``` from the repo root.

--- a/eng/install-emscripten.cmd
+++ b/eng/install-emscripten.cmd
@@ -5,14 +5,14 @@ git clone https://github.com/emscripten-core/emsdk.git
 
 cd emsdk
 rem checkout a known good version to avoid a random break when emscripten changes the top of tree.
-git checkout 92d512f 
+git checkout dec8a63
 
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0update-machine-certs.ps1""" %*"
 
 rem Use the python that is downloaded to native-tools explicitly as its not on the path
-call "%1"\..\native-tools\bin\python3 emsdk.py install 1.39.8
+call "%1"\..\native-tools\bin\python3 emsdk.py install 1.39.19
 if %errorlevel% NEQ 0 goto fail
-call emsdk activate 1.39.8
+call emsdk activate 1.39.19
 if %errorlevel% NEQ 0 goto fail
 
 exit /b 0


### PR DESCRIPTION
Updates emscripten to the latest which should allow thread support to be enabled in Wasm as previous versions do not always call thread destructors. https://github.com/emscripten-core/emscripten/issues/10809