### PR TITLE
Temporary workaround for https://github.com/dotnet/corert/issues/8241

### DIFF
--- a/src/ILCompiler/src/ConfigurablePInvokePolicy.cs
+++ b/src/ILCompiler/src/ConfigurablePInvokePolicy.cs
@@ -70,7 +70,8 @@ namespace ILCompiler
             else
             {
                 // Account for System.Private.CoreLib.Native / System.Globalization.Native / System.Native / etc
-                return importModule.StartsWith("libSystem.");
+                // TODO: Remove "System." prefix - temporary workaround for https://github.com/dotnet/corert/issues/8241
+                return importModule.StartsWith("libSystem.") || importModule.StartsWith("System.");
             }
         }
     }


### PR DESCRIPTION
Temp fix until dotnet/runtime#39717 can be consumed when CoreRT moves to runtimelab.

Confirmed working with Big Sur.

CC @jkotas 