### PR TITLE
Wasm: Support for calling emscripten_set_main_loop

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -1061,6 +1061,7 @@ namespace Internal.IL
                 case TypeFlags.ByRef:
                     return StackValueKind.ByRef;
                 case TypeFlags.Pointer:
+                case TypeFlags.FunctionPointer:
                     return StackValueKind.NativeInt;
                 default:
                     return StackValueKind.Unknown;
@@ -1285,6 +1286,8 @@ namespace Internal.IL
 
                 case TypeFlags.Pointer:
                     return LLVMTypeRef.CreatePointer(type.GetParameterType().IsVoid ? LLVMTypeRef.Int8 : GetLLVMTypeForTypeDesc(type.GetParameterType()), 0);
+                case TypeFlags.FunctionPointer:
+                    return LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
 
                 case TypeFlags.Int64:
                 case TypeFlags.UInt64:

--- a/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/WebAssemblyObjectWriter.cs
@@ -272,6 +272,14 @@ namespace ILCompiler.DependencyAnalysis
             },
             "returnValue");
 
+            LLVMValueRef RhpReversePInvokeReturn2 = Module.GetNamedFunction("RhpReversePInvokeReturn2");
+            LLVMTypeRef reversePInvokeFunctionType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(reversePInvokeFrameType, 0) }, false);
+            if (RhpReversePInvoke2.Handle == IntPtr.Zero)
+            {
+                RhpReversePInvokeReturn2 = Module.AddFunction("RhpReversePInvokeReturn2", reversePInvokeFunctionType);
+            }
+            builder.BuildCall(RhpReversePInvokeReturn2, new LLVMValueRef[] { reversePinvokeFrame }, "");
+
             builder.BuildRet(mainReturn);
             mainFunc.Linkage = LLVMLinkage.LLVMExternalLinkage;
         }

--- a/src/System.Private.CoreLib/src/System/Environment.CoreRT.cs
+++ b/src/System.Private.CoreLib/src/System/Environment.CoreRT.cs
@@ -55,7 +55,7 @@ namespace System
         {
             // TODO: shut down threading etc.
 
-#if !TARGET_WASM // WASMTODO
+#if !TARGET_WASM // WASMTODO Be careful what happens here as if the code has called emscripten_set_main_loop then the main loop method will normally be called repeatedly after this method
             AppContext.OnProcessExit();
 #endif
         }


### PR DESCRIPTION
This PR allows code to use `emscripten_set_main_loop` (https://emscripten.org/docs/api_reference/emscripten.h.html#browser-execution-environment).
This is possible with the .net 5 compiler and the use of e.g.
```
        [DllImport("*")]
        internal static extern unsafe void emscripten_set_main_loop(delegate*<void> f,  int fps, int simulate_infinite_loop);

        [UnmanagedCallersOnly(EntryPoint = "MainLoop", CallingConvention = CallingConvention.Cdecl)]
        static void MainLoop()
        {
            Console.WriteLine("Main loop");
        }
```
and
```
        emscripten_set_main_loop(&MainLoop, 0, 0);
```

It adds handling for `TypeFlags.FunctionPointer` and adds a call to `RhpReversePInvokeReturn2` when the main function exits as emscripten will subsequently make calls into the main loop function and the thread state needs to go back to preemptive.