### PR TITLE
Wasm: add support for ovf op with char type

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -3814,8 +3814,8 @@ namespace Internal.IL
                         break;
 
                     case ILOpcode.add_ovf:
-                        Debug.Assert(type.Category == TypeFlags.Int32 || type.Category == TypeFlags.Int64);
-                        if (type.Category == TypeFlags.Int32)
+                        Debug.Assert(type.Category == TypeFlags.Int32 || type.Category == TypeFlags.Int64 || type.Category == TypeFlags.Char);
+                        if (type.Category == TypeFlags.Int32 || type.Category == TypeFlags.Char)
                         {
                             BuildAddOverflowChecksForSize(ref AddOvf32Function, left, right, LLVMTypeRef.Int32, BuildConstInt32(int.MaxValue), BuildConstInt32(int.MinValue), true);
                         }

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -820,12 +820,6 @@ namespace Internal.IL
             PushLoadExpression(GetStackValueKind(type), (argument ? "arg" : "loc") + index + "_", typedLoadLocation, type);
         }
 
-        private LLVMValueRef LoadTemp(int index)
-        {
-            LLVMValueRef address = LoadVarAddress(index, LocalVarKind.Temp, out TypeDesc type);
-            return _builder.BuildLoad(CastToPointerToTypeDesc(address, type, $"Temp{index}_"), $"LdTemp{index}_");
-        }
-
         internal LLVMValueRef LoadTemp(int index, LLVMTypeRef asType)
         {
             LLVMValueRef address = LoadVarAddress(index, LocalVarKind.Temp, out TypeDesc type);
@@ -3814,8 +3808,8 @@ namespace Internal.IL
                         break;
 
                     case ILOpcode.add_ovf:
-                        Debug.Assert(type.Category == TypeFlags.Int32 || type.Category == TypeFlags.Int64 || type.Category == TypeFlags.Char);
-                        if (type.Category == TypeFlags.Int32 || type.Category == TypeFlags.Char)
+                        Debug.Assert(CanPerformSignedOverflowOperations(op1.Kind));
+                        if (Is32BitStackValue(op1.Kind))
                         {
                             BuildAddOverflowChecksForSize(ref AddOvf32Function, left, right, LLVMTypeRef.Int32, BuildConstInt32(int.MaxValue), BuildConstInt32(int.MinValue), true);
                         }
@@ -3827,8 +3821,8 @@ namespace Internal.IL
                         result = _builder.BuildAdd(left, right, "add");
                         break;
                     case ILOpcode.add_ovf_un:
-                        Debug.Assert(type.Category == TypeFlags.UInt32 || type.Category == TypeFlags.Int32 || type.Category == TypeFlags.UInt64 || type.Category == TypeFlags.Int64 || type.Category == TypeFlags.Pointer);
-                        if (type.Category == TypeFlags.UInt32 || type.Category == TypeFlags.Int32 || type.Category == TypeFlags.Pointer)
+                        Debug.Assert(CanPerformUnsignedOverflowOperations(op1.Kind));
+                        if (Is32BitStackValue(op1.Kind))
                         {
                             BuildAddOverflowChecksForSize(ref AddOvfUn32Function, left, right, LLVMTypeRef.Int32, BuildConstUInt32(uint.MaxValue), BuildConstInt32(0), false);
                         }
@@ -3840,8 +3834,8 @@ namespace Internal.IL
                         result = _builder.BuildAdd(left, right, "add");
                         break;
                     case ILOpcode.sub_ovf:
-                        Debug.Assert(type.Category == TypeFlags.Int32 || type.Category == TypeFlags.Int64);
-                        if (type.Category == TypeFlags.Int32)
+                        Debug.Assert(CanPerformSignedOverflowOperations(op1.Kind));
+                        if (Is32BitStackValue(op1.Kind))
                         {
                             BuildSubOverflowChecksForSize(ref SubOvf32Function, left, right, LLVMTypeRef.Int32, BuildConstInt32(int.MaxValue), BuildConstInt32(int.MinValue), true);
                         }
@@ -3853,8 +3847,8 @@ namespace Internal.IL
                         result = _builder.BuildSub(left, right, "sub");
                         break;
                     case ILOpcode.sub_ovf_un:
-                        Debug.Assert(type.Category == TypeFlags.UInt32 || type.Category == TypeFlags.Int32 || type.Category == TypeFlags.UInt64 || type.Category == TypeFlags.Int64 || type.Category == TypeFlags.Pointer);
-                        if (type.Category == TypeFlags.UInt32 || type.Category == TypeFlags.Int32 || type.Category == TypeFlags.Pointer)
+                        Debug.Assert(CanPerformUnsignedOverflowOperations(op1.Kind));
+                        if (Is32BitStackValue(op1.Kind))
                         {
                             BuildSubOverflowChecksForSize(ref SubOvfUn32Function, left, right, LLVMTypeRef.Int32, BuildConstUInt32(uint.MaxValue), BuildConstInt32(0), false);
                         }
@@ -3885,6 +3879,21 @@ namespace Internal.IL
             PushExpression(kind, "binop", result, type);
         }
 
+        bool CanPerformSignedOverflowOperations(StackValueKind kind)
+        {
+            return kind == StackValueKind.Int32 || kind == StackValueKind.Int64;
+        }
+
+        bool CanPerformUnsignedOverflowOperations(StackValueKind kind)
+        {
+            return CanPerformSignedOverflowOperations(kind) || kind == StackValueKind.ByRef ||
+                   kind == StackValueKind.ObjRef || kind == StackValueKind.NativeInt;
+        }
+
+        bool Is32BitStackValue(StackValueKind kind)
+        {
+            return kind == StackValueKind.Int32 || kind == StackValueKind.ByRef ||  kind == StackValueKind.ObjRef || kind == StackValueKind.NativeInt;
+        }
 
         LLVMValueRef StartOverflowCheckFunction(LLVMTypeRef sizeTypeRef, bool signed,
             string throwFuncName, out LLVMValueRef leftOp, out LLVMValueRef rightOp, out LLVMBuilderRef builder, out LLVMBasicBlockRef elseBlock,

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -2272,6 +2272,8 @@ internal static class Program
 
     static void TestIntOverflows()
     {
+        TestCharInOvf();
+
         TestSignedIntAddOvf();
 
         TestSignedLongAddOvf();
@@ -2327,6 +2329,21 @@ internal static class Program
             return;
         }
         EndTest(true);
+    }
+
+    private static void TestCharInOvf()
+    {
+        // Just checks the compiler can handle the char type
+        // This was failing for https://github.com/dotnet/corert/blob/f542d97f26e87f633310e67497fb01dad29987a5/src/System.Private.CoreLib/shared/System/Environment.Unix.cs#L111
+        StartTest("Test char add overflows");
+        char opChar = '1';
+        int op32r = 2;
+        if (checked(opChar + op32r) != 51)
+        {
+            FailTest("No overflow for char failed"); // check not always throwing an exception
+            return;
+        }
+        PassTest();
     }
 
     private static void TestSignedIntAddOvf()


### PR DESCRIPTION
This PR fixes a compiler assert when compiling https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/shared/System/Environment.Unix.cs#L111 as the char type was not included in the int32 path.  Types short and byte seem ok before this change so no code added for those.