### PR TITLE
Fix race condition in 'IsCancellationRequested'

### DIFF
--- a/src/System.Private.CoreLib/shared/System/Threading/CancellationToken.cs
+++ b/src/System.Private.CoreLib/shared/System/Threading/CancellationToken.cs
@@ -68,7 +68,7 @@ namespace System.Threading
         /// particularly in situations where related objects are being canceled concurrently.
         /// </para>
         /// </remarks>
-        public bool IsCancellationRequested => _source != null && _source.IsCancellationRequested;
+        public bool IsCancellationRequested => _source is CancellationTokenSource _tmp && _tmp.IsCancellationRequested;
 
         /// <summary>
         /// Gets whether this token is capable of being in the canceled state.


### PR DESCRIPTION
A classic race; the `null` check is essentially useless as written, since `_source` can yet become `null` before the secondary use it is supposed to be protecting.

Pulling `_source` into a local restores deterministic correctness by ensuring only a single fetch from the uncontrolled address.