### PR TITLE
Wasm: add switch case for LPUTF8Str in array element

### DIFF
--- a/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/Common/src/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -734,6 +734,8 @@ namespace Internal.TypeSystem.Interop
                         return MarshallerKind.AnsiString;
                     case NativeTypeKind.LPWStr:
                         return MarshallerKind.UnicodeString;
+                    case NativeTypeKind.LPUTF8Str:
+                        return MarshallerKind.UTF8String;
                     default:
                         return MarshallerKind.Invalid;
                 }


### PR DESCRIPTION
This adds the switch case for array element type marshalling as UTF8 which helps for Javascript