### PR TITLE
Wasm: Add support for DefaultConstructorOf and hence Activator.CreateInstance<T>

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2517,7 +2517,7 @@ namespace Internal.IL
                             _dependencies.Add(methodNode);
 
                             MethodDesc ctor = methodNode.Method;
-                            PushExpression(StackValueKind.Int32, "eeType", LLVMFunctionForMethod(ctor, ctor, null, false, null, ctor, out bool _, out LLVMValueRef _, out LLVMValueRef _), GetWellKnownType(WellKnownType.IntPtr));
+                            PushExpression(StackValueKind.Int32, "ctor", LLVMFunctionForMethod(ctor, ctor, null, false, null, ctor, out bool _, out LLVMValueRef _, out LLVMValueRef _), GetWellKnownType(WellKnownType.IntPtr));
                         }
 
                         return true;

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2503,6 +2503,26 @@ namespace Internal.IL
                         return true;
                     }
                     break;
+                case "DefaultConstructorOf":
+                    if (metadataType.Namespace == "System" && metadataType.Name == "Activator" && method.Instantiation.Length == 1)
+                    {
+                        if (runtimeDeterminedMethod.IsRuntimeDeterminedExactMethod)
+                        {
+                            var ctorRef = CallGenericHelper(ReadyToRunHelperId.DefaultConstructor, runtimeDeterminedMethod.Instantiation[0]);
+                            PushExpression(StackValueKind.Int32, "ctor", ctorRef, GetWellKnownType(WellKnownType.IntPtr));
+                        }
+                        else
+                        {
+                            IMethodNode methodNode = (IMethodNode)_compilation.ComputeConstantLookup(ReadyToRunHelperId.DefaultConstructor, method.Instantiation[0]);
+                            _dependencies.Add(methodNode);
+
+                            MethodDesc ctor = methodNode.Method;
+                            PushExpression(StackValueKind.Int32, "eeType", LLVMFunctionForMethod(ctor, ctor, null, false, null, ctor, out bool _, out LLVMValueRef _, out LLVMValueRef _), GetWellKnownType(WellKnownType.IntPtr));
+                        }
+
+                        return true;
+                    }
+                    break;
             }
 
             return false;

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -360,6 +360,8 @@ internal static class Program
 
         TestJavascriptCall();
 
+        TestDefaultConstructorOf();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -2606,6 +2608,13 @@ internal static class Program
         IntPtr resultPtr = JSInterop.InternalCalls.InvokeJSUnmarshalled(out string exception, "Answer", IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
 
         EndTest(resultPtr.ToInt32() == 42);
+    }
+
+    static void TestDefaultConstructorOf()
+    {
+        StartTest("Test DefaultConstructorOf");
+        var c = Activator.CreateInstance<ClassForNre>();
+        EndTest(c != null);
     }
 
     static ushort ReadUInt16()


### PR DESCRIPTION
This PR add support for this intrinsic, enabling `Activator.CreateInstance<T>`