### PR TITLE
Wasm: upgrade emscripten for an llvm and exception fixes.

### DIFF
--- a/Documentation/how-to-build-WebAssembly.md
+++ b/Documentation/how-to-build-WebAssembly.md
@@ -3,7 +3,7 @@
 ## Build WebAssembly on Windows ##
 
 1. Install Emscripten by following the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html). 
-2. Follow the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#updating-the-sdk) to update Emscripten to 2.0.1 ```./emsdk install 2.0.1``` followed by ```./emsdk activate 2.0.1```
+2. Follow the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#updating-the-sdk) to update Emscripten to 2.0.1 ```./emsdk install 2.0.0``` followed by ```./emsdk activate 2.0.0```
 3. Install [Firefox](https://www.getfirefox.com) (for testing).
 3. Get CoreRT set up by following the [Visual Studio instructions](how-to-build-and-run-ilcompiler-in-visual-studio.md).
 4. Build the WebAssembly runtime by running ```build.cmd wasm``` from the repo root.

--- a/Documentation/how-to-build-WebAssembly.md
+++ b/Documentation/how-to-build-WebAssembly.md
@@ -3,7 +3,7 @@
 ## Build WebAssembly on Windows ##
 
 1. Install Emscripten by following the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html). 
-2. Follow the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#updating-the-sdk) to update Emscripten to 1.39.19 ```./emsdk install 1.39.19``` followed by ```./emsdk activate 1.39.19```
+2. Follow the instructions [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#updating-the-sdk) to update Emscripten to 2.0.1 ```./emsdk install 2.0.1``` followed by ```./emsdk activate 2.0.1```
 3. Install [Firefox](https://www.getfirefox.com) (for testing).
 3. Get CoreRT set up by following the [Visual Studio instructions](how-to-build-and-run-ilcompiler-in-visual-studio.md).
 4. Build the WebAssembly runtime by running ```build.cmd wasm``` from the repo root.

--- a/eng/install-emscripten.cmd
+++ b/eng/install-emscripten.cmd
@@ -5,7 +5,7 @@ git clone https://github.com/emscripten-core/emsdk.git
 
 cd emsdk
 rem checkout a known good version to avoid a random break when emscripten changes the top of tree.
-git checkout 6adb624
+git checkout c1f0ad9
 
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0update-machine-certs.ps1""" %*"
 

--- a/eng/install-emscripten.cmd
+++ b/eng/install-emscripten.cmd
@@ -5,14 +5,14 @@ git clone https://github.com/emscripten-core/emsdk.git
 
 cd emsdk
 rem checkout a known good version to avoid a random break when emscripten changes the top of tree.
-git checkout dec8a63
+git checkout 6adb624
 
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0update-machine-certs.ps1""" %*"
 
 rem Use the python that is downloaded to native-tools explicitly as its not on the path
-call "%1"\..\native-tools\bin\python3 emsdk.py install 1.39.19
+call "%1"\..\native-tools\bin\python3 emsdk.py install 2.0.1
 if %errorlevel% NEQ 0 goto fail
-call emsdk activate 1.39.19
+call emsdk activate 2.0.1
 if %errorlevel% NEQ 0 goto fail
 
 exit /b 0

--- a/eng/install-emscripten.cmd
+++ b/eng/install-emscripten.cmd
@@ -10,9 +10,9 @@ git checkout c1f0ad9
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0update-machine-certs.ps1""" %*"
 
 rem Use the python that is downloaded to native-tools explicitly as its not on the path
-call "%1"\..\native-tools\bin\python3 emsdk.py install 2.0.1
+call "%1"\..\native-tools\bin\python3 emsdk.py install 2.0.0
 if %errorlevel% NEQ 0 goto fail
-call emsdk activate 2.0.1
+call emsdk activate 2.0.0
 if %errorlevel% NEQ 0 goto fail
 
 exit /b 0

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -3044,7 +3044,6 @@ namespace Internal.IL
         {
             if (CxaEndCatchFunction == default)
             {
-                // takes the exception structure and returns the c++ exception, defined by emscripten
                 CxaEndCatchFunction = Module.AddFunction("__cxa_end_catch", LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] { }, false));
             }
             return CxaEndCatchFunction;

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2901,7 +2901,8 @@ namespace Internal.IL
                 BuildFinallyFunclet(Module);
             }
 
-            var exPtr = landingPadBuilder.BuildExtractValue(pad, 0, "ex");
+            // __cxa_begin catch to get the c++ exception object, must be paired with __cxa_end_catch (http://libcxxabi.llvm.org/spec.html)
+            var exPtr = landingPadBuilder.BuildCall(GetCxaBeginCatchFunction(), new LLVMValueRef[] { landingPadBuilder.BuildExtractValue(pad, 0, "ex") });
 
             // unwrap managed, cast to 32bit pointer from 8bit personality signature pointer
             var ex32Ptr = landingPadBuilder.BuildPointerCast(exPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int32, 0));
@@ -2953,6 +2954,8 @@ namespace Internal.IL
             landingPadBuilder.BuildCondBr(noCatch, secondPassBlock, foundCatchBlock);
 
             landingPadBuilder.PositionAtEnd(foundCatchBlock);
+            // finished with the c++ exception
+            landingPadBuilder.BuildCall(GetCxaEndCatchFunction(), new LLVMValueRef[] { });
 
             LLVMValueRef[] callCatchArgs = new LLVMValueRef[]
                                   {
@@ -3024,6 +3027,27 @@ namespace Internal.IL
             landingPadBuilder.Dispose();
 
             return landingPad;
+        }
+
+        LLVMValueRef GetCxaBeginCatchFunction()
+        {
+            if (CxaBeginCatchFunction == default)
+            {
+                // takes the exception structure and returns the c++ exception, defined by emscripten
+                CxaBeginCatchFunction = Module.AddFunction("__cxa_begin_catch", LLVMTypeRef.CreateFunction(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), 
+                    new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)}, false));
+            }
+            return CxaBeginCatchFunction;
+        }
+
+        LLVMValueRef GetCxaEndCatchFunction()
+        {
+            if (CxaEndCatchFunction == default)
+            {
+                // takes the exception structure and returns the c++ exception, defined by emscripten
+                CxaEndCatchFunction = Module.AddFunction("__cxa_end_catch", LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] { }, false));
+            }
+            return CxaEndCatchFunction;
         }
 
         private void AddMethodReference(MethodDesc method)

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter_Statics.cs
@@ -111,6 +111,8 @@ namespace Internal.IL
         static LLVMValueRef DebugtrapFunction = default(LLVMValueRef);
         static LLVMValueRef TrapFunction = default(LLVMValueRef);
         static LLVMValueRef DoNothingFunction = default(LLVMValueRef);
+        static LLVMValueRef CxaBeginCatchFunction = default(LLVMValueRef);
+        static LLVMValueRef CxaEndCatchFunction = default(LLVMValueRef);
         static LLVMValueRef RhpThrowEx = default(LLVMValueRef);
         static LLVMValueRef RhpCallCatchFunclet = default(LLVMValueRef);
         static LLVMValueRef LlvmCatchFunclet = default(LLVMValueRef);


### PR DESCRIPTION
This PR upgrades the version of emscripten to version 2.0.1 (version 2 signifies the removal of the fastcomp backend).  This lets us take advantage of an LLVM fix: https://bugs.llvm.org/show_bug.cgi?id=47040 and "nearly" thread safe exceptions in emscripten: https://github.com/emscripten-core/emscripten/pull/11518.  To do this the retrieval of the c++ exception from the landing pad needed fixing by using __cxa_begin_catch and __cxa_end_catch, which should make sure that the c++ exception is cleaned up properly, see

https://releases.llvm.org/7.0.0/docs/ExceptionHandling.html#throw
http://libcxxabi.llvm.org/spec.html

