### PR TITLE
ARM64: Fix AllocFast large object size check

### DIFF
--- a/src/Native/Runtime/arm64/AllocFast.S
+++ b/src/Native/Runtime/arm64/AllocFast.S
@@ -89,7 +89,7 @@ RhpNewFast_RarePath:
 
         // If the object is bigger than RH_LARGE_OBJECT_SIZE, we must publish it to the BGC
         ldr         w1, [x19, #OFFSETOF__EEType__m_uBaseSize]
-        movk        x2, #(RH_LARGE_OBJECT_SIZE & 0xFFFF)
+        movz        x2, #(RH_LARGE_OBJECT_SIZE & 0xFFFF)
         movk        x2, #(RH_LARGE_OBJECT_SIZE >> 16), lsl #16
         cmp         x1, x2
         blo         New_SkipPublish
@@ -264,7 +264,7 @@ ArraySizeOverflow:
         str         x20, [x0, #OFFSETOF__Array__m_Length]
 
         // If the object is bigger than RH_LARGE_OBJECT_SIZE, we must publish it to the BGC
-        movk        x2, #(RH_LARGE_OBJECT_SIZE & 0xFFFF)
+        movz        x2, #(RH_LARGE_OBJECT_SIZE & 0xFFFF)
         movk        x2, #(RH_LARGE_OBJECT_SIZE >> 16), lsl #16
         cmp         x21, x2
         blo         NewArray_SkipPublish

--- a/src/Native/Runtime/arm64/AllocFast.asm
+++ b/src/Native/Runtime/arm64/AllocFast.asm
@@ -81,7 +81,7 @@ RhpNewFast_RarePath
 
         ;; If the object is bigger than RH_LARGE_OBJECT_SIZE, we must publish it to the BGC
         ldr         w1, [x19, #OFFSETOF__EEType__m_uBaseSize]
-        movk        x2, #(RH_LARGE_OBJECT_SIZE & 0xFFFF)
+        movz        x2, #(RH_LARGE_OBJECT_SIZE & 0xFFFF)
         movk        x2, #(RH_LARGE_OBJECT_SIZE >> 16), lsl #16
         cmp         x1, x2
         blo         New_SkipPublish
@@ -261,7 +261,7 @@ ArraySizeOverflow
         str         x20, [x0, #OFFSETOF__Array__m_Length]
 
         ;; If the object is bigger than RH_LARGE_OBJECT_SIZE, we must publish it to the BGC
-        movk        x2, #(RH_LARGE_OBJECT_SIZE & 0xFFFF)
+        movz        x2, #(RH_LARGE_OBJECT_SIZE & 0xFFFF)
         movk        x2, #(RH_LARGE_OBJECT_SIZE >> 16), lsl #16
         cmp         x21, x2
         blo         NewArray_SkipPublish


### PR DESCRIPTION
After allocation objects in the large object heap needs to be published for some cleanups related to the background gc. The constant value for this limit (RH_LARGE_OBJECT_SIZE) was not loaded correctly in the register. This caused that the upper 32 bits of the register were in an undefined state. Therefore the check for large objects did practically always fail and the objects were never published. Therefore the cleanup never happened and the background GC did fail.