### PR TITLE
Both examples of using IntPtr and unsafe keyword provided

### DIFF
--- a/samples/NativeLibrary/Class1.cs
+++ b/samples/NativeLibrary/Class1.cs
@@ -37,20 +37,36 @@ namespace NativeLibrary
         }
 
         [UnmanagedCallersOnly(EntryPoint = "sumstring")]
-        public static IntPtr sumstring(IntPtr first, IntPtr second)
+        public static unsafe char* sumstring(char* first, char* second)
         {
             // Parse strings from the passed pointers 
-            string my1String = Marshal.PtrToStringAnsi(first);
-            string my2String = Marshal.PtrToStringAnsi(second);
+            string my1String = Marshal.PtrToStringAnsi((IntPtr)first);
+            string my2String = Marshal.PtrToStringAnsi((IntPtr)second);
 
             // Concatenate strings 
             string sum = my1String + my2String;
 
             // Assign pointer of the concatenated string to sumPointer
-            IntPtr sumPointer = Marshal.StringToHGlobalAnsi(sum);
+            char* sumPointer = (char*)Marshal.StringToHGlobalAnsi(sum);
 
             // Return pointer
             return sumPointer;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "populateStrArr")]
+        public static unsafe void populateStrArr(char** destination, char* first, char* second)
+        {
+            // Parse strings from the passed pointers 
+            string my1String = Marshal.PtrToStringAnsi((IntPtr)first);
+            string my2String = Marshal.PtrToStringAnsi((IntPtr)second);
+
+            //Copy sum string into an unmanaged memory location
+            char* firstElement = (char*)Marshal.StringToHGlobalAnsi(my1String + my2String);
+            char* secondElement = (char*)Marshal.StringToHGlobalAnsi(my2String + my1String);
+
+            // Assign the two strings to their respective positions
+            destination[0] = firstElement;
+            destination[1] = secondElement;
         }
     }
 }

--- a/samples/NativeLibrary/LoadLibrary.c
+++ b/samples/NativeLibrary/LoadLibrary.c
@@ -21,6 +21,7 @@
 
 int callSumFunc(char *path, char *funcName, int a, int b);
 char *callSumStringFunc(char *path, char *funcName, char *a, char *b);
+char *callPopulateStringArrayFunc(char *path, char *funcName, char **destination, char* firstString, char* secondString);
 
 int main()
 {
@@ -38,6 +39,11 @@ int main()
     // Concatenate two strings
     char *sumstring = callSumStringFunc(PathToLibrary, "sumstring", "ok", "ko");
     printf("The concatenated string is %s \n", sumstring);
+
+    // Put two char* into an array
+    char* myStrings[2];
+    callPopulateStringArrayFunc(PathToLibrary, "populateStrArr", myStrings, "ok", "ko");
+    printf("First element: %s \n Second element: %s \n", myStrings[0],myStrings[1]);
 
     // Free string
     free(sumstring);
@@ -74,7 +80,7 @@ char *callSumStringFunc(char *path, char *funcName, char *firstString, char *sec
     // Declare a typedef
     typedef char *(*myFunc)();
 
-    // Import Symbol named funcName
+    // Import symbol named funcName
     myFunc MyImport = symLoad(handle, funcName);
 
     // The C# function will return a pointer
@@ -83,4 +89,26 @@ char *callSumStringFunc(char *path, char *funcName, char *firstString, char *sec
     // CoreRT libraries do not support unloading
     // See https://github.com/dotnet/corert/issues/7887
     return result;
+}
+
+char *callPopulateStringArrayFunc(char *path, char *funcName, char **destination, char* firstString, char* secondString)
+{
+    // Library loading
+    #ifdef _WIN32
+        HINSTANCE handle = LoadLibrary(path);
+    #else
+        void *handle = dlopen(path, RTLD_LAZY);
+    #endif
+
+    // Declare a typedef
+    typedef void (*myFunc)();
+
+    // Import Symbol named funcName
+    myFunc MyImport = symLoad(handle, funcName);
+
+    // The C# function will return a pointer
+    MyImport(destination, firstString, secondString);
+
+    // CoreRT libraries do not support unloading
+    // See https://github.com/dotnet/corert/issues/7887
 }

--- a/samples/NativeLibrary/NativeLibrary.csproj
+++ b/samples/NativeLibrary/NativeLibrary.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Unsafe keyword supports also char** parameters, while IntPtr doesn't