### PR TITLE
Wasm: create unboxes for struct ctor overloads

### DIFF
--- a/src/ILCompiler.Compiler/src/Compiler/CoreRTNameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CoreRTNameMangler.cs
@@ -528,12 +528,6 @@ namespace ILCompiler
                     // Method on an instantiated type
                     utf8MangledName = GetUnqualifiedMangledMethodName(typicalMethodDefinition);
                 }
-                else if (method is CompilerTypeSystemContext.ValueTypeInstanceMethodWithHiddenParameter)
-                {
-                    utf8MangledName = GetUnqualifiedMangledMethodName(
-                        ((CompilerTypeSystemContext.ValueTypeInstanceMethodWithHiddenParameter)method)
-                        .MethodRepresented);
-                }
                 else if (method is IPrefixMangledMethod)
                 {
                     utf8MangledName = GetPrefixMangledMethodName((IPrefixMangledMethod)method);

--- a/src/ILCompiler.Compiler/src/Compiler/CoreRTNameMangler.cs
+++ b/src/ILCompiler.Compiler/src/Compiler/CoreRTNameMangler.cs
@@ -528,6 +528,12 @@ namespace ILCompiler
                     // Method on an instantiated type
                     utf8MangledName = GetUnqualifiedMangledMethodName(typicalMethodDefinition);
                 }
+                else if (method is CompilerTypeSystemContext.ValueTypeInstanceMethodWithHiddenParameter)
+                {
+                    utf8MangledName = GetUnqualifiedMangledMethodName(
+                        ((CompilerTypeSystemContext.ValueTypeInstanceMethodWithHiddenParameter)method)
+                        .MethodRepresented);
+                }
                 else if (method is IPrefixMangledMethod)
                 {
                     utf8MangledName = GetPrefixMangledMethodName((IPrefixMangledMethod)method);

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2077,7 +2077,6 @@ namespace Internal.IL
             dictPtrPtrStore = default(LLVMValueRef);
             fatFunctionPtr = default(LLVMValueRef);
 
-            string canonMethodName = _compilation.NameMangler.GetMangledMethodName(canonMethod).ToString();
             TypeDesc owningType = callee.OwningType;
             bool delegateInvoke = owningType.IsDelegate && callee.Name == "Invoke";
             // Sealed methods must not be called virtually due to sealed vTables, so call them directly, but not delegate Invoke
@@ -2088,7 +2087,8 @@ namespace Internal.IL
                     hasHiddenParam = canonMethod.RequiresInstArg() || canonMethod.IsArrayAddressMethod();
                 }
                 AddMethodReference(canonMethod);
-                return GetOrCreateLLVMFunction(canonMethodName, canonMethod.Signature, hasHiddenParam);
+                string physicalName = _compilation.NodeFactory.MethodEntrypoint(canonMethod).GetMangledName(_compilation.NameMangler);
+                return GetOrCreateLLVMFunction(physicalName, canonMethod.Signature, hasHiddenParam);
             }
 
             LLVMValueRef thisRef = default;
@@ -2159,6 +2159,7 @@ namespace Internal.IL
 
             hasHiddenParam = canonMethod.RequiresInstArg();
             AddMethodReference(canonMethod);
+            string canonMethodName = _compilation.NodeFactory.MethodEntrypoint(canonMethod).GetMangledName(_compilation.NameMangler);
             return GetOrCreateLLVMFunction(canonMethodName, canonMethod.Signature, hasHiddenParam);
         }
 

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -365,6 +365,8 @@ internal static class Program
 
         TestDefaultConstructorOf();
 
+        TestStructUnboxOverload();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -2881,6 +2883,30 @@ internal static class Program
         StartTest("Test DefaultConstructorOf");
         var c = Activator.CreateInstance<ClassForNre>();
         EndTest(c != null);
+    }
+
+    internal struct LargeArrayBuilder<T>
+    {
+        private readonly int _maxCapacity;
+
+        public LargeArrayBuilder(bool initialize)
+            : this(maxCapacity: int.MaxValue)
+        {
+        }
+
+        public LargeArrayBuilder(int maxCapacity)
+            : this()
+        {
+            _maxCapacity = maxCapacity;
+        }
+    }
+
+    static void TestStructUnboxOverload()
+    {
+        StartTest("Test DefaultConstructorOf");
+        var s = new LargeArrayBuilder<string>(true);
+        var s2 = new LargeArrayBuilder<string>(1);
+        EndTest(true); // testing compilation 
     }
 
     static ushort ReadUInt16()


### PR DESCRIPTION
With the following code the WebAssembly backend generates invalid LLVM

```
    internal struct LargeArrayBuilder<T>
    {
        private readonly int _maxCapacity;

        public LargeArrayBuilder(bool initialize)
            : this(maxCapacity: int.MaxValue)
        {
        }

        public LargeArrayBuilder(int maxCapacity)
            : this()
        {
            _maxCapacity = maxCapacity;
        }
    }

    static void TestStructUnboxOverload()
    {
        StartTest("Test DefaultConstructorOf");
        var s = new LargeArrayBuilder<string>(true);
        var s2 = new LargeArrayBuilder<string>(1);
        EndTest(true); // testing compilation 
    }
```

It generates a single unbox for the ctor call:

```
define void @"<Boxed>HelloWasm_Program_LargeArrayBuilder_1<System___Canon>__<unbox>HelloWasm_Program_LargeArrayBuilder_1___ctor_0"(i8*, i32)
```
which calls the wrong ctor, i.e. the one that takes the bool
```
 call void @"HelloWasm_Program_LargeArrayBuilder_1<System___Canon>___ctor"(i8* %5, i8* %LoadField_m_pEEType, i32 %Loadarg1_)
```
ctor definitions:
```
define void @"HelloWasm_Program_LargeArrayBuilder_1<System___Canon>___ctor"(i8*, i8*, i1)  // the bool

define void @"HelloWasm_Program_LargeArrayBuilder_1<System___Canon>___ctor_0"(i8*, i8*, i32) // the int 
```

With this change it generates 2 unboxes calling the relevant ctors


```
define void @"<Boxed>HelloWasm_Program_LargeArrayBuilder_1<System___Canon>__<unbox>HelloWasm_Program_LargeArrayBuilder_1___ctor"(i8*, i1)
...
  call void @"HelloWasm_Program_LargeArrayBuilder_1<System___Canon>___ctor"(i8* %5, i8* %LoadField_m_pEEType, i1 %Loadarg1_)
```
and 
```
define void @"<Boxed>HelloWasm_Program_LargeArrayBuilder_1<System___Canon>__<unbox>HelloWasm_Program_LargeArrayBuilder_1___ctor_0"(i8*, i32)
...
  call void @"HelloWasm_Program_LargeArrayBuilder_1<System___Canon>___ctor_0"(i8* %5, i8* %LoadField_m_pEEType, i32 %Loadarg1_)
```

Maybe this is not the right way to fix this, the fix should perhaps be in the WebAssembly backend code as I'm surprised the other backends have not hit this?
