### PR TITLE
ARM64: fix loading function address in CallingConventionConverter_Get…

### DIFF
--- a/src/Native/Runtime/arm64/CallingConventionConverterHelpers.S
+++ b/src/Native/Runtime/arm64/CallingConventionConverterHelpers.S
@@ -52,10 +52,10 @@ POINTER_SIZE = 0x08
     // void CallingConventionConverter_GetStubs(IntPtr *returnVoidStub, IntPtr *returnIntegerStub, IntPtr *commonCallingStub)
     //
     LEAF_ENTRY CallingConventionConverter_GetStubs, _TEXT
-        ldr     x12, =CallingConventionConverter_ReturnThunk
+        PREPARE_EXTERNAL_VAR CallingConventionConverter_ReturnThunk, x12
         str     x12, [x0] // ARM doesn't need different return thunks.
         str     x12, [x1]
-        ldr     x12, =__jmpstub__CallingConventionConverter_CommonCallingStub
+        PREPARE_EXTERNAL_VAR __jmpstub__CallingConventionConverter_CommonCallingStub, x12
         str     x12, [x2]
         ret
     LEAF_END CallingConventionConverter_GetStubs, _TEXT


### PR DESCRIPTION
The current way to load the address of a functions there can cause the assembler to add a data field in a executable section itself. Depending on how smart the linker is this might generate position dependent code. In this case the OS might need to patch these data fields after loading. Therefore the linker needs to add relocation information for the code section. A hardened OS can reject to load an file that contains relocation in the executable part for security reasons. 

The new way doesn't have this issue. It is already used for other functions.