### PR TITLE
Wasm: avoid redirection for GetSystemArrayEEType for InPlaceRuntime

### DIFF
--- a/src/Runtime.Base/src/System/Runtime/EEType.Runtime.cs
+++ b/src/Runtime.Base/src/System/Runtime/EEType.Runtime.cs
@@ -13,11 +13,15 @@ namespace Internal.Runtime
     {
         internal EEType* GetArrayEEType()
         {
+#if INPLACE_RUNTIME
+            return EETypePtr.EETypePtrOf<Array>().ToPointer();
+#else
             fixed (EEType* pThis = &this)
             {
                 IntPtr pGetArrayEEType = (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType(new IntPtr(pThis), ClassLibFunctionId.GetSystemArrayEEType);
                 return (EEType*)CalliIntrinsics.Call<IntPtr>(pGetArrayEEType);
             }
+#endif
         }
 
         internal Exception GetClasslibException(ExceptionIDs id)

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
+using System.Collections;
 using System.Reflection;
 using System.Diagnostics;
 
@@ -366,6 +367,8 @@ internal static class Program
         TestDefaultConstructorOf();
 
         TestStructUnboxOverload();
+
+        TestGetSystemArrayEEType();
 
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
@@ -2906,6 +2909,16 @@ internal static class Program
         StartTest("Test DefaultConstructorOf");
         var s = new LargeArrayBuilder<string>(true);
         var s2 = new LargeArrayBuilder<string>(1);
+        EndTest(true); // testing compilation 
+    }
+
+    static void TestGetSystemArrayEEType()
+    {
+        StartTest("Test can call GetSystemArrayEEType through CalliIntrinsic");
+        IList e = new string[] { "1" };
+        foreach (string s in e)
+        {
+        }
         EndTest(true); // testing compilation 
     }
 


### PR DESCRIPTION
This PR addresses a difficulty in Wasm when its tries to get the address type through the class lib functions.  The `&GetSystemArrayEEType` occurs in cpp and registers the RuntimeExport function which in Wasm does not get the shadow stack argument, however it is called from `CalliIntrinsics` which adds that argument and a signature mismatch occurs at runtime.

Thanks @jkotas.

Fixes #8312 