### PR TITLE
Wasm: do not sign extend bools

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/EvaluationStack.cs
@@ -577,7 +577,7 @@ namespace Internal.IL
             LLVMTypeRef origLLVMType = ILImporter.GetLLVMTypeForTypeDesc(Type);
             LLVMValueRef value = _importer.LoadTemp(LocalIndex, origLLVMType);
 
-            return ILImporter.CastIfNecessary(builder, value, type);
+            return ILImporter.CastIfNecessary(builder, value, type, unsigned: !signExtend);
         }
 
         public override StackEntry Duplicate(LLVMBuilderRef builder)

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -4054,6 +4054,7 @@ namespace Internal.IL
             if (enumCleanTargetType != null && targetType.IsPrimitive)
             {
                 if (enumCleanTargetType.IsWellKnownType(WellKnownType.Byte) ||
+                    enumCleanTargetType.IsWellKnownType(WellKnownType.Boolean) ||
                     enumCleanTargetType.IsWellKnownType(WellKnownType.Char) ||
                     enumCleanTargetType.IsWellKnownType(WellKnownType.UInt16) ||
                     enumCleanTargetType.IsWellKnownType(WellKnownType.UInt32) ||
@@ -4145,7 +4146,7 @@ namespace Internal.IL
                 }
             }
 
-            PushExpression(StackValueKind.Int32, "cmpop", result, GetWellKnownType(WellKnownType.SByte));
+            PushExpression(StackValueKind.Int32, "cmpop", result, GetWellKnownType(WellKnownType.UInt32));
         }
 
         private void ImportConvert(WellKnownType wellKnownType, bool checkOverflow, bool unsigned)

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -370,6 +370,8 @@ internal static class Program
 
         TestGetSystemArrayEEType();
 
+        TestBoolCompare();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -2920,6 +2922,14 @@ internal static class Program
         {
         }
         EndTest(true); // testing compilation 
+    }
+
+    static void TestBoolCompare()
+    {
+        StartTest("Test Bool.Equals");
+        bool expected = true;
+        bool actual = true;
+        EndTest(expected.Equals(actual));
     }
 
     static ushort ReadUInt16()


### PR DESCRIPTION
This PR fixes an issue where operands of boolean expressions, if they were bools, where getting sign extended from i1 to i32.

Fixes: #8321 