### PR TITLE
Wasm: RhpNewArrayAlign8 use non-padded size when going to the slow path

### DIFF
--- a/src/Native/Runtime/portable.cpp
+++ b/src/Native/Runtime/portable.cpp
@@ -64,12 +64,12 @@ COOP_PINVOKE_HELPER(Object *, RhpNewFast, (EEType* pEEType))
 
     size_t size = pEEType->get_BaseSize();
 
-    UInt8* result = acontext->alloc_ptr;
-    UInt8* advance = result + size;
-    if (advance <= acontext->alloc_limit)
+    UInt8* alloc_ptr = acontext->alloc_ptr;
+    ASSERT(alloc_ptr <= acontext->alloc_limit);
+    if ((size_t)(acontext->alloc_limit - alloc_ptr) >= size)
     {
-        acontext->alloc_ptr = advance;
-        pObject = (Object *)result;
+        acontext->alloc_ptr = alloc_ptr + size;
+        pObject = (Object *)alloc_ptr;
         pObject->set_EEType(pEEType);
         return pObject;
     }
@@ -147,22 +147,12 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArray, (EEType * pArrayEEType, int numElement
         size = ALIGN_UP(size, sizeof(UIntNative));
     }
 
-    UInt8* result = acontext->alloc_ptr;
-#ifdef HOST_64BIT
-    UInt8* advance = result + size;
-#else
-    uint64_t advance64 = (uint64_t)result + (uint64_t)size;
-    size_t advance32 = (size_t)advance64;
-    if (advance32 != advance64)
+    UInt8* alloc_ptr = acontext->alloc_ptr;
+    ASSERT(alloc_ptr <= acontext->alloc_limit);
+    if ((size_t)(acontext->alloc_limit - alloc_ptr) >= size)
     {
-        ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
-    }
-    UInt8* advance = (UInt8*)advance32;
-#endif // HOST_64BIT
-    if (advance <= acontext->alloc_limit)
-    {
-        acontext->alloc_ptr = advance;
-        pObject = (Array *)result;
+        acontext->alloc_ptr = alloc_ptr + size;
+        pObject = (Array *)alloc_ptr;
         pObject->set_EEType(pArrayEEType);
         pObject->InitArrayLength((UInt32)numElements);
         return pObject;
@@ -202,6 +192,7 @@ COOP_PINVOKE_HELPER(Object *, RhpNewFinalizableAlign8, (EEType* pEEType))
     return pObject;
 }
 
+#ifndef HOST_64BIT
 COOP_PINVOKE_HELPER(Object *, RhpNewFastAlign8, (EEType* pEEType))
 {
     ASSERT(pEEType->RequiresAlign8());
@@ -220,41 +211,26 @@ COOP_PINVOKE_HELPER(Object *, RhpNewFastAlign8, (EEType* pEEType))
     size_t paddedSize = size;
     if (requiresPadding) 
     {
-#ifdef HOST_64BIT
-        paddedSize += 12;
-#else
-        uint64_t paddedSize64 = (uint64_t)paddedSize + (uint64_t)12;
-        paddedSize = (size_t)paddedSize64;
-        if (paddedSize != paddedSize64)
+        if(paddedSize > SIZE_MAX - 12)
         {
             ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
         }
-#endif // HOST_64BIT
+        paddedSize += 12;
     }
 
-#ifdef HOST_64BIT
-    UInt8* advance = result + paddedSize;
-#else
-    uint64_t advance64 = (uint64_t)result + (uint64_t)paddedSize;
-    size_t advance32 = (size_t)advance64;
-    if (advance32 != advance64)
+    UInt8* alloc_ptr = acontext->alloc_ptr;
+    ASSERT(alloc_ptr <= acontext->alloc_limit);
+    if ((size_t)(acontext->alloc_limit - alloc_ptr) >= paddedSize)
     {
-        ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
-    }
-    UInt8* advance = (UInt8*)advance32;
-#endif // HOST_64BIT
-    if (advance <= acontext->alloc_limit)
-    {
-        acontext->alloc_ptr = advance;
+        acontext->alloc_ptr = alloc_ptr + paddedSize;
         if (requiresPadding)
         {
-            Object* dummy = (Object*)result;
+            Object* dummy = (Object*)alloc_ptr;
             dummy->set_EEType(g_pFreeObjectEEType);
-            result += 12; // if result + paddedSize was ok, then cant overflow
+            alloc_ptr += 12; // if result + paddedSize was ok, then cant overflow
         }
-        pObject = (Object*)result;
+        pObject = (Object *)alloc_ptr;
         pObject->set_EEType(pEEType);
-
         return pObject;
     }
 
@@ -284,40 +260,25 @@ COOP_PINVOKE_HELPER(Object*, RhpNewFastMisalign, (EEType* pEEType))
     size_t paddedSize = size;
     if (requiresPadding) 
     {
-#ifdef HOST_64BIT
-        paddedSize += 12;
-#else
-        uint64_t paddedSize64 = (uint64_t)paddedSize + (uint64_t)12;
-        paddedSize = (size_t)paddedSize64;
-        if (paddedSize != paddedSize64)
+        if(paddedSize > SIZE_MAX - 12)
         {
             ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
         }
-#endif // HOST_64BIT
+        paddedSize += 12;
     }
-#ifdef HOST_64BIT
-    UInt8* advance = result + paddedSize;
-#else
-    uint64_t advance64 = (uint64_t)result + (uint64_t)paddedSize;
-    size_t advance32 = (size_t)advance64;
-    if (advance32 != advance64)
+    UInt8* alloc_ptr = acontext->alloc_ptr;
+    ASSERT(alloc_ptr <= acontext->alloc_limit);
+    if ((size_t)(acontext->alloc_limit - alloc_ptr) >= paddedSize)
     {
-        ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
-    }
-    UInt8* advance = (UInt8*)advance32;
-#endif // HOST_64BIT
-    if (advance <= acontext->alloc_limit)
-    {
-        acontext->alloc_ptr = advance;
+        acontext->alloc_ptr = alloc_ptr + paddedSize;
         if (requiresPadding)
         {
-            Object* dummy = (Object*)result;
+            Object* dummy = (Object*)alloc_ptr;
             dummy->set_EEType(g_pFreeObjectEEType);
-            result += 12; // if result + paddedSize was ok, then cant overflow
+            alloc_ptr += 12; // if result + paddedSize was ok, then cant overflow
         }
-        pObject = (Object*)result;
+        pObject = (Object *)alloc_ptr;
         pObject->set_EEType(pEEType);
-
         return pObject;
     }
 
@@ -350,7 +311,6 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArrayAlign8, (EEType * pArrayEEType, int numE
     size_t size;
 
     UInt32 baseSize = pArrayEEType->get_BaseSize();
-#ifndef HOST_64BIT
     // if the element count is <= 0x10000, no overflow is possible because the component size is
     // <= 0xffff, and thus the product is <= 0xffff0000, and the base size is only ~12 bytes
     if (numElements > 0x10000)
@@ -366,7 +326,6 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArrayAlign8, (EEType * pArrayEEType, int numE
         }
     }
     else
-#endif // !HOST_64BIT
     {
         size = (size_t)baseSize + ((size_t)numElements * (size_t)pArrayEEType->get_ComponentSize());
         size = ALIGN_UP(size, sizeof(UIntNative));
@@ -376,38 +335,24 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArrayAlign8, (EEType * pArrayEEType, int numE
     size_t paddedSize = size;
     if (requiresAlignObject) 
     {
-#ifdef HOST_64BIT
-        paddedSize += 12;
-#else
-        uint64_t paddedSize64 = (uint64_t)paddedSize + (uint64_t)12;
-        paddedSize = (size_t)paddedSize64;
-        if (paddedSize != paddedSize64)
+        if(paddedSize > SIZE_MAX - 12)
         {
             ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
         }
-#endif // HOST_64BIT
+        paddedSize += 12;
     }
-#ifdef HOST_64BIT
-    UInt8* advance = result + paddedSize;
-#else
-    uint64_t advance64 = (uint64_t)result + (uint64_t)paddedSize;
-    size_t advance32 = (size_t)advance64;
-    if (advance32 != advance64)
+    UInt8* alloc_ptr = acontext->alloc_ptr;
+    ASSERT(alloc_ptr <= acontext->alloc_limit);
+    if ((size_t)(acontext->alloc_limit - alloc_ptr) >= paddedSize)
     {
-        ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
-    }
-    UInt8* advance = (UInt8*)advance32;
-#endif // HOST_64BIT
-    if (advance <= acontext->alloc_limit)
-    {
-        acontext->alloc_ptr = advance;
+        acontext->alloc_ptr = alloc_ptr + paddedSize;
         if (requiresAlignObject)
         {
-            Object* dummy = (Object*)result;
+            Object* dummy = (Object*)alloc_ptr;
             dummy->set_EEType(g_pFreeObjectEEType);
-            result += 12; // if result + paddedSize was ok, then cant overflow
+            alloc_ptr += 12; // if result + paddedSize was ok, then cant overflow
         }
-        pObject = (Array*)result;
+        pObject = (Array*)alloc_ptr;
         pObject->set_EEType(pArrayEEType);
         pObject->InitArrayLength((UInt32)numElements);
         return pObject;
@@ -426,6 +371,7 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArrayAlign8, (EEType * pArrayEEType, int numE
 
     return pObject;
 }
+#endif // !HOST_64BIT
 #endif // defined(HOST_ARM) || defined(HOST_WASM)
 
 COOP_PINVOKE_HELPER(void, RhpInitialDynamicInterfaceDispatch, ())

--- a/src/Native/Runtime/portable.cpp
+++ b/src/Native/Runtime/portable.cpp
@@ -148,7 +148,17 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArray, (EEType * pArrayEEType, int numElement
     }
 
     UInt8* result = acontext->alloc_ptr;
+#ifdef HOST_64BIT
     UInt8* advance = result + size;
+#else
+    uint64_t advance64 = (uint64_t)result + (uint64_t)size;
+    size_t advance32 = (size_t)advance64;
+    if (advance32 != advance64)
+    {
+        ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
+    }
+    UInt8* advance = (UInt8*)advance32;
+#endif // HOST_64BIT
     if (advance <= acontext->alloc_limit)
     {
         acontext->alloc_ptr = advance;
@@ -208,8 +218,31 @@ COOP_PINVOKE_HELPER(Object *, RhpNewFastAlign8, (EEType* pEEType))
 
     int requiresPadding = ((uint32_t)result) & 7;
     size_t paddedSize = size;
-    if (requiresPadding) paddedSize += 12;
+    if (requiresPadding) 
+    {
+#ifdef HOST_64BIT
+        paddedSize += 12;
+#else
+        uint64_t paddedSize64 = (uint64_t)paddedSize + (uint64_t)12;
+        paddedSize = (size_t)paddedSize64;
+        if (paddedSize != paddedSize64)
+        {
+            ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
+        }
+#endif // HOST_64BIT
+    }
+
+#ifdef HOST_64BIT
     UInt8* advance = result + paddedSize;
+#else
+    uint64_t advance64 = (uint64_t)result + (uint64_t)paddedSize;
+    size_t advance32 = (size_t)advance64;
+    if (advance32 != advance64)
+    {
+        ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
+    }
+    UInt8* advance = (UInt8*)advance32;
+#endif // HOST_64BIT
     if (advance <= acontext->alloc_limit)
     {
         acontext->alloc_ptr = advance;
@@ -217,7 +250,7 @@ COOP_PINVOKE_HELPER(Object *, RhpNewFastAlign8, (EEType* pEEType))
         {
             Object* dummy = (Object*)result;
             dummy->set_EEType(g_pFreeObjectEEType);
-            result += 12;
+            result += 12; // if result + paddedSize was ok, then cant overflow
         }
         pObject = (Object*)result;
         pObject->set_EEType(pEEType);
@@ -249,8 +282,30 @@ COOP_PINVOKE_HELPER(Object*, RhpNewFastMisalign, (EEType* pEEType))
 
     int requiresPadding = (((uint32_t)result) & 7) != 4;
     size_t paddedSize = size;
-    if (requiresPadding) paddedSize += 12;
+    if (requiresPadding) 
+    {
+#ifdef HOST_64BIT
+        paddedSize += 12;
+#else
+        uint64_t paddedSize64 = (uint64_t)paddedSize + (uint64_t)12;
+        paddedSize = (size_t)paddedSize64;
+        if (paddedSize != paddedSize64)
+        {
+            ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
+        }
+#endif // HOST_64BIT
+    }
+#ifdef HOST_64BIT
     UInt8* advance = result + paddedSize;
+#else
+    uint64_t advance64 = (uint64_t)result + (uint64_t)paddedSize;
+    size_t advance32 = (size_t)advance64;
+    if (advance32 != advance64)
+    {
+        ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
+    }
+    UInt8* advance = (UInt8*)advance32;
+#endif // HOST_64BIT
     if (advance <= acontext->alloc_limit)
     {
         acontext->alloc_ptr = advance;
@@ -258,7 +313,7 @@ COOP_PINVOKE_HELPER(Object*, RhpNewFastMisalign, (EEType* pEEType))
         {
             Object* dummy = (Object*)result;
             dummy->set_EEType(g_pFreeObjectEEType);
-            result += 12;
+            result += 12; // if result + paddedSize was ok, then cant overflow
         }
         pObject = (Object*)result;
         pObject->set_EEType(pEEType);
@@ -319,9 +374,30 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArrayAlign8, (EEType * pArrayEEType, int numE
     UInt8* result = acontext->alloc_ptr;
     int requiresAlignObject = ((uint32_t)result) & 7;
     size_t paddedSize = size;
-    if (requiresAlignObject) paddedSize += 12;
-
+    if (requiresAlignObject) 
+    {
+#ifdef HOST_64BIT
+        paddedSize += 12;
+#else
+        uint64_t paddedSize64 = (uint64_t)paddedSize + (uint64_t)12;
+        paddedSize = (size_t)paddedSize64;
+        if (paddedSize != paddedSize64)
+        {
+            ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
+        }
+#endif // HOST_64BIT
+    }
+#ifdef HOST_64BIT
     UInt8* advance = result + paddedSize;
+#else
+    uint64_t advance64 = (uint64_t)result + (uint64_t)paddedSize;
+    size_t advance32 = (size_t)advance64;
+    if (advance32 != advance64)
+    {
+        ASSERT_UNCONDITIONALLY("NYI");  // TODO: Throw overflow
+    }
+    UInt8* advance = (UInt8*)advance32;
+#endif // HOST_64BIT
     if (advance <= acontext->alloc_limit)
     {
         acontext->alloc_ptr = advance;
@@ -329,7 +405,7 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArrayAlign8, (EEType * pArrayEEType, int numE
         {
             Object* dummy = (Object*)result;
             dummy->set_EEType(g_pFreeObjectEEType);
-            result += 12;
+            result += 12; // if result + paddedSize was ok, then cant overflow
         }
         pObject = (Array*)result;
         pObject->set_EEType(pArrayEEType);

--- a/src/Native/Runtime/portable.cpp
+++ b/src/Native/Runtime/portable.cpp
@@ -207,8 +207,9 @@ COOP_PINVOKE_HELPER(Object *, RhpNewFastAlign8, (EEType* pEEType))
     UInt8* result = acontext->alloc_ptr;
 
     int requiresPadding = ((uint32_t)result) & 7;
-    if (requiresPadding) size += 12;
-    UInt8* advance = result + size;
+    size_t paddedSize = size;
+    if (requiresPadding) paddedSize += 12;
+    UInt8* advance = result + paddedSize;
     if (advance <= acontext->alloc_limit)
     {
         acontext->alloc_ptr = advance;
@@ -247,8 +248,9 @@ COOP_PINVOKE_HELPER(Object*, RhpNewFastMisalign, (EEType* pEEType))
     UInt8* result = acontext->alloc_ptr;
 
     int requiresPadding = (((uint32_t)result) & 7) != 4;
-    if (requiresPadding) size += 12;
-    UInt8* advance = result + size;
+    size_t paddedSize = size;
+    if (requiresPadding) paddedSize += 12;
+    UInt8* advance = result + paddedSize;
     if (advance <= acontext->alloc_limit)
     {
         acontext->alloc_ptr = advance;

--- a/src/Native/Runtime/portable.cpp
+++ b/src/Native/Runtime/portable.cpp
@@ -316,9 +316,10 @@ COOP_PINVOKE_HELPER(Array *, RhpNewArrayAlign8, (EEType * pArrayEEType, int numE
     }
     UInt8* result = acontext->alloc_ptr;
     int requiresAlignObject = ((uint32_t)result) & 7;
-    if (requiresAlignObject) size += 12;
+    size_t paddedSize = size;
+    if (requiresAlignObject) paddedSize += 12;
 
-    UInt8* advance = result + size;
+    UInt8* advance = result + paddedSize;
     if (advance <= acontext->alloc_limit)
     {
         acontext->alloc_ptr = advance;

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections;
 using System.Reflection;
 using System.Diagnostics;
+using System.Collections.Specialized;
 
 #if TARGET_WINDOWS
 using CpObj;
@@ -449,39 +450,43 @@ internal static class Program
     }
 
     class F4 { internal int i; }
-    class F2Plus4 { internal short s; internal int i; }
     class F8 { internal long l; }
     class F2Plus8 { internal short s; internal long l; }
+    class CDisp : IDisposable  { public void Dispose() { } }
+    struct StructF48 { internal int i1; internal long l2; }
     private static bool TestCreateDifferentObjects()
     {
-        var mr = new MiniRandom(57);
+        var mr = new MiniRandom(257);
         var keptObjects = new object[100];
-        for (var i = 0; i < 10000; i++)
+        for (var i = 0; i < 1000000; i++)
         {
             var r = mr.Next();
             object o;
-            switch (r % 7)
+            switch (r % 8)
             {
                 case 0:
                     o = new F4 { i = 1, };
                     break;
                 case 1:
-                    o = new F2Plus4 { i = 2, s = 3 };
-                    break;
-                case 2:
                     o = new F8 { l = 4 };
                     break;
-                case 3:
+                case 2:
                     o = new F2Plus8 { l = 5, s = 6 };
                     break;
-                case 4:
+                case 3:
                     o = i.ToString();
                     break;
-                case 5:
+                case 4:
                     o = new long[10000];
                     break;
-                case 6:
+                case 5:
                     o = new int[10000];
+                    break;
+                case 6:
+                    o = new StructF48 { i1 = 7, l2 = 8 };
+                    break;
+                case 7:
+                    o = new CDisp();
                     break;
                 default:
                     o = null;


### PR DESCRIPTION
This PR fixes a bug when allocating arrays that required 8 byte alignment, if the slow path was chosen the padded size, i.e. with the extra 12 byte object, was being passed to `RhpGcAlloc` (and `RhpPublishObject`).  This change passes the size of the actual new array without the padding.

Fixes #8317 