### PR TITLE
ARM64: Use RhpMemoryBarrier from portable.cpp for ARM64

### DIFF
--- a/src/Native/Runtime/portable.cpp
+++ b/src/Native/Runtime/portable.cpp
@@ -490,12 +490,10 @@ COOP_PINVOKE_HELPER(Int64, RhpLockCmpXchg64, (Int64 * location, Int64 value, Int
 
 #endif // USE_PORTABLE_HELPERS
 
-#if !defined(HOST_ARM64)
 COOP_PINVOKE_HELPER(void, RhpMemoryBarrier, ())
 {
     PalMemoryBarrier();
 }
-#endif
 
 #if defined(USE_PORTABLE_HELPERS)
 EXTERN_C REDHAWK_API void* __cdecl RhAllocateThunksMapping()


### PR DESCRIPTION
portable.cpp contains an implementation that just forwards to PalMemoryBarrier. It was disabeled for ARM64 only. As the forward works fine for ARM64 there is no reason to not use the same code for all CPUs