### PR TITLE
UNIX: Higher Thread priority

### DIFF
--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -618,9 +618,6 @@ REDHAWK_PALEXPORT bool REDHAWK_PALAPI PalStartBackgroundWork(_In_ BackgroundCall
     int st = pthread_attr_init(&attrs);
     ASSERT(st == 0);
 
-    // TODO: Figure out which scheduler to use, the default one doesn't seem to
-    // support per thread priorities.
-
     // Create the thread as detached, that means not joinable
     st = pthread_attr_setdetachstate(&attrs, PTHREAD_CREATE_DETACHED);
     ASSERT(st == 0);

--- a/src/Native/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/Native/Runtime/unix/PalRedhawkUnix.cpp
@@ -648,8 +648,6 @@ REDHAWK_PALEXPORT bool REDHAWK_PALAPI PalStartBackgroundWork(_In_ BackgroundCall
         }
     }
 
-
-
     return st == 0;
 }
 

--- a/src/Native/gc/unix/gcenv.unix.cpp
+++ b/src/Native/gc/unix/gcenv.unix.cpp
@@ -1064,6 +1064,8 @@ bool GCToOSInterface::BoostThreadPriority()
         return false;
     }
 
+    param.sched_priority = max;
+
     return (pthread_setschedparam(thread, policy, &param) == 0);
 }
 


### PR DESCRIPTION
implements GCToOSInterface::BoostThreadPriority & PalStartBackgroundWork highPriority

The default scheduler SCHED_OTHER doesn't have different priorities. This implementation tries to switch to 90% of the max priority of the SCHED_RR policy if the current policy don't allow different priorities. 

But as this requires special privileges it might fail. In this case these thread will have the same priority as all the others. Therefore in the worst case anything will behaves like before. In the best cases these thread will have a higher priority as planend.