### PR TITLE
ARM64: FlushProcessWriteBuffers

### DIFF
--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -818,6 +818,13 @@ void GCToEEInterface::RestartEE(bool /*bFinishedGC*/)
 {
     FireEtwGCRestartEEBegin_V1(GetClrInstanceId());
 
+#if defined(TARGET_ARM) || defined(TARGET_ARM64)
+    // Flush the store buffers on all CPUs, to ensure that they all see changes made
+    // by the GC threads. This only matters on weak memory ordered processors as 
+    // the strong memory ordered processors wouldn't have reordered the relevant reads.
+    ::FlushProcessWriteBuffers();
+#endif //TARGET_ARM || TARGET_ARM64
+
     SyncClean::CleanUp();
 
     GetThreadStore()->ResumeAllThreads(true);

--- a/src/Native/Runtime/gcrhenv.cpp
+++ b/src/Native/Runtime/gcrhenv.cpp
@@ -822,6 +822,9 @@ void GCToEEInterface::RestartEE(bool /*bFinishedGC*/)
     // Flush the store buffers on all CPUs, to ensure that they all see changes made
     // by the GC threads. This only matters on weak memory ordered processors as 
     // the strong memory ordered processors wouldn't have reordered the relevant reads.
+    // This is needed to synchronize threads that were running in preemptive mode while
+    // the runtime was suspended and that will return to cooperative mode after the runtime 
+    // is restarted. 
     ::FlushProcessWriteBuffers();
 #endif //TARGET_ARM || TARGET_ARM64
 


### PR DESCRIPTION
-Redirect FlushProcessWriteBuffers from Unix Pal to the Unix GC Env. This avoids maintaining the same functionality twice.
-Port https://github.com/dotnet/runtime/pull/42243