### PR TITLE
ARM64: Add more cfi data

### DIFF
--- a/src/Native/Runtime/arm64/CallDescrWorker.S
+++ b/src/Native/Runtime/arm64/CallDescrWorker.S
@@ -14,8 +14,8 @@
 //void RhCallDescrWorker(CallDescrData * pCallDescrData);
     NESTED_ENTRY RhCallDescrWorker, _TEXT, NoHandler
 
-        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, #-32
-        PROLOG_SAVE_REG_PAIR   x19, x20, #16
+        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -32
+        PROLOG_SAVE_REG_PAIR   x19, x20, 16
 
         // Save the value of SP before we start pushing any arguments
         mov     x20, sp
@@ -133,8 +133,8 @@ LReturnDone:
         // Restore the value of SP
         mov     sp, x20
 
-        EPILOG_RESTORE_REG_PAIR x19, x20, #16
-        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, #32
+        EPILOG_RESTORE_REG_PAIR x19, x20, 16
+        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
         EPILOG_RETURN
 
     NESTED_END RhCallDescrWorker

--- a/src/Native/Runtime/arm64/ExceptionHandling.S
+++ b/src/Native/Runtime/arm64/ExceptionHandling.S
@@ -24,19 +24,20 @@
             // TODO PROLOG_PUSH_MACHINE_FRAME
         .else
             PROLOG_STACK_ALLOC 0x50
+            .cfi_adjust_cfa_offset 0x50
             stp x3, lr, [sp]   // x3 is the SP and lr is the IP of the fault site 
         .endif
         stp d8, d9, [sp, #0x10]
         stp d10, d11, [sp, #0x20]
         stp d12, d13, [sp, #0x30]
         stp d14, d15, [sp, #0x40]
-        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, #-0x70
+        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -0x70
         stp xzr, xzr, [sp, #0x10] // locations reserved for return value, not used for exception handling
-        PROLOG_SAVE_REG_PAIR x19, x20, #0x20
-        PROLOG_SAVE_REG_PAIR x21, x22, #0x30
-        PROLOG_SAVE_REG_PAIR x23, x24, #0x40
-        PROLOG_SAVE_REG_PAIR x25, x26, #0x50
-        PROLOG_SAVE_REG_PAIR x27, x28, #0x60
+        PROLOG_SAVE_REG_PAIR x19, x20, 0x20
+        PROLOG_SAVE_REG_PAIR x21, x22, 0x30
+        PROLOG_SAVE_REG_PAIR x23, x24, 0x40
+        PROLOG_SAVE_REG_PAIR x25, x26, 0x50
+        PROLOG_SAVE_REG_PAIR x27, x28, 0x60
         // } end PAL_LIMITED_CONTEXT
  
         PROLOG_STACK_ALLOC STACKSIZEOF_ExInfo 
@@ -53,17 +54,14 @@
         // sp in fp. If sp is saved in fp in prolog then it is not expected that fp can change in the body
         // of method. However, this method needs to be able to change fp before calling funclet.
         // This is required to access locals in funclet.
-        PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED fp,lr, #-0x60
-        PROLOG_SAVE_REG_PAIR x19, x20, #0x10
-        PROLOG_SAVE_REG_PAIR x21, x22, #0x20
-        PROLOG_SAVE_REG_PAIR x23, x24, #0x30
-        PROLOG_SAVE_REG_PAIR x25, x26, #0x40
-        PROLOG_SAVE_REG_PAIR x27, x28, #0x50
+        PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED fp,lr, -0x60
+        PROLOG_SAVE_REG_PAIR x19, x20, 0x10
+        PROLOG_SAVE_REG_PAIR x21, x22, 0x20
+        PROLOG_SAVE_REG_PAIR x23, x24, 0x30
+        PROLOG_SAVE_REG_PAIR x25, x26, 0x40
+        PROLOG_SAVE_REG_PAIR x27, x28, 0x50
         mov fp, sp
-
-        .cfi_def_cfa 29, 16
-        .cfi_offset 30, -8
-        .cfi_offset 29, -16
+        .cfi_def_cfa_register fp
 
         .if \extraStackSize != 0
             PROLOG_STACK_ALLOC \extraStackSize
@@ -82,12 +80,12 @@
             EPILOG_STACK_FREE \extraStackSize
         .endif
 
-        EPILOG_RESTORE_REG_PAIR x19, x20, #0x10
-        EPILOG_RESTORE_REG_PAIR x21, x22, #0x20
-        EPILOG_RESTORE_REG_PAIR x23, x24, #0x30
-        EPILOG_RESTORE_REG_PAIR x25, x26, #0x40
-        EPILOG_RESTORE_REG_PAIR x27, x28, #0x50
-        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, #0x60
+        EPILOG_RESTORE_REG_PAIR x19, x20, 0x10
+        EPILOG_RESTORE_REG_PAIR x21, x22, 0x20
+        EPILOG_RESTORE_REG_PAIR x23, x24, 0x30
+        EPILOG_RESTORE_REG_PAIR x25, x26, 0x40
+        EPILOG_RESTORE_REG_PAIR x27, x28, 0x50
+        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 0x60
    .endm
 
 
@@ -203,6 +201,26 @@
 
 
 
+#ifdef FEATURE_EMULATED_TLS
+// All these exception handling functions have their own stack frame.
+// To avoid creating more than one frame per function we encapsulate these ETLS helper in own functions
+
+    NESTED_ENTRY RhpGetThreadETLS1, _TEXT, NoHandler
+        GETTHREAD_ETLS_1
+        ret
+    NESTED_END RhpGetThreadETLS1, _TEXT
+
+    NESTED_ENTRY RhpGetThreadETLS2, _TEXT, NoHandler
+        GETTHREAD_ETLS_2
+        ret
+    NESTED_END RhpGetThreadETLS2, _TEXT
+
+    NESTED_ENTRY RhpGetThreadETLS5, _TEXT, NoHandler
+        GETTHREAD_ETLS_5
+        ret
+    NESTED_END RhpGetThreadETLS5, _TEXT
+#endif
+
 #define rsp_offsetof_ExInfo  0
 #define rsp_offsetof_Context STACKSIZEOF_ExInfo
 
@@ -220,7 +238,7 @@
 
         // x2 = GetThread()
 #ifdef FEATURE_EMULATED_TLS
-        GETTHREAD_ETLS_2
+        bl RhpGetThreadETLS2
 #else
         INLINE_GETTHREAD x2
 #endif
@@ -268,7 +286,7 @@
 
         // x2 = GetThread()
 #ifdef FEATURE_EMULATED_TLS
-        GETTHREAD_ETLS_2
+        bl RhpGetThreadETLS2
 #else
         INLINE_GETTHREAD x2
 #endif
@@ -362,7 +380,7 @@ NotHijacked:
 
         // x2 = GetThread()
 #ifdef FEATURE_EMULATED_TLS
-        GETTHREAD_ETLS_2
+        bl RhpGetThreadETLS2
 #else
         INLINE_GETTHREAD x2
 #endif
@@ -425,7 +443,7 @@ NotHijacked:
         // clear the DoNotTriggerGc flag, trashes x4-x6
         //
 #ifdef FEATURE_EMULATED_TLS
-        GETTHREAD_ETLS_5
+        bl RhpGetThreadETLS5
 #else
         INLINE_GETTHREAD x5
 #endif
@@ -468,7 +486,7 @@ ClearSuccess_Catch:
 // @TODO: add debug-only validation code for ExInfo pop
 
 #ifdef FEATURE_EMULATED_TLS
-        GETTHREAD_ETLS_1
+        bl RhpGetThreadETLS1
 #else
         INLINE_GETTHREAD x1
 #endif
@@ -542,7 +560,7 @@ NoAbort:
         // clear the DoNotTriggerGc flag, trashes x2-x4
         //
 #ifdef FEATURE_EMULATED_TLS
-        GETTHREAD_ETLS_2
+        bl RhpGetThreadETLS2
 #else
         INLINE_GETTHREAD x2
 #endif
@@ -584,7 +602,7 @@ ClearSuccess:
         // set the DoNotTriggerGc flag, trashes x1-x3
         //
 #ifdef FEATURE_EMULATED_TLS
-        GETTHREAD_ETLS_2
+        bl RhpGetThreadETLS2
 #else
         INLINE_GETTHREAD x2
 #endif

--- a/src/Native/Runtime/arm64/ExceptionHandling.S
+++ b/src/Native/Runtime/arm64/ExceptionHandling.S
@@ -61,6 +61,10 @@
         PROLOG_SAVE_REG_PAIR x27, x28, #0x50
         mov fp, sp
 
+        .cfi_def_cfa 29, 16
+        .cfi_offset 30, -8
+        .cfi_offset 29, -16
+
         .if \extraStackSize != 0
             PROLOG_STACK_ALLOC \extraStackSize
         .endif

--- a/src/Native/Runtime/arm64/MiscStubs.S
+++ b/src/Native/Runtime/arm64/MiscStubs.S
@@ -76,7 +76,7 @@ RhpCheckCctor__SlowPath:
     NESTED_ENTRY RhpCheckCctor2__SlowPath, _TEXT, NoHandler
 
         // Need to preserve x0, x1 and lr across helper call. fp is also pushed to keep the stack 16 byte aligned.
-        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, #-0x20
+        PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -0x20
         stp     x0, x1, [sp, #0x10]
 
         // Call a C++ helper to retrieve the address of the classlib callback. The caller's return address is
@@ -91,7 +91,7 @@ RhpCheckCctor__SlowPath:
         // frames).
         mov     x12, x0
         ldp     x0, x1, [sp, #0x10]
-        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, #0x20
+        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 0x20
         // tail-call the class lib cctor check function. This function is required to return its first
         // argument, so that x0 can be preserved.
         br x12

--- a/src/Native/Runtime/arm64/PInvoke.S
+++ b/src/Native/Runtime/arm64/PInvoke.S
@@ -31,7 +31,7 @@ TSF_DoNotTriggerGc_Bit          = 4
     NESTED_ENTRY RhpWaitForSuspend, _TEXT, NoHandler
 
         // FP and LR registers
-        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, #-0xA0            // Push down stack pointer and store FP and LR
+        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -0xA0            // Push down stack pointer and store FP and LR
 
         // Need to save argument registers x0-x7 and the return buffer register x8
         // Also save x9 which may be used for saving indirect call target
@@ -63,7 +63,7 @@ TSF_DoNotTriggerGc_Bit          = 4
         ldp            x8, x9, [sp, #0x50]
 
         // Restore FP and LR registers, and free the allocated stack block
-        EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, #0xA0
+        EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 0xA0
         EPILOG_RETURN
 
     NESTED_END RhpWaitForSuspend, _TEXT
@@ -81,7 +81,7 @@ TSF_DoNotTriggerGc_Bit          = 4
     NESTED_ENTRY RhpWaitForGCNoAbort, _TEXT, NoHandler
 
         // FP and LR registers
-        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, #-0x40            // Push down stack pointer and store FP and LR
+        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -0x40            // Push down stack pointer and store FP and LR
 
         // Save the integer return registers, as well as the floating return registers
         stp         x0, x1, [sp, #0x10]
@@ -99,7 +99,7 @@ Done:
         ldp         x0, x1, [sp, #0x10]
         ldp         d0, d1, [sp, #0x20]
         ldp         d2, d3, [sp, #0x30]
-        EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, #0x40
+        EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 0x40
         EPILOG_RETURN
 
     NESTED_END RhpWaitForGCNoAbort
@@ -116,7 +116,7 @@ Done:
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
     NESTED_ENTRY RhpWaitForGC, _TEXT, NoHandler
 
-        PROLOG_SAVE_REG_PAIR_INDEXED    fp, lr, #-0x10
+        PROLOG_SAVE_REG_PAIR_INDEXED    fp, lr, -0x10
 
         PREPARE_EXTERNAL_VAR_INDIRECT_W RhpTrapThreads, 10
 
@@ -127,13 +127,13 @@ NoWait:
         ldr         x10, [x9, #OFFSETOF__PInvokeTransitionFrame__m_Flags]
         tbz         x10, #PTFF_THREAD_ABORT_BIT, NoAbort
 
-        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, #0x10
+        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 0x10
         mov w0, #STATUS_REDHAWK_THREAD_ABORT
         mov x1, lr          // hijack target address as exception PC
         b RhpThrowHwEx        
 
 NoAbort:
-        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, #0x10
+        EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 0x10
         EPILOG_RETURN
 
     NESTED_END RhpWaitForGC, _TEXT
@@ -153,7 +153,7 @@ NoAbort:
     NESTED_ENTRY RhpReversePInvokeAttachOrTrapThread, _TEXT, NoHandler
 
         // FP and LR registers
-        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, #-0xA0            // Push down stack pointer and store FP and LR
+        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -0xA0            // Push down stack pointer and store FP and LR
 
         // Need to save argument registers x0-x7 and the return buffer register x8 (twice for 16B alignment)
         stp         x0, x1, [sp, #0x10]
@@ -185,7 +185,7 @@ NoAbort:
         ldr         x8, [sp, #0x50] 
 
         // Restore FP and LR registers, and free the allocated stack block
-        EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, #0xA0
+        EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 0xA0
         EPILOG_RETURN
 
     NESTED_END RhpReversePInvokeTrapThread

--- a/src/Native/Runtime/arm64/UniversalTransition.S
+++ b/src/Native/Runtime/arm64/UniversalTransition.S
@@ -92,7 +92,7 @@
     NESTED_ENTRY Rhp\FunctionName, _TEXT, NoHandler
 
         // FP and LR registers
-        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, #-STACK_SIZE           // ;; Push down stack pointer and store FP and LR
+        PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -STACK_SIZE           // ;; Push down stack pointer and store FP and LR
 
         // Floating point registers
         stp         d0, d1, [sp, #(FLOAT_ARG_OFFSET       )]
@@ -141,7 +141,7 @@
         ldr         x8,      [sp, #(ARGUMENT_REGISTERS_OFFSET + 0x40)]
 
         // Restore FP and LR registers, and free the allocated stack block
-        EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, #STACK_SIZE
+        EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, STACK_SIZE
 
         // Tailcall to the target address.
         // TODO EPILOG_NOP

--- a/src/Native/Runtime/unix/unixasmmacrosarm64.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosarm64.inc
@@ -62,11 +62,11 @@ C_FUNC(\Name):
 
 .macro PROLOG_STACK_ALLOC Size
         sub sp, sp, \Size
-        .cfi_adjust_cfa_offset \Size
 .endm
 
 .macro EPILOG_STACK_FREE Size
         add sp, sp, \Size
+        .cfi_adjust_cfa_offset -\Size
 .endm
 
 .macro EPILOG_STACK_RESTORE
@@ -75,10 +75,13 @@ C_FUNC(\Name):
 
 .macro PROLOG_SAVE_REG reg, ofs
         str \reg, [sp, \ofs]
+        .cfi_rel_offset \reg, \ofs
 .endm
 
 .macro PROLOG_SAVE_REG_PAIR reg1, reg2, ofs
         stp \reg1, \reg2, [sp, \ofs]
+        .cfi_rel_offset \reg1, \ofs
+        .cfi_rel_offset \reg2, \ofs + 8
         .ifc \reg1, fp
         mov fp, sp
         .endif
@@ -86,34 +89,39 @@ C_FUNC(\Name):
 
 .macro PROLOG_SAVE_REG_PAIR_INDEXED reg1, reg2, ofs
         stp \reg1, \reg2, [sp, \ofs]!
+        .cfi_adjust_cfa_offset -\ofs
+        .cfi_rel_offset \reg1, 0
+        .cfi_rel_offset \reg2, 8
         .ifc \reg1, fp
         mov fp, sp
-
-        .cfi_def_cfa 29, 16
-
-        .ifc \reg2, lr
-        .cfi_offset 30, -8
-        .endif
-
-        .cfi_offset 29, -16
+        .cfi_def_cfa_register fp
         .endif
 .endm
 
 .macro PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED reg1, reg2, ofs
         stp \reg1, \reg2, [sp, \ofs]!
+        .cfi_adjust_cfa_offset -\ofs
+        .cfi_rel_offset \reg1, 0
+        .cfi_rel_offset \reg2, 8
 .endm
 
 
 .macro EPILOG_RESTORE_REG reg, ofs
         ldr \reg, [sp, \ofs]
+        .cfi_restore \reg
 .endm
 
 .macro EPILOG_RESTORE_REG_PAIR reg1, reg2, ofs
         ldp \reg1, \reg2, [sp, \ofs]
+        .cfi_restore \reg1
+        .cfi_restore \reg2
 .endm
 
 .macro EPILOG_RESTORE_REG_PAIR_INDEXED reg1, reg2, ofs
         ldp \reg1, \reg2, [sp], \ofs
+        .cfi_restore \reg1
+        .cfi_restore \reg2
+        .cfi_adjust_cfa_offset -\ofs
 .endm
 
 .macro EPILOG_RETURN
@@ -187,30 +195,33 @@ C_FUNC(\Name):
     INLINE_GET_TLS_VAR \target, tls_CurrentThread
 .endm
 
+// Do not use these ETLS macros in functions that already create a stack frame. 
+// Creating two stack frames in one function can confuse the unwinder/debugger
+
 .macro GETTHREAD_ETLS_1
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, #-32           // ;; Push down stack pointer and store FP and LR
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -32           // ;; Push down stack pointer and store FP and LR
     str         x0,  [sp, #0x10]
 
     bl RhpGetThread
     mov x1, x0
 
     ldr         x0,  [sp, #0x10]
-    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, #32
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 32
 .endm
 
 .macro GETTHREAD_ETLS_2
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, #-32           // ;; Push down stack pointer and store FP and LR
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -32           // ;; Push down stack pointer and store FP and LR
     stp         x0, x1, [sp, #0x10]
 
     bl RhpGetThread
     mov x2, x0
 
     ldp         x0, x1, [sp, #0x10]
-    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, #32
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 32
 .endm
 
 .macro GETTHREAD_ETLS_3
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, #-48           // ;; Push down stack pointer and store FP and LR
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -48           // ;; Push down stack pointer and store FP and LR
     stp         x0, x1, [sp, #0x10]
     str         x2,  [sp, #0x20]
 
@@ -219,11 +230,11 @@ C_FUNC(\Name):
 
     ldp         x0, x1, [sp, #0x10]
     ldr         x2,  [sp, #0x20]
-    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, #48
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 48
 .endm
 
 .macro GETTHREAD_ETLS_5
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, #-64           // ;; Push down stack pointer and store FP and LR
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -64           // ;; Push down stack pointer and store FP and LR
     stp         x0, x1, [sp, #0x10]
     stp         x2, x3, [sp, #0x20]
     str         x4,  [sp, #0x30]
@@ -234,11 +245,11 @@ C_FUNC(\Name):
     ldp         x0, x1, [sp, #0x10]
     ldp         x2, x3, [sp, #0x20]
     ldr         x4,  [sp, #0x30]
-    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, #64
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 64
 .endm
 
 .macro GETTHUNKDATA_ETLS_9
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, #-96           // ;; Push down stack pointer and store FP and LR
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -96           // ;; Push down stack pointer and store FP and LR
     stp         x0, x1, [sp, #0x10]
     stp         x2, x3, [sp, #0x20]
     stp         x4, x5, [sp, #0x30]
@@ -253,7 +264,7 @@ C_FUNC(\Name):
     ldp         x4, x5, [sp, #0x30]
     ldp         x6, x7, [sp, #0x40]
     ldp         x8, xip0, [sp, #0x50]
-    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, #96
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 96
 .endm
 
 .macro  ArmInterlockedOperationBarrier
@@ -296,16 +307,16 @@ DEFAULT_FRAME_SAVE_FLAGS = PTFF_SAVE_ALL_PRESERVED + PTFF_SAVE_SP
 
 .macro PUSH_COOP_PINVOKE_FRAME trashReg
 
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, #-0x80      // Push down stack pointer and store FP and LR
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -0x80      // Push down stack pointer and store FP and LR
 
     // 0x10 bytes reserved for Thread* and flags
 
     // Save callee saved registers
-    PROLOG_SAVE_REG_PAIR   x19, x20, #0x20
-    PROLOG_SAVE_REG_PAIR   x21, x22, #0x30
-    PROLOG_SAVE_REG_PAIR   x23, x24, #0x40
-    PROLOG_SAVE_REG_PAIR   x25, x26, #0x50
-    PROLOG_SAVE_REG_PAIR   x27, x28, #0x60
+    PROLOG_SAVE_REG_PAIR   x19, x20, 0x20
+    PROLOG_SAVE_REG_PAIR   x21, x22, 0x30
+    PROLOG_SAVE_REG_PAIR   x23, x24, 0x40
+    PROLOG_SAVE_REG_PAIR   x25, x26, 0x50
+    PROLOG_SAVE_REG_PAIR   x27, x28, 0x60
 
     // Save the value of SP before stack allocation to the last slot in the frame (slot #15)
     add                    \trashReg, sp, #0x80
@@ -321,12 +332,12 @@ DEFAULT_FRAME_SAVE_FLAGS = PTFF_SAVE_ALL_PRESERVED + PTFF_SAVE_SP
 // Pop the frame and restore register state preserved by PUSH_COOP_PINVOKE_FRAME
 .macro POP_COOP_PINVOKE_FRAME
 
-    EPILOG_RESTORE_REG_PAIR   x19, x20, #0x20
-    EPILOG_RESTORE_REG_PAIR   x21, x22, #0x30
-    EPILOG_RESTORE_REG_PAIR   x23, x24, #0x40
-    EPILOG_RESTORE_REG_PAIR   x25, x26, #0x50
-    EPILOG_RESTORE_REG_PAIR   x27, x28, #0x60
-    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, #0x80
+    EPILOG_RESTORE_REG_PAIR   x19, x20, 0x20
+    EPILOG_RESTORE_REG_PAIR   x21, x22, 0x30
+    EPILOG_RESTORE_REG_PAIR   x23, x24, 0x40
+    EPILOG_RESTORE_REG_PAIR   x25, x26, 0x50
+    EPILOG_RESTORE_REG_PAIR   x27, x28, 0x60
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 0x80
 .endm
 
 // Bit position for the flags above, to be used with tbz / tbnz instructions

--- a/src/Native/Runtime/unix/unixasmmacrosarm64.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosarm64.inc
@@ -88,6 +88,14 @@ C_FUNC(\Name):
         stp \reg1, \reg2, [sp, \ofs]!
         .ifc \reg1, fp
         mov fp, sp
+
+        .cfi_def_cfa 29, 16
+
+        .ifc \reg2, lr
+        .cfi_offset 30, -8
+        .endif
+
+        .cfi_offset 29, -16
         .endif
 .endm
 


### PR DESCRIPTION
While the assembler helpers follow the ARM64 ABI and build a correct chain of frame information the debugger still have trouble to show a correct call stack when it include one of these assembler functions. The callstack either stops with with the last of these functions or shows it like it was called recursive It although makes stepping really slow. 

This fix adds additional cfi data based on the same prolog/epilog macros from CoreCLR. With this additional information the debugger can now show a correct callstack.

The modified macros caused some adjustments.