### PR TITLE
Wasm: fix copying of generic struct return value

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -2879,7 +2879,7 @@ namespace Internal.IL
             var destStruct = GetLLVMTypeForTypeDesc(actualReturnType).Undef;
             for (uint elemNo = 0; elemNo < llvmReturn.TypeOf.StructElementTypesCount; elemNo++)
             {
-                var elemValRef = _builder.BuildExtractValue(llvmReturn, 0, "ex" + elemNo);
+                var elemValRef = _builder.BuildExtractValue(llvmReturn, elemNo, "ex" + elemNo);
                 destStruct = _builder.BuildInsertValue(destStruct, elemValRef, elemNo, "st" + elemNo);
             }
             return new ExpressionEntry(stackValueKind, calleeName, destStruct, actualReturnType);

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -1367,7 +1367,7 @@ internal static class Program
         var values = new string[1];
         // testing that the generic return value type from the function can be stored in a concrete type
         values = values.AsSpan(0, 1).ToArray();
-        PassTest();
+        EndTest(values.Length == 1);
     }
 
     private static void TestCallToGenericInterfaceMethod()


### PR DESCRIPTION
This PR fixes a silly mistake copying generic struct return values where the first element was copied to all elements.  
Test extended to catch this mistake.