### PR TITLE
ARM64: EH helper use always RhpGetThread

### DIFF
--- a/src/Native/Runtime/StackFrameIterator.cpp
+++ b/src/Native/Runtime/StackFrameIterator.cpp
@@ -833,7 +833,7 @@ void StackFrameIterator::UnwindFuncletInvokeThunk()
     {
         // RhpCallCatchFunclet puts a couple of extra things on the stack that aren't put there by the other two
         // thunks, but we don't need to know what they are here, so we just skip them.
-        SP += EQUALS_RETURN_ADDRESS(m_ControlPC, RhpCallCatchFunclet2) ? 4 : 2;
+        SP += EQUALS_RETURN_ADDRESS(m_ControlPC, RhpCallCatchFunclet2) ? 6 : 4;
 
         // Save the preserved regs portion of the REGDISPLAY across the unwind through the C# EH dispatch code.
         m_funcletPtrs.pX19  = m_RegDisplay.pX19;

--- a/src/Native/Runtime/arm64/ExceptionHandling.S
+++ b/src/Native/Runtime/arm64/ExceptionHandling.S
@@ -199,27 +199,30 @@
 #endif // _DEBUG
     .endm
 
+.macro GetThreadX1
+    str x0, [sp, -16]!
+    bl RhpGetThread
+    mov x1, x0
+    ldr x0, [sp], 16
+.endm
 
+.macro GetThreadX2
+    stp x0, x1, [sp, -16]!
+    bl RhpGetThread
+    mov x2, x0
+    ldp x0, x1, [sp], 16
+.endm
 
-#ifdef FEATURE_EMULATED_TLS
-// All these exception handling functions have their own stack frame.
-// To avoid creating more than one frame per function we encapsulate these ETLS helper in own functions
-
-    NESTED_ENTRY RhpGetThreadETLS1, _TEXT, NoHandler
-        GETTHREAD_ETLS_1
-        ret
-    NESTED_END RhpGetThreadETLS1, _TEXT
-
-    NESTED_ENTRY RhpGetThreadETLS2, _TEXT, NoHandler
-        GETTHREAD_ETLS_2
-        ret
-    NESTED_END RhpGetThreadETLS2, _TEXT
-
-    NESTED_ENTRY RhpGetThreadETLS5, _TEXT, NoHandler
-        GETTHREAD_ETLS_5
-        ret
-    NESTED_END RhpGetThreadETLS5, _TEXT
-#endif
+.macro GetThreadX5
+    stp x0, x1, [sp, -48]!
+    stp x2, x3, [sp, 0x10]
+    str x4, [sp, 0x20]
+    bl RhpGetThread
+    mov x5, x0
+    ldr x4, [sp, 0x20]
+    ldp x2, x3, [sp, 0x10]
+    ldp x0, x1, [sp], 48
+.endm
 
 #define rsp_offsetof_ExInfo  0
 #define rsp_offsetof_Context STACKSIZEOF_ExInfo
@@ -236,12 +239,7 @@
 
         ALLOC_THROW_FRAME HARDWARE_EXCEPTION
 
-        // x2 = GetThread()
-#ifdef FEATURE_EMULATED_TLS
-        bl RhpGetThreadETLS2
-#else
-        INLINE_GETTHREAD x2
-#endif
+        GetThreadX2
 
         add         x1, sp, #rsp_offsetof_ExInfo                    // x1 <- ExInfo*
         str         xzr, [x1, #OFFSETOF__ExInfo__m_exception]       // pExInfo->m_exception = null
@@ -284,12 +282,7 @@
 
         ALLOC_THROW_FRAME SOFTWARE_EXCEPTION
 
-        // x2 = GetThread()
-#ifdef FEATURE_EMULATED_TLS
-        bl RhpGetThreadETLS2
-#else
-        INLINE_GETTHREAD x2
-#endif
+        GetThreadX2
 
         // There is runtime C# code that can tail call to RhpThrowEx using a binder intrinsic.  So the return 
         // address could have been hijacked when we were in that C# code and we must remove the hijack and
@@ -378,12 +371,7 @@ NotHijacked:
 
         ALLOC_THROW_FRAME SOFTWARE_EXCEPTION
 
-        // x2 = GetThread()
-#ifdef FEATURE_EMULATED_TLS
-        bl RhpGetThreadETLS2
-#else
-        INLINE_GETTHREAD x2
-#endif
+        GetThreadX2
 
         add         x1, sp, #rsp_offsetof_ExInfo                    // x1 <- ExInfo*
         str         xzr, [x1, #OFFSETOF__ExInfo__m_exception]       // pExInfo->m_exception = null
@@ -442,11 +430,8 @@ NotHijacked:
         //
         // clear the DoNotTriggerGc flag, trashes x4-x6
         //
-#ifdef FEATURE_EMULATED_TLS
-        bl RhpGetThreadETLS5
-#else
-        INLINE_GETTHREAD x5
-#endif
+
+        GetThreadX5
 
         ldr         x4, [x5, #OFFSETOF__Thread__m_threadAbortException]
         sub         x4, x4, x0
@@ -485,11 +470,7 @@ ClearSuccess_Catch:
 
 // @TODO: add debug-only validation code for ExInfo pop
 
-#ifdef FEATURE_EMULATED_TLS
-        bl RhpGetThreadETLS1
-#else
-        INLINE_GETTHREAD x1
-#endif
+        GetThreadX1
 
         // We must unhijack the thread at this point because the section of stack where the hijack is applied
         // may go dead.  If it does, then the next time we try to unhijack the thread, it will corrupt the stack.
@@ -559,11 +540,8 @@ NoAbort:
         //
         // clear the DoNotTriggerGc flag, trashes x2-x4
         //
-#ifdef FEATURE_EMULATED_TLS
-        bl RhpGetThreadETLS2
-#else
-        INLINE_GETTHREAD x2
-#endif
+
+        GetThreadX2
 
         add         x12, x2, #OFFSETOF__Thread__m_ThreadStateFlags
 
@@ -601,11 +579,8 @@ ClearSuccess:
         //
         // set the DoNotTriggerGc flag, trashes x1-x3
         //
-#ifdef FEATURE_EMULATED_TLS
-        bl RhpGetThreadETLS2
-#else
-        INLINE_GETTHREAD x2
-#endif
+
+        GetThreadX2
 
         add         x12, x2, #OFFSETOF__Thread__m_ThreadStateFlags
 SetRetry:

--- a/src/Native/Runtime/arm64/ExceptionHandling.S
+++ b/src/Native/Runtime/arm64/ExceptionHandling.S
@@ -199,29 +199,11 @@
 #endif // _DEBUG
     .endm
 
-.macro GetThreadX1
-    str x0, [sp, -16]!
-    bl RhpGetThread
-    mov x1, x0
-    ldr x0, [sp], 16
-.endm
-
 .macro GetThreadX2
     stp x0, x1, [sp, -16]!
     bl RhpGetThread
     mov x2, x0
     ldp x0, x1, [sp], 16
-.endm
-
-.macro GetThreadX5
-    stp x0, x1, [sp, -48]!
-    stp x2, x3, [sp, 0x10]
-    str x4, [sp, 0x20]
-    bl RhpGetThread
-    mov x5, x0
-    ldr x4, [sp, 0x20]
-    ldp x2, x3, [sp, 0x10]
-    ldp x0, x1, [sp], 48
 .endm
 
 #define rsp_offsetof_ExInfo  0
@@ -415,23 +397,31 @@ NotHijacked:
 
     NESTED_ENTRY RhpCallCatchFunclet, _TEXT, NoHandler
 
-        ALLOC_CALL_FUNCLET_FRAME 0x60
+        ALLOC_CALL_FUNCLET_FRAME 0x70 // Size needs to be equal with ExceptionHandling.asm variant of this function
         stp d8, d9,   [sp, #0x00]
         stp d10, d11, [sp, #0x10]
         stp d12, d13, [sp, #0x20]
         stp d14, d15, [sp, #0x30]
-        stp x0, x2,   [sp, #0x40]  // x0, x2 & x3 are saved so we have the exception object, REGDISPLAY and 
-        stp x3, xzr,  [sp, #0x50]  // ExInfo later, xzr makes space for the local "is_not_handling_thread_abort"
+        stp x0, x1,   [sp, #0x40] // x0 to x3 are stored to restore them anytime
+        stp x2, x3,   [sp, #0x50] 
+        str xzr,      [sp, #0x60] // xzr makes space for the local "is_not_handling_thread_abort"; last qword will store the thread obj  
 
-#define rsp_offset_is_not_handling_thread_abort 0x58
-#define rsp_offset_x2 0x48
-#define rsp_offset_x3 0x50
+#define rsp_offset_is_not_handling_thread_abort 0x60
+#define rsp_offset_x0 0x40
+#define rsp_offset_x1 0x48
+#define rsp_offset_x2 0x50
+#define rsp_offset_x3 0x58
+#define rsp_CatchFunclet_offset_thread 0x68
 
         //
         // clear the DoNotTriggerGc flag, trashes x4-x6
         //
 
-        GetThreadX5
+        bl RhpGetThread
+        str x0, [sp, rsp_CatchFunclet_offset_thread]
+        mov x5,x0
+        ldp x0, x1,   [sp, #0x40]
+        ldp x2, x3,   [sp, #0x50]
 
         ldr         x4, [x5, #OFFSETOF__Thread__m_threadAbortException]
         sub         x4, x4, x0
@@ -470,7 +460,7 @@ ClearSuccess_Catch:
 
 // @TODO: add debug-only validation code for ExInfo pop
 
-        GetThreadX1
+        ldr x1, [sp, rsp_CatchFunclet_offset_thread]
 
         // We must unhijack the thread at this point because the section of stack where the hijack is applied
         // may go dead.  If it does, then the next time we try to unhijack the thread, it will corrupt the stack.
@@ -520,14 +510,15 @@ NoAbort:
 
     NESTED_ENTRY RhpCallFinallyFunclet, _TEXT, NoHandler
 
-        ALLOC_CALL_FUNCLET_FRAME 0x50
+        ALLOC_CALL_FUNCLET_FRAME 0x60 // Size needs to be equal with ExceptionHandling.asm variant of this function
         stp d8, d9,   [sp, #0x00]
         stp d10, d11, [sp, #0x10]
         stp d12, d13, [sp, #0x20]
         stp d14, d15, [sp, #0x30]
-        stp x0, x1,   [sp, #0x40]   // x1 is saved so we have the REGDISPLAY later, x0 is just alignment padding
+        stp x0, x1,   [sp, #0x40]   // x0 and x1 are saved so we have them later
 
 #define rsp_offset_x1 0x48
+#define rsp_FinallyFunclet_offset_thread 0x50
 
         
         // We want to suppress hijacking between invocations of subsequent finallys.  We do this because we
@@ -541,7 +532,10 @@ NoAbort:
         // clear the DoNotTriggerGc flag, trashes x2-x4
         //
 
-        GetThreadX2
+        bl RhpGetThread
+        str x0, [sp, rsp_FinallyFunclet_offset_thread]
+        mov x2, x0
+        ldp x0, x1, [sp, #0x40]
 
         add         x12, x2, #OFFSETOF__Thread__m_ThreadStateFlags
 
@@ -580,7 +574,7 @@ ClearSuccess:
         // set the DoNotTriggerGc flag, trashes x1-x3
         //
 
-        GetThreadX2
+        ldr x2, [sp, rsp_FinallyFunclet_offset_thread]
 
         add         x12, x2, #OFFSETOF__Thread__m_ThreadStateFlags
 SetRetry:
@@ -596,7 +590,7 @@ SetSuccess:
         ldp         d12, d13, [sp, #0x20]
         ldp         d14, d15, [sp, #0x30]
 
-        FREE_CALL_FUNCLET_FRAME 0x50
+        FREE_CALL_FUNCLET_FRAME 0x60
         EPILOG_RETURN
 
     NESTED_END RhpCallFinallyFunclet, _Text

--- a/src/Native/Runtime/arm64/ExceptionHandling.asm
+++ b/src/Native/Runtime/arm64/ExceptionHandling.asm
@@ -400,7 +400,7 @@ NotHijacked
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     NESTED_ENTRY RhpCallCatchFunclet
 
-        ALLOC_CALL_FUNCLET_FRAME 0x60
+        ALLOC_CALL_FUNCLET_FRAME 0x70 // Size needs to be equal with ExceptionHandling.S variant of this function
         stp d8, d9,   [sp, #0x00]
         stp d10, d11, [sp, #0x10]
         stp d12, d13, [sp, #0x20]
@@ -505,7 +505,7 @@ NoAbort
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     NESTED_ENTRY RhpCallFinallyFunclet
 
-        ALLOC_CALL_FUNCLET_FRAME 0x50
+        ALLOC_CALL_FUNCLET_FRAME 0x60 // Size needs to be equal with ExceptionHandling.S variant of this function
         stp d8, d9,   [sp, #0x00]
         stp d10, d11, [sp, #0x10]
         stp d12, d13, [sp, #0x20]
@@ -579,7 +579,7 @@ SetSuccess
         ldp         d12, d13, [sp, #0x20]
         ldp         d14, d15, [sp, #0x30]
 
-        FREE_CALL_FUNCLET_FRAME 0x50
+        FREE_CALL_FUNCLET_FRAME 0x60
         EPILOG_RETURN
 
     NESTED_END RhpCallFinallyFunclet

--- a/src/Native/Runtime/threadstore.cpp
+++ b/src/Native/Runtime/threadstore.cpp
@@ -413,17 +413,10 @@ EXTERN_C DECLSPEC_THREAD ThreadBuffer tls_CurrentThread =
     0,                                  // all other fields are initialized by zeroes
 };
 
-#ifdef FEATURE_EMULATED_TLS
-
-// When there is no full TLS support it might be emulated by the compiler
-// In this case we need a C function that allows the assembler code to ask for the correct value for the current thread
-
 EXTERN_C ThreadBuffer* RhpGetThread()
 {
     return &tls_CurrentThread;
 }
-
-#endif // FEATURE_EMULATED_TLS
 
 #endif // !DACCESS_COMPILE
 

--- a/src/Native/Runtime/unix/unixasmmacrosarm64.inc
+++ b/src/Native/Runtime/unix/unixasmmacrosarm64.inc
@@ -209,17 +209,6 @@ C_FUNC(\Name):
     EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 32
 .endm
 
-.macro GETTHREAD_ETLS_2
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -32           // ;; Push down stack pointer and store FP and LR
-    stp         x0, x1, [sp, #0x10]
-
-    bl RhpGetThread
-    mov x2, x0
-
-    ldp         x0, x1, [sp, #0x10]
-    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 32
-.endm
-
 .macro GETTHREAD_ETLS_3
     PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -48           // ;; Push down stack pointer and store FP and LR
     stp         x0, x1, [sp, #0x10]
@@ -231,21 +220,6 @@ C_FUNC(\Name):
     ldp         x0, x1, [sp, #0x10]
     ldr         x2,  [sp, #0x20]
     EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 48
-.endm
-
-.macro GETTHREAD_ETLS_5
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, lr, -64           // ;; Push down stack pointer and store FP and LR
-    stp         x0, x1, [sp, #0x10]
-    stp         x2, x3, [sp, #0x20]
-    str         x4,  [sp, #0x30]
-
-    bl RhpGetThread
-    mov x5, x0
-
-    ldp         x0, x1, [sp, #0x10]
-    ldp         x2, x3, [sp, #0x20]
-    ldr         x4,  [sp, #0x30]
-    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 64
 .endm
 
 .macro GETTHUNKDATA_ETLS_9


### PR DESCRIPTION
To simplify the code the exception handling assembler helpers use now always RhpGetThread. This will add some small additional overhead when the regular TLS code could have been inlined. But as EH needs an expensive stack walk anyway it will have no significant impact overall.

funclets store all parameters and the thread object as local variable to avoid making the expensive call twice.

As the new code needs more stack space it is although increased for the asm variant to avoid having different sizes as the stack frame iterator needs to know.