### PR TITLE
ARM64: RhNewString use MAX_STRING_LENGTH

### DIFF
--- a/src/Native/Runtime/arm64/AllocFast.S
+++ b/src/Native/Runtime/arm64/AllocFast.S
@@ -124,8 +124,8 @@ NewOutOfMemory:
 //  x1 == element/character count
     LEAF_ENTRY RhNewString, _TEXT
         // Make sure computing the overall allocation size wont overflow
-        // TODO: this should be actually MAX_STRING_LENGTH
-        mov         x2, 0x7FFFFFFF
+        movz        x2, MAX_STRING_LENGTH & 0xFFFF
+        movk        x2, MAX_STRING_LENGTH >> 16, lsl 16
         cmp         x1, x2
         bhi         StringSizeOverflow
 

--- a/src/Native/Runtime/arm64/AllocFast.asm
+++ b/src/Native/Runtime/arm64/AllocFast.asm
@@ -112,8 +112,8 @@ NewOutOfMemory
 ;;  x1 == element/character count
     LEAF_ENTRY RhNewString
         ;; Make sure computing the overall allocation size won't overflow
-        ;; TODO: this should be actually MAX_STRING_LENGTH
-        mov         x2, 0x7FFFFFFF
+        movz        x2, #(MAX_STRING_LENGTH & 0xFFFF)
+        movk        x2, #(MAX_STRING_LENGTH >> 16), lsl #16
         cmp         x1, x2
         bhi         StringSizeOverflow
 


### PR DESCRIPTION
The code had a hardcoded (to high) maximum string length for the overflow check