### PR TITLE
ARM64:  support TRASH_SAVED_ARGUMENT_REGISTERS for UniversalTransition

### DIFF
--- a/src/Native/Runtime/arm64/UniversalTransition.S
+++ b/src/Native/Runtime/arm64/UniversalTransition.S
@@ -8,8 +8,8 @@
 #endif
 
 #ifdef TRASH_SAVED_ARGUMENT_REGISTERS
-    // TODO .extern RhpIntegerTrashValues
-    // TODO .extern RhpFpTrashValues
+    .global RhpIntegerTrashValues
+    .global RhpFpTrashValues
 #endif // TRASH_SAVED_ARGUMENT_REGISTERS
 
 // Padding to account for the odd number of saved integer registers
@@ -110,7 +110,18 @@
         stp         x8, xzr, [sp, #(ARGUMENT_REGISTERS_OFFSET + 0x40)]
 
 #ifdef TRASH_SAVED_ARGUMENT_REGISTERS
-        // ARM64TODO
+        PREPARE_EXTERNAL_VAR RhpFpTrashValues, x1
+
+        ldp d0,d1, [x1, 0x0] 
+        ldp d2,d3, [x1, 0x10] 
+        ldp d4,d5, [x1, 0x20] 
+        ldp d6,d7, [x1, 0x30] 
+
+        PREPARE_EXTERNAL_VAR RhpIntegerTrashValues, x1
+
+        ldp x2,x3, [x1, 0x10]
+        ldp x4,x5, [x1, 0x20]
+        ldp x6,x7, [x1, 0x30]
 #endif // TRASH_SAVED_ARGUMENT_REGISTERS
 
         add         x0, sp, #DISTANCE_FROM_CHILDSP_TO_RETURN_BLOCK  // First parameter to target function is a pointer to the return block
@@ -144,7 +155,6 @@
         EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, STACK_SIZE
 
         // Tailcall to the target address.
-        // TODO EPILOG_NOP
         br x12
 
     NESTED_END Rhp\FunctionName, _TEXT


### PR DESCRIPTION
implements the missing TRASH_SAVED_ARGUMENT_REGISTERS debug part for UniversalTransition