### PR TITLE
Wasm: add support for most of the conv_ovf operations

### DIFF
--- a/src/Common/src/TypeSystem/IL/ILImporter.cs
+++ b/src/Common/src/TypeSystem/IL/ILImporter.cs
@@ -746,25 +746,25 @@ namespace Internal.IL
                         ImportConvert(WellKnownType.SByte, true, false);
                         break;
                     case ILOpcode.conv_ovf_u1:
-                        ImportConvert(WellKnownType.Byte, true, false);
+                        ImportConvert(WellKnownType.Byte, true, true);
                         break;
                     case ILOpcode.conv_ovf_i2:
                         ImportConvert(WellKnownType.Int16, true, false);
                         break;
                     case ILOpcode.conv_ovf_u2:
-                        ImportConvert(WellKnownType.UInt16, true, false);
+                        ImportConvert(WellKnownType.UInt16, true, true);
                         break;
                     case ILOpcode.conv_ovf_i4:
                         ImportConvert(WellKnownType.Int32, true, false);
                         break;
                     case ILOpcode.conv_ovf_u4:
-                        ImportConvert(WellKnownType.UInt32, true, false);
+                        ImportConvert(WellKnownType.UInt32, true, true);
                         break;
                     case ILOpcode.conv_ovf_i8:
                         ImportConvert(WellKnownType.Int64, true, false);
                         break;
                     case ILOpcode.conv_ovf_u8:
-                        ImportConvert(WellKnownType.UInt64, true, false);
+                        ImportConvert(WellKnownType.UInt64, true, true);
                         break;
                     case ILOpcode.refanyval:
                         ImportRefAnyVal(ReadILToken());
@@ -779,10 +779,10 @@ namespace Internal.IL
                         ImportLdToken(ReadILToken());
                         break;
                     case ILOpcode.conv_u2:
-                        ImportConvert(WellKnownType.UInt16, false, false);
+                        ImportConvert(WellKnownType.UInt16, false, true);
                         break;
                     case ILOpcode.conv_u1:
-                        ImportConvert(WellKnownType.Byte, false, false);
+                        ImportConvert(WellKnownType.Byte, false, true);
                         break;
                     case ILOpcode.conv_i:
                         ImportConvert(WellKnownType.IntPtr, false, false);
@@ -791,7 +791,7 @@ namespace Internal.IL
                         ImportConvert(WellKnownType.IntPtr, true, false);
                         break;
                     case ILOpcode.conv_ovf_u:
-                        ImportConvert(WellKnownType.UIntPtr, true, false);
+                        ImportConvert(WellKnownType.UIntPtr, true, true);
                         break;
                     case ILOpcode.add_ovf:
                     case ILOpcode.add_ovf_un:

--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -4167,7 +4167,7 @@ namespace Internal.IL
 
         private void ImportConvert(WellKnownType wellKnownType, bool checkOverflow, bool unsigned)
         {
-            //TODO checkOverflow - r_un & r_4
+            //TODO checkOverflow - r_un & r_4, i & i_un
             StackEntry value = _stack.Pop();
             TypeDesc destType = GetWellKnownType(wellKnownType);
 

--- a/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/MathHelpers.cs
+++ b/src/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/MathHelpers.cs
@@ -255,7 +255,7 @@ namespace Internal.Runtime.CompilerHelpers
             const double two64 = 2.0 * 2147483648.0 * 4294967296.0;
 
             // Note that this expression also works properly for val = NaN case
-            if (val < two64)
+            if (val > -1.0 && val < two64)
                 return unchecked((ulong)val);
 
             return ThrowULngOvf();

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -2409,6 +2409,459 @@ internal static class Program
         TestSignedIntMulOvf();
 
         TestSignedLongMulOvf();
+
+        TestSignedToSignedNativeIntConvOvf();
+
+        TestUnsignedToSignedNativeIntConvOvf();
+
+        TestSignedToUnsignedNativeIntConvOvf();
+
+        TestI1ConvOvf();
+
+        TestUnsignedI1ConvOvf();
+
+        TestI2ConvOvf();
+
+        TestUnsignedI2ConvOvf();
+
+        TestI4ConvOvf();
+
+        TestUnsignedI4ConvOvf();
+
+        TestI8ConvOvf();
+
+        TestUnsignedI8ConvOvf();
+    }
+
+    private static void TestSignedToSignedNativeIntConvOvf()
+    {
+        // TODO: when use of nint is available
+    }
+
+    private static void TestUnsignedToSignedNativeIntConvOvf()
+    {
+        // TODO: when use of nuint is available
+    }
+
+    private static unsafe void TestSignedToUnsignedNativeIntConvOvf()
+    {
+        StartTest("Test unsigned native int Conv_Ovf"); // TODO : wasm64
+        int thrown = 0;
+        long i = 1;
+        void * converted;
+        checked { converted = (void *)i; }
+        if (converted != new IntPtr(1).ToPointer()) FailTest("Test unsigned native int Conv_Ovf conversion failed");
+        try
+        {
+            i = uint.MaxValue + 1L;
+            checked { converted = (void *)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            i = -1;
+            checked { converted = (void *)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        if (thrown != 2) FailTest("Test unsigned native int Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
+        EndTest(true);
+
+    }
+
+    private static void TestI1ConvOvf()
+    {
+        StartTest("Test I1 Conv_Ovf");
+        int thrown = 0;
+        int i = 1;
+        float f = 127.9F;
+        sbyte converted;
+        checked { converted = (sbyte)i; }
+        if (converted != 1) FailTest("Test I1 Conv_Ovf conversion failed" + converted.ToString());
+        checked { converted = (sbyte)(-1); }
+        checked { converted = (sbyte)f; }
+        checked { converted = (sbyte)((float)-128.5F); }
+        try
+        {
+            i = sbyte.MaxValue + 1;
+            checked { converted = (sbyte)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            i = sbyte.MinValue - 1;
+            checked { converted = (sbyte)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = (float)(sbyte.MaxValue + 1);
+            checked { converted = (sbyte)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = (float)(sbyte.MinValue - 1);
+            checked { converted = (sbyte)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        if (thrown != 4) FailTest("Test I1 Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
+        EndTest(true);
+    }
+
+    private static void TestUnsignedI1ConvOvf()
+    {
+        StartTest("Test unsigned I1 Conv_Ovf");
+        int thrown = 0;
+        int i = 1;
+        float f = 255.9F;
+        byte converted;
+        checked { converted = (byte)i; }
+        if (converted != 1) FailTest("Test unsigned I1 Conv_Ovf conversion failed" + converted.ToString());
+        checked { converted = (byte)f; }
+        try
+        {
+            i = byte.MaxValue + 1;
+            checked { converted = (byte)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            i = -1;
+            checked { converted = (byte)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = (float)(byte.MaxValue + 1);
+            checked { converted = (byte)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = -1f;
+            checked { converted = (byte)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        if (thrown != 4) FailTest("Test unsigned I1 Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
+        EndTest(true);
+    }
+
+    private static void TestI2ConvOvf()
+    {
+        StartTest("Test I2 Conv_Ovf");
+        int thrown = 0;
+        int i = 1;
+        float f = 32767.9F;
+        Int16 converted;
+        checked { converted = (Int16)i; }
+        if (converted != 1) FailTest("Test I2 Conv_Ovf conversion failed" + converted.ToString());
+        checked { converted = (Int16)(-1); }
+        checked { converted = (Int16)f; }
+        checked { converted = (Int16)((float)-32768.5F); }
+        try
+        {
+            i = Int16.MaxValue + 1;
+            checked { converted = (Int16)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            i = Int16.MinValue - 1;
+            checked { converted = (Int16)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = (float)(Int16.MaxValue + 1);
+            checked { converted = (Int16)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = (float)(Int16.MinValue - 1);
+            checked { converted = (Int16)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        if (thrown != 4) FailTest("Test I2 Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
+        EndTest(true);
+    }
+
+    private static void TestUnsignedI2ConvOvf()
+    {
+        StartTest("Test unsigned I2 Conv_Ovf");
+        int thrown = 0;
+        int i = 1;
+        float f = 65535.9F;
+        UInt16 converted;
+        checked { converted = (UInt16)i; }
+        if (converted != 1) FailTest("Test unsigned I2 Conv_Ovf conversion failed" + converted.ToString());
+        checked { converted = (UInt16)f; }
+        try
+        {
+            i = UInt16.MaxValue + 1;
+            checked { converted = (UInt16)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            i = -1;
+            checked { converted = (UInt16)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            short s = -1; // test overflow check is not reliant on different widths
+            checked { converted = (UInt16)s; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = (float)(UInt16.MaxValue + 1);
+            checked { converted = (UInt16)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = -1f;
+            checked { converted = (UInt16)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        if (thrown != 5) FailTest("Test unsigned I2 Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
+        EndTest(true);
+    }
+
+    private static void TestI4ConvOvf()
+    {
+        StartTest("Test I4 Conv_Ovf");
+        int thrown = 0;
+        long i = 1;
+        double f = 2147483647.9d;
+        int converted;
+        checked { converted = (int)i; }
+        if (converted != 1) FailTest("Test I4 Conv_Ovf conversion failed" + converted.ToString());
+        checked { converted = (int)(-1); }
+        checked { converted = (int)f; }
+        checked { converted = (int)((double)-2147483648.9d); }
+        try
+        {
+            i = int.MaxValue + 1L;
+            checked { converted = (int)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            i = int.MinValue - 1L;
+            checked { converted = (int)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = (double)(int.MaxValue + 1L);
+            checked { converted = (int)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = (double)(int.MinValue - 1L);
+            checked { converted = (int)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        if (thrown != 4) FailTest("Test I4 Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
+        EndTest(true);
+    }
+
+    private static void TestUnsignedI4ConvOvf()
+    {
+        StartTest("Test unsigned I4 Conv_Ovf");
+        int thrown = 0;
+        long i = 1;
+        double f = 4294967294.9d;
+        uint converted;
+        checked { converted = (uint)i; }
+        if (converted != 1) FailTest("Test unsigned I4 Conv_Ovf conversion failed" + converted.ToString());
+        checked { converted = (uint)f; }
+        try
+        {
+            i = uint.MaxValue + 1L;
+            checked { converted = (uint)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            i = -1;
+            checked { converted = (uint)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = (double)(uint.MaxValue + 1L);
+            checked { converted = (uint)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = -1d;
+            checked { converted = (uint)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        if (thrown != 4) FailTest("Test unsigned I4 Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
+        EndTest(true);
+    }
+
+    private static void TestI8ConvOvf()
+    {
+        StartTest("Test I8 Conv_Ovf");
+        int thrown = 0;
+        long i = 1;
+        double f = 9223372036854774507.9d; /// not a precise check
+        long converted;
+        checked { converted = (long)i; }
+        if (converted != 1) FailTest("Test I8 Conv_Ovf conversion failed" + converted.ToString());
+        checked { converted = (long)(-1); }
+        checked { converted = (long)f; }
+        checked { converted = (long)((double)-9223372036854776508d); } // not a precise check
+        try
+        {
+            f = (double)(long.MaxValue) + 1000d; // need to get into the next representable double
+            checked { converted = (int)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = (double)(long.MinValue) - 1000d; // need to get into the next representable double
+            checked { converted = (long)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        if (thrown != 2) FailTest("Test I8 Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
+        EndTest(true);
+    }
+
+    private static void TestUnsignedI8ConvOvf()
+    {
+        StartTest("Test unsigned I8 Conv_Ovf");
+        int thrown = 0;
+        long i = 1;
+        double f = 18446744073709540015.9d; // not a precise check
+        ulong converted;
+        checked { converted = (ulong)i; }
+        if (converted != 1) FailTest("Test unsigned I8 Conv_Ovf conversion failed" + converted.ToString());
+        checked { converted = (ulong)f; }
+        try
+        {
+            i = -1;
+            checked { converted = (ulong)i; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = (double)(ulong.MaxValue) + 1000d; // need to get into the next representable double
+            checked { converted = (ulong)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
+            f = -1d;
+            checked { converted = (ulong)f; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        if (thrown != 3) FailTest("Test unsigned I8 Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
+        EndTest(true);
     }
 
     private static void TestSignedLongAddOvf()

--- a/tests/src/Simple/HelloWasm/Program.cs
+++ b/tests/src/Simple/HelloWasm/Program.cs
@@ -2803,6 +2803,15 @@ internal static class Program
         checked { converted = (long)((double)-9223372036854776508d); } // not a precise check
         try
         {
+            ulong ul = long.MaxValue + (ulong)1;
+            checked { converted = (int)ul; }
+        }
+        catch (OverflowException)
+        {
+            thrown++;
+        }
+        try
+        {
             f = (double)(long.MaxValue) + 1000d; // need to get into the next representable double
             checked { converted = (int)f; }
         }
@@ -2812,14 +2821,14 @@ internal static class Program
         }
         try
         {
-            f = (double)(long.MinValue) - 1000d; // need to get into the next representable double
+            f = (double)(long.MinValue) - 2000d; // need to get into the next representable double
             checked { converted = (long)f; }
         }
         catch (OverflowException)
         {
             thrown++;
         }
-        if (thrown != 2) FailTest("Test I8 Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
+        if (thrown != 3) FailTest("Test I8 Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
         EndTest(true);
     }
 
@@ -2844,7 +2853,7 @@ internal static class Program
         }
         try
         {
-            f = (double)(ulong.MaxValue) + 1000d; // need to get into the next representable double
+            f = (double)(ulong.MaxValue) + 2000d; // need to get into the next representable double
             checked { converted = (ulong)f; }
         }
         catch (OverflowException)


### PR DESCRIPTION
This PR adds support for overflow checking for Wasm for most of the Conv_Ovf opcodes. Still to do are two of native int: `Conv_Ovf_I`, `Conv_Ovf_I_Un` . (`Conv_Ovf_U` is included here).  Was going to wait until c#9 was available to do the missing ones.