### PR TITLE
[Interpreter] Static constructors and field access

### DIFF
--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/ILInterpreter.cs
@@ -2887,6 +2887,12 @@ setstackitem:
                     nativeFormatField.Handle,
                     out FieldAccessMetadata fieldAccessMetadata);
 
+                IntPtr cctorContext = TypeLoaderEnvironment.TryGetStaticClassConstructionContext(nativeFormatField.OwningType.GetRuntimeTypeHandle());
+                if (cctorContext != IntPtr.Zero)
+                {
+                    RuntimeAugments.EnsureClassConstructorRun(cctorContext);
+                }
+
                 FieldTableFlags fieldFlags = fieldAccessMetadata.Flags & FieldTableFlags.StorageClass;
                 if (fieldFlags == FieldTableFlags.NonGCStatic)
                 {
@@ -3052,6 +3058,13 @@ setstackitem:
                     nativeFormatField.OwningType.GetRuntimeTypeHandle(),
                     nativeFormatField.Handle,
                     out FieldAccessMetadata fieldAccessMetadata);
+
+
+                IntPtr cctorContext = TypeLoaderEnvironment.TryGetStaticClassConstructionContext(nativeFormatField.OwningType.GetRuntimeTypeHandle());
+                if (cctorContext != IntPtr.Zero)
+                {
+                    RuntimeAugments.EnsureClassConstructorRun(cctorContext);
+                }
 
                 FieldTableFlags fieldFlags = fieldAccessMetadata.Flags & FieldTableFlags.StorageClass;
                 if (fieldFlags == FieldTableFlags.NonGCStatic)

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StaticsRegion.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StaticsRegion.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace Internal.Runtime.Interpreter
+{
+    internal enum StaticsKind { NonGcStatics, GcStatics, ThreadNonGcStatics, ThreadGcStatics }
+
+    internal class StaticsRegion
+    {
+        public DefType OwningType { get; private set; }
+
+        public IntPtr Base { get; private set; }
+
+        public StaticsRegion(DefType type, int size)
+        {
+            OwningType = type;
+            Base = Marshal.AllocHGlobal(size);
+        }
+    }
+
+    internal class StaticsRegionHashTable : LockFreeReaderHashtable<EcmaType, StaticsRegion>
+    {
+        private readonly StaticsKind _staticsKind;
+
+        public StaticsRegionHashTable(StaticsKind staticsKind)
+        {
+            _staticsKind = staticsKind;
+        }
+
+        protected override bool CompareKeyToValue(EcmaType key, StaticsRegion value)
+        {
+            return key == value.OwningType;
+        }
+
+        protected override bool CompareValueToValue(StaticsRegion value1, StaticsRegion value2)
+        {
+            return Object.ReferenceEquals(value1, value2);
+        }
+
+        protected override StaticsRegion CreateValueFromKey(EcmaType key)
+        {
+            var fieldLayoutAlgorithm = key.Context.GetLayoutAlgorithmForType(key);
+            var layout = fieldLayoutAlgorithm.ComputeStaticFieldLayout(key, StaticLayoutKind.StaticRegionSizes);
+            return _staticsKind switch
+            {
+                StaticsKind.GcStatics => new StaticsRegion(key, layout.GcStatics.Size.AsInt),
+                StaticsKind.ThreadGcStatics => new StaticsRegion(key, layout.ThreadGcStatics.Size.AsInt),
+                StaticsKind.ThreadNonGcStatics => new StaticsRegion(key, layout.ThreadNonGcStatics.Size.AsInt),
+                _ => new StaticsRegion(key, layout.NonGcStatics.Size.AsInt),
+            };
+        }
+
+        protected override int GetKeyHashCode(EcmaType key)
+        {
+            return key.GetHashCode();
+        }
+
+        protected override int GetValueHashCode(StaticsRegion value)
+        {
+            return value.GetHashCode();
+        }
+    }
+}

--- a/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StaticsRegion.cs
+++ b/src/System.Private.Interpreter/src/Internal/Runtime/Interpreter/StaticsRegion.cs
@@ -43,7 +43,7 @@ namespace Internal.Runtime.Interpreter
     {
         protected override bool CompareKeyToValue(EcmaType key, StaticsRegion value)
         {
-            return key.GetFullName() == value.OwningType.GetFullName();
+            return GetFullyQualifiedTypeName(key) == GetFullyQualifiedTypeName(value.OwningType);
         }
 
         protected override bool CompareValueToValue(StaticsRegion value1, StaticsRegion value2)
@@ -66,6 +66,12 @@ namespace Internal.Runtime.Interpreter
         protected override int GetValueHashCode(StaticsRegion value)
         {
             return value.GetHashCode();
+        }
+
+        protected string GetFullyQualifiedTypeName(EcmaType type)
+        {
+            string module = type.Module.ToString() ?? string.Empty;
+            return $"{module}!{type.GetFullName()}";
         }
     }
 }

--- a/src/System.Private.Interpreter/src/System.Private.Interpreter.csproj
+++ b/src/System.Private.Interpreter/src/System.Private.Interpreter.csproj
@@ -29,6 +29,7 @@
     <Compile Include="Internal\Runtime\Interpreter\StackItem.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Internal\Runtime\Interpreter\StaticsRegion.cs" />
     <Compile Include="Internal\Runtime\Interpreter\ILInterpreter.cs" />
     <Compile Include="Internal\Runtime\Interpreter\InterpreterCallInterceptor.cs" />
     <Compile Include="Internal\Runtime\Interpreter\InterpreterExecutionStrategy.cs" />


### PR DESCRIPTION
This PR adds support for instance and static fields on a reference type. It interprets the following opcodes:
* `ldfld`
* `ldsfld`
* `stfld`
* `stsfld`

As a consequence of adding static field support, I also added support for interpreting static constructors on dynamically loaded types. The following scenario is now supported:

```csharp
class Class1
{
    public string Field1;
    public int Field2;
    public float Field3;

    public static string StaticField1;
    public static int StaticField2;
    public static float StaticField3;

    [ThreadStatic]
    public static int ThreadStaticField1;

    static Class1()
    {
        StaticField1 = "statically nice!";
        StaticField2 = 10;
        StaticField3 = 3.56f;
        ThreadStaticField1 = 56;
    }
}

.....

public static void DoFields()
{
    Class1 class1 = new Class1();
    class1.Field1 = "nice";
    class1.Field2 = 23;
    class1.Field3 = 2.5f;

    Console.WriteLine(class1.Field1);
    Console.WriteLine(class1.Field2);
    Console.WriteLine(class1.Field3);
}

public static void DoStaticFields()
{
    Console.WriteLine(Class1.StaticField1);
    Console.WriteLine(String.Empty);
    Console.WriteLine(Class1.StaticField2);
    Console.WriteLine(Class1.StaticField3);
    Console.WriteLine(Class1.ThreadStaticField1);
}
```

The interpreter will happily load instance and static fields on both dynamically loaded types and types compiled into the native executable, while ensuring that static constructors have been run in both cases.
