### PR TITLE
Wasm: dont `RhpAssignRef` static fields

### DIFF
--- a/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
+++ b/src/ILCompiler.WebAssembly/src/CodeGen/ILToWebAssemblyImporter.cs
@@ -4856,7 +4856,7 @@ namespace Internal.IL
             StackEntry valueEntry = _stack.Pop();
 
             LLVMValueRef fieldAddress = GetFieldAddress(runtimeDeterminedField, field, isStatic);
-            CastingStore(fieldAddress, valueEntry, field.FieldType, true);
+            CastingStore(fieldAddress, valueEntry, field.FieldType, !isStatic);
         }
 
         // Loads symbol address. Address is represented as a i32*


### PR DESCRIPTION
This PR changes the implementation of `stsfld` so that `RhpAssignRef` is not called when storing a gc  pointer in a static field.  For example, previous to this change, https://github.com/dotnet/corert/blob/145402e00724acbc9e7636739140fb84f7d64845/src/System.Private.CoreLib/shared/System/AttributeUsageAttribute.cs#L23 resulted in a call to `RhpAssignRef` in the cctor.

