### PR TITLE
Display which type providing compiler helper is missing

### DIFF
--- a/src/Common/src/TypeSystem/IL/HelperExtensions.cs
+++ b/src/Common/src/TypeSystem/IL/HelperExtensions.cs
@@ -28,7 +28,7 @@ namespace Internal.IL
             }
             catch (InvalidOperationException ex)
             {
-                throw new InvalidOperationException($"Cannot find type {typeName} to obtain compiler helper method {methodName}", ex);
+                throw new InvalidOperationException($"Cannot find compiler helper method {methodName} on type {typeName}.", ex);
             }
         }
 

--- a/src/Common/src/TypeSystem/IL/HelperExtensions.cs
+++ b/src/Common/src/TypeSystem/IL/HelperExtensions.cs
@@ -20,9 +20,16 @@ namespace Internal.IL
 
         public static MethodDesc GetHelperEntryPoint(this TypeSystemContext context, string typeName, string methodName)
         {
-            MetadataType helperType = context.GetHelperType(typeName);
-            MethodDesc helperMethod = helperType.GetKnownMethod(methodName, null);
-            return helperMethod;
+            try
+            {
+                MetadataType helperType = context.GetHelperType(typeName);
+                MethodDesc helperMethod = helperType.GetKnownMethod(methodName, null);
+                return helperMethod;
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new InvalidOperationException($"Cannot find type {typeName} to obtain compiler helper method {methodName}", ex);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
I add these changes when I attempt to troubleshoot custom runtime and it failed that type was missing without indication why it want that type in first place. Have to know method which compiler want to use helps me troubleshoot what I should do.